### PR TITLE
Added Compilation Configuration for Apple Clang

### DIFF
--- a/config/apple.cmake
+++ b/config/apple.cmake
@@ -1,0 +1,14 @@
+# for Apple clang compiler
+# additional libomp and gfortran installation required
+# mac computers are suggested to use this configuration for better performance
+set(CMAKE_C_COMPILER "clang" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-g -O0 -Wall  -Wformat -Werror=format-security")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -Wno-unknown-pragmas -Wno-logical-not-parentheses")
+set(CMAKE_Fortran_COMPILER "gfortran" CACHE STRING "" FORCE)
+
+# OpenMP with libomp
+set(CMAKE_EXE_LINKER_FLAGS "-L/usr/local/lib -lomp") 
+set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp" CACHE STRING "" FORCE) 
+set(OpenMP_C_LIB_NAMES "")
+set(CMAKE_OSX_SYSROOT "")
+


### PR DESCRIPTION
Using `clang+libomp+gfortran` toolchain for build saves both compile and runtime cost under mac. 
As cmake seems to have a little problem recognizing libomp, additional variables have to be set in the configuration. I'm uploading mine.

Simple benchmark: 
```
45.35s user 30.20s system 329% cpu 22.906 total # gcc9+mkl
89.03s user  0.53s system 772% cpu 11.590 total # icc+mkl
76.39s user  0.28s system 779% cpu  9.834 total # clang+accelerate
```