### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ src/ComplexUHF/UHF
 tool/corplot
 *.mod
 tool/fourier
+tool/greenr2k
 doc/fourier/ja/_build/
 doc/fourier/en/_build/
 *.bak


### PR DESCRIPTION
皆さん今晩は、許ルーキンです。

特にないですけど、`.gitignore` に新しい `greenr2k` ツールの実行可能プログラムを付けないみたいです。`greenr2k` はコンパイル出力ファイルので、`ignore` の方がいいと思います。

以上。邪魔するので申し訳ない。