### PR TITLE
Specify ip as OMP Shared Variable in CalHam

### DIFF
--- a/src/mVMC/calham.c
+++ b/src/mVMC/calham.c
@@ -82,7 +82,7 @@ double complex CalculateHamiltonian(const double complex ip, int *eleIdx, const 
                NCoulombInter, CoulombInter, ParaCoulombInter, NHundCoupling, HundCoupling, ParaHundCoupling, \
                NTransfer, Transfer, ParaTransfer, NPairHopping, PairHopping, ParaPairHopping, \
                NExchangeCoupling, ExchangeCoupling, ParaExchangeCoupling, NInterAll, InterAll, ParaInterAll, n0, n1) \
-  shared(eleCfg, eleProjCnt, eleIdx, eleNum) reduction(+:e)
+  shared(eleCfg, eleProjCnt, eleIdx, eleNum, ip) reduction(+:e)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);
     myEleNum = GetWorkSpaceThreadInt(Nsite2);

--- a/src/mVMC/calham_real.c
+++ b/src/mVMC/calham_real.c
@@ -61,7 +61,7 @@ double CalculateHamiltonian_real(const double ip, int *eleIdx, const int *eleCfg
     NCoulombInter, CoulombInter, ParaCoulombInter, NHundCoupling, HundCoupling, ParaHundCoupling,    \
     NTransfer, Transfer, ParaTransfer, NPairHopping, PairHopping, ParaPairHopping,    \
     NExchangeCoupling, ExchangeCoupling, ParaExchangeCoupling, NInterAll, InterAll, ParaInterAll, n0, n1)\
-    shared(eleCfg, eleProjCnt, eleIdx, eleNum) reduction(+:e)
+    shared(eleCfg, eleProjCnt, eleIdx, eleNum, ip) reduction(+:e)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);
     myEleNum = GetWorkSpaceThreadInt(Nsite2);


### PR DESCRIPTION
Hello. This is Ruqing Xu.

In the `#pragma omp parallel` section in `CalculateHamiltonian_real` and `CalculateHamiltonian`, constant argument `ip` was not set as `shared`, while `default` is `none` (for rigorous control of omp's behavior maybe?).
All previous compilers has ignored this and shared `ip` implicitly, but the latest GCC 9 is reporting an error. Hence it should get fixed I think?