### PR TITLE
Blocked Pfaffian Update with Optimized Pfaffian Library (Pfaffine) Based on BLIS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/pfaffine"]
+	path = src/pfaffine
+	url = https://github.com/xrq-phys/Pfaffine
+	branch = blis

--- a/mVMCconfig.sh
+++ b/mVMCconfig.sh
@@ -144,7 +144,7 @@ EOF
     fi
     # Link make.sys to make.inc for Pfaffine
     if [ ! -e src/pfaffine/make.inc ]; then
-	ln -s \$(PWD)/src/make.sys src/pfaffine/make.inc;
+	ln -s $PWD/src/make.sys src/pfaffine/make.inc;
     fi
 
     echo

--- a/mVMCconfig.sh
+++ b/mVMCconfig.sh
@@ -130,11 +130,26 @@ EOF
         exit
     fi
 
+    echo "CXX = #Specify a valid C++ compiler." >> src/make.sys
+    echo "BLIS_ROOT = #Specify your xrq-phys/BLIS installation here." >> src/make.sys
+    echo "# CFLAGS += -D_pfaffine -D_pf_block_update #Uncomment to use optimization." >> src/make.sys
     echo "cat src/make.sys"
     cat src/make.sys
 
+    echo 
+    echo "Checking out submodules for fast Pfaffian computation."
+    # Clone Pfaffine if submodule not loaded.
+    if [ ! -e src/pfaffine ]; then
+	git submodule update --init --recursive
+    fi
+    # Link make.sys to make.inc for Pfaffine
+    if [ ! -e src/pfaffine/make.inc ]; then
+	ln -s \$(PWD)/src/make.sys src/pfaffine/make.inc;
+    fi
+
     echo
-    echo "config DONE"
+    echo "Config is not done yet."
+    echo "Please edit make.sys and specify BLIS_ROOT, etc."
     echo
 
     cat > makefile <<EOF

--- a/mVMCconfig.sh
+++ b/mVMCconfig.sh
@@ -139,12 +139,12 @@ EOF
     echo 
     echo "Checking out submodules for fast Pfaffian computation."
     # Clone Pfaffine if submodule not loaded.
-    if [ ! -e src/pfaffine ]; then
-	git submodule update --init --recursive
+    if [ ! -e src/pfaffine/src ]; then
+        git submodule update --init --recursive
     fi
     # Link make.sys to make.inc for Pfaffine
     if [ ! -e src/pfaffine/make.inc ]; then
-	ln -s $PWD/src/make.sys src/pfaffine/make.inc;
+        ln -s $PWD/src/make.sys src/pfaffine/make.inc;
     fi
 
     echo

--- a/src/ComplexUHF/makefile_uhf
+++ b/src/ComplexUHF/makefile_uhf
@@ -3,6 +3,7 @@ include ../make.sys
 SFMT = ../sfmt/SFMT.o
 
 OBJS = \
+../common/setmemory.c \
 cal_energy.o \
 diag.o \
 green.o \
@@ -27,7 +28,6 @@ clean :
 	cd ../sfmt; $(MAKE) -f makefile_sfmt clean
 
 UHFmain.o:include/Def.h
-UHFmain.o:mfmemory.c
 UHFmain.o:include/matrixlapack.h
 UHFmain.o:include/readdef.h
 UHFmain.o:include/initial.h
@@ -42,17 +42,13 @@ UHFmain.o:xsetmem_large.c
 cal_energy.o:include/cal_energy.h
 diag.o:include/matrixlapack.h
 diag.o:include/diag.h
-diag.o:mfmemory.c
 green.o:include/green.h
 green.o:include/matrixlapack.h
-green.o:mfmemory.c
 initial.o:include/initial.h
 initial.o:../sfmt/SFMT.h
 makeham.o:include/makeham.h
 matrixlapack.o:include/matrixlapack.h
-matrixlapack.o:mfmemory.c
 output.o:include/output.h
-output.o:mfmemory.c
 output.o:../sfmt/SFMT.h
 readdef.o:include/readdef.h
 include/Def.h:include/struct.h

--- a/src/StdFace/makefile_StdFace
+++ b/src/StdFace/makefile_StdFace
@@ -3,7 +3,7 @@ include ../make.sys
 StdFace_OBJS = StdFace_main.o StdFace_ModelUtil.o
 Lattice_OBJS = SquareLattice.o ChainLattice.o TriangularLattice.o \
 	HoneycombLattice.o Ladder.o Kagome.o Orthorhombic.o FCOrtho.o \
-	Pyrochlore.o Wannier90.o
+	Pyrochlore.o Wannier90.o setmemory.o
 
 libStdFace.a:$(StdFace_OBJS) $(Lattice_OBJS)
 	ar -r -v $(AROPT) $@ $(StdFace_OBJS) $(Lattice_OBJS)

--- a/src/mVMC/include/blas_externs.h
+++ b/src/mVMC/include/blas_externs.h
@@ -46,11 +46,15 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #define M_ZGETRI zgetri_
 #define M_ZPOSV  zposv_
 
-// pfaPACK
+// Skew-symmetric LAPACK-level routines:
+// Vendor switch: PFAPACK77 or Pfaffine
+#ifdef _pfaffine
 #define M_DSKPFA m_dskpfa_
 #define M_ZSKPFA m_zskpfa_
-#define OLD_DSKPFA dskpfa_
-#define OLD_ZSKPFA zskpfa_
+#else
+#define M_DSKPFA dskpfa_
+#define M_ZSKPFA zskpfa_
+#endif
 
 // pBLAS
 #define M_PDGEMV  pdgemv_
@@ -112,7 +116,11 @@ extern int M_DSKPFA(const char *uplo, const char *mthd, const int *n,
                     double *work, const int *lwork, int *info);
 extern int M_ZSKPFA(const char *uplo, const char *mthd, const int *n,
                     double complex *a, const int *lda, double complex *pfaff, int *iwork,
-                    double complex *work, const int *lwork/*, double *rwork*/, int *info);
+                    double complex *work, const int *lwork,
+#ifndef _pfaffine
+                    double *rwork,
+#endif
+                    int *info);
 
 // pBLAS
 extern void M_PDGEMV(const char *trans, const int *m, const int *n,

--- a/src/mVMC/include/blas_externs.h
+++ b/src/mVMC/include/blas_externs.h
@@ -24,6 +24,11 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #define _BLAS_EXTERNS_H
 
 // BLAS
+#define M_DDOT ddot_
+#define M_DZASUM dzasum_
+#define M_DZNRM2 dznrm2_
+#define M_DSCAL dscal_
+#define M_ZSCAL zscal_
 #define M_DAXPY daxpy_
 #define M_DGEMM  dgemm_
 #define M_DGEMV  dgemv_
@@ -42,8 +47,10 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #define M_ZPOSV  zposv_
 
 // pfaPACK
-#define M_DSKPFA dskpfa_
-#define M_ZSKPFA zskpfa_
+#define M_DSKPFA m_dskpfa_
+#define M_ZSKPFA m_zskpfa_
+#define OLD_DSKPFA dskpfa_
+#define OLD_ZSKPFA zskpfa_
 
 // pBLAS
 #define M_PDGEMV  pdgemv_
@@ -58,6 +65,10 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 
 // BLAS
 
+extern double M_DDOT(const int *n, const double *x, const int *incx, const double *y, const int *incy);
+extern double M_DZNRM2(const int *n, const double complex *x, const int *incx);
+extern void M_DSCAL(const int *n, const double *a, double *x, const int *incx);
+extern void M_ZSCAL(const int *n, const double complex *a, double complex *x, const int *incx);
 extern void M_DGEMV(const char *trans, const int *m, const int *n, const double *alpha,
                     const double *a, const int *lda, const double *x, const int *incx,
                     const double *beta, double *y, const int *incy);
@@ -101,7 +112,7 @@ extern int M_DSKPFA(const char *uplo, const char *mthd, const int *n,
                     double *work, const int *lwork, int *info);
 extern int M_ZSKPFA(const char *uplo, const char *mthd, const int *n,
                     double complex *a, const int *lda, double complex *pfaff, int *iwork,
-                    double complex *work, const int *lwork, double *rwork, int *info);
+                    double complex *work, const int *lwork/*, double *rwork*/, int *info);
 
 // pBLAS
 extern void M_PDGEMV(const char *trans, const int *m, const int *n,

--- a/src/mVMC/include/global.h
+++ b/src/mVMC/include/global.h
@@ -77,6 +77,7 @@ int NVMCWarmUp; /* Monte Carlo steps for warming up */
 int NVMCInterval; /* sampling interval [MCS] */ 
 int NVMCSample; /* the number of samples */
 int NExUpdatePath; /* update by exchange hopping  0: off, 1: on */
+int NBlockUpdateSize; /* {DEFINED: _pf_block_update} size of block Pfaffian update */
 
 int RndSeed; /* seed for pseudorandom number generator */
 int NSplitSize; /* the number of inner MPI processes */

--- a/src/mVMC/locgrn.c
+++ b/src/mVMC/locgrn.c
@@ -392,7 +392,8 @@ double complex calculateNewPfMN_child(const int qpidx, const int n, const int *m
   /* calculate Pf M */
   //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
   //M_ZSKPFA(&uplo, &mthd, &n, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
-  M_ZSKPFA(&uplo, &mthd, &n, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
+  info = 1; // Skip inverse.
+  M_ZSKPFA(&uplo, &mthd, &n, mat, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;
 
   return sgn * pfaff * PfM[qpidx];

--- a/src/mVMC/locgrn.c
+++ b/src/mVMC/locgrn.c
@@ -392,8 +392,12 @@ double complex calculateNewPfMN_child(const int qpidx, const int n, const int *m
   /* calculate Pf M */
   //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
   //M_ZSKPFA(&uplo, &mthd, &n, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
+#ifdef _pfaffine
   info = 1; // Skip inverse.
   M_ZSKPFA(&uplo, &mthd, &n, mat, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
+#else
+  M_ZSKPFA(&uplo, &mthd, &n, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+#endif
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;
 
   return sgn * pfaff * PfM[qpidx];

--- a/src/mVMC/locgrn_fsz.c
+++ b/src/mVMC/locgrn_fsz.c
@@ -569,8 +569,11 @@ double complex GreenFunc2_fsz2(const int ri, const int rj, const int rk, const i
 //  }
 //
 //  /* calculate Pf M */
+//  // Coverage-0 and commented out,
+//  // but should be useful sometimes.
 //  //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
-//  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
+//  info = 1; // Skipping inverse.
+//  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
 //
 //  sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;
 //

--- a/src/mVMC/locgrn_real.c
+++ b/src/mVMC/locgrn_real.c
@@ -397,6 +397,9 @@ double calculateNewPfMN_real_child(const int qpidx, const int n, const int *msa,
   }
 
   /* calculate Pf M */
+  // TODO: Maybe block updating is faster than recalculation of Pfaffian.
+  //       Maybe I'll also give support for this in Pfaffine.
+  info = 1; // Skip inverse.
   M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -1,6 +1,6 @@
 include ../make.sys
 
-PFAPACK = # ../pfapack/libpfapack.a
+PFAPACK = ../pfapack/libpfapack.a
 SFMT = ../sfmt/SFMT.o
 STDFACE = ../StdFace/libStdFace.a
 OPTION = -D_mpi_use
@@ -96,7 +96,7 @@ HEADERS = \
 ./include/workspace.h
 
 all : 
-	# cd ../pfapack; $(MAKE) -f makefile_pfapack
+	cd ../pfapack; $(MAKE) -f makefile_pfapack
 	cd ../sfmt; $(MAKE) -f makefile_sfmt
 	cd ../StdFace; $(MAKE) -f makefile_StdFace libStdFace.a
 	make -f makefile_src vmc.out

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -1,6 +1,6 @@
 include ../make.sys
 
-PFAPACK = ../pfapack/libpfapack.a
+PFAPACK = $(Pfaffine_ROOT)/src/libpfaffine.a # ../pfapack/libpfapack.a
 SFMT = ../sfmt/SFMT.o
 STDFACE = ../StdFace/libStdFace.a
 OPTION = -D_mpi_use
@@ -96,7 +96,7 @@ HEADERS = \
 ./include/workspace.h
 
 all : 
-	cd ../pfapack; $(MAKE) -f makefile_pfapack
+	# cd ../pfapack; $(MAKE) -f makefile_pfapack
 	cd ../sfmt; $(MAKE) -f makefile_sfmt
 	cd ../StdFace; $(MAKE) -f makefile_StdFace libStdFace.a
 	make -f makefile_src vmc.out
@@ -104,10 +104,10 @@ all :
 	cd ../ComplexUHF; $(MAKE) -f makefile_uhf
 
 vmc.out : $(OBJS)
-	$(CC) -o $@ $(OBJS) $(OPTION) $(CFLAGS) $(LIBS)
+	$(CXX) -o $@ $(OBJS) $(OPTION) $(CFLAGS) $(LIBS)
 
 vmcdry.out : vmcdry.o $(STDFACE)
-	$(CC) -o $@ $^ $(OPTION) $(CFLAGS) $(LIBS)
+	$(CXX) -o $@ $^ $(OPTION) $(CFLAGS) $(LIBS)
 
 SUFFIXES: .o .c
 

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -1,6 +1,8 @@
 include ../make.sys
 
 PFAPACK = ../pfapack/libpfapack.a
+PFAFFINE = ../pfaffine/src/libpfaffine.a
+PFUPDATES = ../pfupdates/pfupdates.o
 SFMT = ../sfmt/SFMT.o
 STDFACE = ../StdFace/libStdFace.a
 OPTION = -D_mpi_use
@@ -9,7 +11,8 @@ OBJS = \
 	physcal_lanczos.o \
 	splitloop.o \
 	vmcmain.o \
-	$(PFAPACK) $(SFMT) $(STDFACE)
+	$(PFAPACK) $(SFMT) $(STDFACE) \
+	$(PFAFFINE) $(PFUPDATES)
 
 SOURCES = \
 average.c \
@@ -97,6 +100,8 @@ HEADERS = \
 
 all : 
 	cd ../pfapack; $(MAKE) -f makefile_pfapack
+	cd ../pfaffine; $(MAKE) -f makefile lib
+	cd ../pfupdates; $(MAKE) -f makefile_pfupdates
 	cd ../sfmt; $(MAKE) -f makefile_sfmt
 	cd ../StdFace; $(MAKE) -f makefile_StdFace libStdFace.a
 	make -f makefile_src vmc.out
@@ -118,6 +123,8 @@ clean :
 	rm -f *.o vmc.out vmcdry.out
 	cd ../sfmt; $(MAKE) -f makefile_sfmt clean
 	cd ../pfapack; $(MAKE) -f makefile_pfapack clean
+	cd ../pfaffine; $(MAKE) -f makefile clean
+	cd ../pfupdates; $(MAKE) -f makefile_pfupdates clean
 	cd ../StdFace; $(MAKE) -f makefile_StdFace clean
 	cd ../ComplexUHF; $(MAKE) -f makefile_uhf clean
 

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -1,6 +1,6 @@
 include ../make.sys
 
-PFAPACK = $(Pfaffine_ROOT)/src/libpfaffine.a # ../pfapack/libpfapack.a
+PFAPACK = # ../pfapack/libpfapack.a
 SFMT = ../sfmt/SFMT.o
 STDFACE = ../StdFace/libStdFace.a
 OPTION = -D_mpi_use

--- a/src/mVMC/matrix.c
+++ b/src/mVMC/matrix.c
@@ -192,7 +192,7 @@ int calculateMAll_child_fsz(const int *eleIdx,const int *eleSpn, const int qpSta
   // M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
 
   // InvM -> InvM(T) -> -InvM
-  M_ZSCAL(&nsq, &minus_one, InvM, &one);
+  M_ZSCAL(&nsq, &minus_one, invM, &one);
 
   return info;
 }
@@ -435,7 +435,7 @@ int calculateMAll_child_fcmp(const int *eleIdx, const int qpStart, const int qpE
 
   /* mVMC's handling InvM as row-major,
    * i.e. InvM needs a transpose, InvM -> -InvM according antisymmetric properties. */
-  M_ZSCAL(&nsq, &minus_one, InvM, &one);
+  M_ZSCAL(&nsq, &minus_one, invM, &one);
 
   return info;
 }

--- a/src/mVMC/matrix.c
+++ b/src/mVMC/matrix.c
@@ -69,7 +69,11 @@ int getLWork_fcmp() {
   lwork=-1;
   M_ZGETRI(&n, &a, &lda, &iwork, &optSize1, &lwork, &info);
   lwork=-1;
+#ifdef _pfaffine
   M_ZSKPFA(&uplo, &mthd, &n, &a, &lda, &pfaff, &iwork, &optSize2, &lwork/*, &rwork*/, &info);
+#else
+  M_ZSKPFA(&uplo, &mthd, &n, &a, &lda, &pfaff, &iwork, &optSize2, &lwork, &rwork, &info);
+#endif
 
   lwork = (creal(optSize1)>creal(optSize2)) ? (int)creal(optSize1) : (int)creal(optSize2);
   return lwork;
@@ -164,35 +168,39 @@ int calculateMAll_child_fsz(const int *eleIdx,const int *eleSpn, const int qpSta
     for(msj=0;msj<nsize;msj++) {
       rsj = eleIdx[msj] + eleSpn[msj]*Nsite;//fsz
       bufM_i[msj] = -sltE_i[rsj];
-      //printf("DEBUG: msi=%d msj=%d: rsi=%d rsj=%d :bufM=%lf %lf \n",msi,msj,rsi,rsj,creal(bufM_i[msj]),cimag(bufM_i[msj]));
     }
   }
 
-  /* copy bufM to invM */
-  /* For Pfaffian calculation, invM is used as second buffer */
-#pragma loop noalias
-  for(msi=0;msi<nsize*nsize;msi++) {
+#ifdef _pfaffine
+  info=0; /* Fused Pfaffian/inverse computation. */
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work/*, rwork*/, &lwork, &info);
+#else
+  /* Pfaffian/inverse computed separately. */
+  /* Copy bufM to invM before using bufM to compute Pfaffian. */
+  for(msi=0;msi<nsize*nsize;msi++)
     invM[msi] = bufM[msi];
-  }
-  /* calculate Pf M */
-  //printf("DEBUG: n=%d \n",n);
-  //for(msi=0;msi<nsize;msi++){
-  //  for(msj=0;msj<nsize;msj++){
-  //    printf("DEBUG: msi=%d msj=%d bufM %lf %lf \n",msi,msj,creal(bufM[msi+msj*n]),cimag(bufM[msi+msj*n]));
-  //  }
-  //}
-  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work/*, rwork*/, &lwork, &info);
-  //printf("DEBUG: pfaff=%lf %lf\n",creal(pfaff),cimag(pfaff));
+
+  /* Calculate Pf M */
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+#endif
+
   if(info!=0) return info;
   if(!isfinite(creal(pfaff) + cimag(pfaff))) return qpidx+1;
   PfM[qpidx] = pfaff;
 
-  /* DInv */
-  // M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
-  // M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
+#ifdef _pfaffine
+  /* For fused Pfaffian/inverse, inv(M) is already stored in bufM.
+   * Now to transpose (.* -1) it to invM. */
+  for(msi=0;msi<nsize*nsize;msi++)
+    invM[msi] = -bufM[msi];
+#else
+  /* Calculate inverse. */
+  M_ZGETRF(&m, &n, invM, &lda, iwork, &info); /* ipiv = iwork */
+  M_ZGETRI(&n, invM, &lda, iwork, work, &lwork, &info);
 
-  // InvM -> InvM(T) -> -InvM
+  /* InvM -> InvM(T) -> -InvM */
   M_ZSCAL(&nsq, &minus_one, invM, &one);
+#endif
 
   return info;
 }
@@ -247,9 +255,9 @@ int calculateMAll_child_fsz_real(const int *eleIdx,const int *eleSpn, const int 
   int rsi,rsj;
 
   char uplo='U', mthd='P';
-  int m,n,lda,info=0;
+  int m,n,lda,one,nsq,info=0;
   //int nspn = 2*Ne+2*Nsite+2*Nsite+NProj; this is useful?
-  double pfaff;
+  double pfaff,minus_one;
 
   /* optimization for Kei */
   const int nsize = Nsize;
@@ -263,6 +271,9 @@ int calculateMAll_child_fsz_real(const int *eleIdx,const int *eleSpn, const int 
   double *bufM_i, *bufM_i2;
 
   m=n=lda=Nsize;
+  nsq=n*n;
+  one=1;
+  minus_one=-1.0;
 
   /* store bufM */
   /* Note that bufM is column-major and skew-symmetric. */
@@ -279,37 +290,37 @@ int calculateMAll_child_fsz_real(const int *eleIdx,const int *eleSpn, const int 
     }
   }
 
-  /* copy bufM to invM */
-  /* For Pfaffian calculation, invM is used as second buffer */
-#pragma loop noalias
-  for(msi=0;msi<nsize*nsize;msi++) {
+#ifdef _pfaffine
+  info=0; /* Fused Pfaffian/inverse computation. */
+#else
+  /* Pfaffian/inverse computed separately. */
+  /* Copy bufM to invM before using bufM to compute Pfaffian. */
+  for(msi=0;msi<nsize*nsize;msi++)
     invM[msi] = bufM[msi];
-  }
-  /* calculate Pf M */
-  M_DSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, &info);
+#endif
+
+  /* Calculate Pf M */
+  M_DSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, &info);
+
   if(info!=0) return info;
   if(!isfinite(pfaff)) return qpidx+1;
   PfM_real[qpidx] = pfaff;
 
-  /* DInv */
-  M_DGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
+#ifdef _pfaffine
+  /* inv(M) already stored in bufM.
+   * Transpose (.* -1) to invM. */
+  for(msi=0;msi<nsize*nsize;msi++)
+    invM[msi] = -bufM[msi];
+#else
+  /* Calculate inverse. */
+  M_DGETRF(&m, &n, invM, &lda, iwork, &info); /* ipiv = iwork */
+  if(info!=0) return info;
+  M_DGETRI(&n, invM, &lda, iwork, work, &lwork, &info);
   if(info!=0) return info;
 
-  M_DGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
-  if(info!=0) return info;
-
-  /* store InvM */
-  /* BufM is column-major, InvM is row-major */
-#pragma loop noalias
-  for(msi=0;msi<nsize;msi++) {
-    invM_i = invM + msi*Nsize;
-    bufM_i = bufM + msi*Nsize;
-    bufM_i2 = bufM + msi;
-    for(msj=0;msj<nsize;msj++) {
-      invM_i[msj] = 0.5*(bufM_i2[msj*nsize] - bufM_i[msj]);
-      /* invM[i][j] = 0.5*(bufM[i][j]-bufM[j][i]) */
-    }
-  }
+  /* InvM -> InvM(T) -> -InvM */
+  M_DSCAL(&nsq, &minus_one, invM, &one);
+#endif
 
   return info;
 }
@@ -405,37 +416,40 @@ int calculateMAll_child_fcmp(const int *eleIdx, const int qpStart, const int qpE
     for(msj=0;msj<nsize;msj++) {
       rsj = eleIdx[msj] + (msj/Ne)*Nsite;
       bufM_i[msj] = -sltE_i[rsj];
-      //      printf("DEBUG: msi=%d msj=%d bufM=%lf %lf \n",msi,msj,creal(bufM_i[msj]),cimag(bufM_i[msj]));
     }
   }
 
-  /* copy bufM to invM */
-  /* For Pfaffian calculation, invM is used as second buffer */
-#pragma loop noalias
-  for(msi=0;msi<nsize*nsize;msi++) {
+#ifdef _pfaffine
+  info=0; /* Fused Pfaffian/inverse computation. */
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work/*, rwork*/, &lwork, &info);
+#else
+  /* Pfaffian/inverse computed separately. */
+  /* Copy bufM to invM before using bufM to compute Pfaffian. */
+  for(msi=0;msi<nsize*nsize;msi++)
     invM[msi] = bufM[msi];
-  }
-  // [TODO] Now bufM is not needed. Remove.
-  /* calculate Pf M */
-  //printf("DEBUG: n=%d \n",n);
-  //for(msi=0;msi<nsize;msi++){
-  //  for(msj=0;msj<nsize;msj++){
-  //    printf("DEBUG: msi=%d msj=%d bufM %lf %lf \n",msi,msj,creal(bufM[msi+msj*n]),cimag(bufM[msi+msj*n]));
-  //  }
-  //}
-  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work/*, rwork*/, &lwork, &info);
-  // printf("DEBUG: pfaff=%lf %lf\n",creal(pfaff),cimag(pfaff));
+
+  /* Calculate Pf M */
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+#endif
+
   if(info!=0) return info;
   if(!isfinite(creal(pfaff) + cimag(pfaff))) return qpidx+1;
   PfM[qpidx] = pfaff;
 
-  /* DInv */
-  // M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
-  // M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
+#ifdef _pfaffine
+  /* inv(M) already stored in bufM.
+   * Transpose (.* -1) to invM. */
+  for(msi=0;msi<nsize*nsize;msi++)
+    invM[msi] = -bufM[msi];
+#else
+  /* Calculate inverse. */
+  M_ZGETRF(&m, &n, invM, &lda, iwork, &info); /* ipiv = iwork */
+  M_ZGETRI(&n, invM, &lda, iwork, work, &lwork, &info);
 
   /* mVMC's handling InvM as row-major,
    * i.e. InvM needs a transpose, InvM -> -InvM according antisymmetric properties. */
   M_ZSCAL(&nsq, &minus_one, invM, &one);
+#endif
 
   return info;
 }
@@ -505,8 +519,8 @@ int calculateMAll_BF_fcmp_child(
   int rsi,rsj;
 
   char uplo='U', mthd='P';
-  int m,n,lda,info=0;
-  double complex pfaff;
+  int m,n,lda,nsq,one,info=0;
+  double complex pfaff,minus_one;
 
   /* optimization for Kei */
   const int nsize = Nsize;
@@ -520,6 +534,9 @@ int calculateMAll_BF_fcmp_child(
   double complex*bufM_i, *bufM_i2;
 
   m=n=lda=Nsize;
+  nsq=n*n;
+  one=1;
+  minus_one=-1.0;
 
   /* store bufM */
   /* Note that bufM is column-major and skew-symmetric. */
@@ -536,39 +553,38 @@ int calculateMAll_BF_fcmp_child(
     }
   }
 
-  /* copy bufM to invM */
-  /* For Pfaffian calculation, invM is used as second buffer */
-#pragma loop noalias
-  for(msi=0;msi<nsize*nsize;msi++) {
+#ifdef _pfaffine
+  info=0; /* Fused Pfaffian/inverse computation. */
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
+#else
+  /* Pfaffian/inverse computed separately. */
+  /* Copy bufM to invM before using bufM to compute Pfaffian. */
+  for(msi=0;msi<nsize*nsize;msi++)
     invM[msi] = bufM[msi];
-  }
-  /* calculate Pf M */
-  // [R-Xu] Coverage-0 code. Skipping inverse only.
-  // NOTE: One may want to modify this according to calculateMAll_fcmp_child if he needs BF.
-  info = 1; // Skip inverse.
-  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
+
+  /* Calculate Pf M */
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+#endif
+
   if(info!=0) return info;
   if(!(isfinite(creal(pfaff)) && isfinite(cimag(pfaff)))) return qpidx+1;
   PfM[qpidx] = pfaff;
 
-  /* DInv */
-  M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
+#ifdef _pfaffine
+  /* inv(M) already stored in bufM.
+   * Transpose (.* -1) to invM. */
+  for(msi=0;msi<nsize*nsize;msi++)
+    invM[msi] = -bufM[msi];
+#else
+  /* Calculate inverse. */
+  M_ZGETRF(&m, &n, invM, &lda, iwork, &info); /* ipiv = iwork */
+  if(info!=0) return info;
+  M_ZGETRI(&n, invM, &lda, iwork, work, &lwork, &info);
   if(info!=0) return info;
 
-  M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
-  if(info!=0) return info;
-
-  /* store InvM */
-  /* BufM is column-major, InvM is row-major */
-#pragma loop noalias
-  for(msi=0;msi<nsize;msi++) {
-    invM_i = invM + msi*Nsize;
-    bufM_i = bufM + msi*Nsize;
-    bufM_i2 = bufM + msi;
-    for(msj=0;msj<nsize;msj++) {
-      invM_i[msj] = 0.5*(bufM_i2[msj*nsize] - bufM_i[msj]);
-    }
-  }
+  /* InvM -> InvM(T) -> -InvM */
+  M_ZSCAL(&nsq, &minus_one, invM, &one);
+#endif
 
   return info;
 }
@@ -655,8 +671,6 @@ int calculateMAll_child_real(const int *eleIdx, const int qpStart, const int qpE
     rsi = eleIdx[msi] + (msi/Ne)*Nsite;
     bufM_i = bufM + msi*Nsize;
     sltE_i = sltE + rsi*Nsite2;
-    //printf("Debug: bufM=%ld, sltE=%ld\n", bufM, sltE);
-    //    printf("Debug: bufM_i=%ld, sltE_i=%ld, rsi=%ld\n", bufM_i, sltE_i, rsi);
 #pragma loop norecurrence
     for(msj=0;msj<nsize;msj++) {
       rsj = eleIdx[msj] + (msj/Ne)*Nsite;
@@ -664,35 +678,36 @@ int calculateMAll_child_real(const int *eleIdx, const int qpStart, const int qpE
 
     }
   }
-  /*
-     printf("DEBUG: n=%d \n",n);
-     for(msi=0;msi<nsize;msi++){
-     for(msj=0;msj<nsize;msj++){
-     printf("DEBUG: msi=%d msj=%d bufM %lf \n",msi,msj,bufM[msi+msj*n]);
-     }
-     }
-     */
 
-  /* copy bufM to invM */
-  /* For Pfaffian calculation, invM is used as second buffer */
-#pragma loop noalias
-  for(msi=0;msi<nsize*nsize;msi++) {
+#ifdef _pfaffine
+  info=0; /* Fused Pfaffian/inverse computation. */
+#else
+  /* Pfaffian/inverse computed separately. */
+  /* Copy bufM to invM before using bufM to compute Pfaffian. */
+  for(msi=0;msi<nsize*nsize;msi++)
     invM[msi] = bufM[msi];
-  }
+#endif
 
   /* calculate Pf M */
-  M_DSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, &info);
+  M_DSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, &info);
+
   if(info!=0) return info;
   if(!isfinite(pfaff)) return qpidx+1;
   PfM_real[qpidx] = pfaff;
 
-  //  printf("Debug: M_DGETRF\n");
-  /* DInv */
-  // M_DGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
-  // M_DGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
+#ifdef _pfaffine
+  /* inv(M) already stored in bufM.
+   * Transpose (.* -1) to invM. */
+  for(msi=0;msi<nsize*nsize;msi++)
+    invM[msi] = -bufM[msi];
+#else
+  /* Compute inverse */
+  M_DGETRF(&m, &n, invM, &lda, iwork, &info); /* ipiv = iwork */
+  M_DGETRI(&n, invM, &lda, iwork, work, &lwork, &info);
 
   // InvM -> InvM' = -InvM
   M_DSCAL(&nsq, &minus_one, invM, &one);
+#endif
 
   return info;
 }
@@ -744,8 +759,8 @@ int calculateMAll_BF_real_child(const int *eleIdx, const int qpStart, const int 
   int rsi,rsj;
 
   char uplo='U', mthd='P';
-  int m,n,lda,info=0;
-  double pfaff;
+  int m,n,nsq,one,lda,info=0;
+  double pfaff,minus_one;
 
   /* optimization for Kei */
   const int nsize = Nsize;
@@ -759,6 +774,9 @@ int calculateMAll_BF_real_child(const int *eleIdx, const int qpStart, const int 
   double *bufM_i, *bufM_i2;
 
   m=n=lda=Nsize;
+  nsq=n*n;
+  one=1;
+  minus_one=-1.0;
 
   /* store bufM */
   /* Note that bufM is column-major and skew-symmetric. */
@@ -775,42 +793,37 @@ int calculateMAll_BF_real_child(const int *eleIdx, const int qpStart, const int 
     }
   }
 
-  /* copy bufM to invM */
-  /* For Pfaffian calculation, invM is used as second buffer */
-#pragma loop noalias
-  for(msi=0;msi<nsize*nsize;msi++) {
+#ifdef _pfaffine
+  info=0; /* Fused Pfaffian/inverse computation. */
+#else
+  /* Pfaffian/inverse computed separately. */
+  /* Copy bufM to invM before using bufM to compute Pfaffian. */
+  for(msi=0;msi<nsize*nsize;msi++)
     invM[msi] = bufM[msi];
-  }
-  /* calculate Pf M */
-  // [R-Xu]
-  // NOTE: This piece of code is coverage 0, i.e. cannot be tested
-  //       hence I'm keeping GETRF and GETRI to safety.
-  // TODO: If anyone'd like to utilize this, try to use Pfaffine's inv-mode and remove GETRF&GETRI.
-  info = 1; // Skip inverse.
-  M_DSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, &info);
+#endif
+
+  /* Calculate Pf M */
+  M_DSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, &info);
+
   if(info!=0) return info;
   if(!isfinite(pfaff)) return qpidx+1;
   PfM_real[qpidx] = pfaff;
 
-  /* DInv */
-  M_DGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
+#ifdef _pfaffine
+  /* inv(M) already stored in bufM.
+   * Transpose (.* -1) to invM. */
+  for(msi=0;msi<nsize*nsize;msi++)
+    invM[msi] = -bufM[msi];
+#else
+  /* Compute inverse. */
+  M_DGETRF(&m, &n, invM, &lda, iwork, &info); /* ipiv = iwork */
+  if(info!=0) return info;
+  M_DGETRI(&n, invM, &lda, iwork, work, &lwork, &info);
   if(info!=0) return info;
 
-  M_DGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
-  if(info!=0) return info;
-
-  /* store InvM */
-  /* BufM is column-major, InvM is row-major */
-#pragma loop noalias
-  for(msi=0;msi<nsize;msi++) {
-    invM_i = invM + msi*Nsize;
-    bufM_i = bufM + msi*Nsize;
-    bufM_i2 = bufM + msi;
-    for(msj=0;msj<nsize;msj++) {
-      invM_i[msj] = 0.5*(bufM_i2[msj*nsize] - bufM_i[msj]);
-      /* invM[i][j] = 0.5*(bufM[i][j]-bufM[j][i]) */
-    }
-  }
+  // InvM -> InvM' = -InvM
+  M_DSCAL(&nsq, &minus_one, invM, &one);
+#endif
 
   return info;
 }

--- a/src/mVMC/matrix.c
+++ b/src/mVMC/matrix.c
@@ -69,7 +69,7 @@ int getLWork_fcmp() {
   lwork=-1;
   M_ZGETRI(&n, &a, &lda, &iwork, &optSize1, &lwork, &info);
   lwork=-1;
-  M_ZSKPFA(&uplo, &mthd, &n, &a, &lda, &pfaff, &iwork, &optSize2, &lwork, &rwork, &info);
+  M_ZSKPFA(&uplo, &mthd, &n, &a, &lda, &pfaff, &iwork, &optSize2, &lwork/*, &rwork*/, &info);
 
   lwork = (creal(optSize1)>creal(optSize2)) ? (int)creal(optSize1) : (int)creal(optSize2);
   return lwork;
@@ -132,9 +132,9 @@ int calculateMAll_child_fsz(const int *eleIdx,const int *eleSpn, const int qpSta
   int rsi,rsj;
 
   char uplo='U', mthd='P';
-  int m,n,lda,info=0;
+  int m,n,nsq,one,lda,info=0;
   //int nspn = 2*Ne+2*Nsite+2*Nsite+NProj; this is useful?
-  double complex pfaff;
+  double complex pfaff,minus_one;
 
   /* optimization for Kei */
   const int nsize = Nsize;
@@ -148,6 +148,9 @@ int calculateMAll_child_fsz(const int *eleIdx,const int *eleSpn, const int qpSta
   double complex *bufM_i, *bufM_i2;
 
   m=n=lda=Nsize;
+  nsq=n*n;
+  one=1;
+  minus_one=-1.0;
 
   /* store bufM */
   /* Note that bufM is column-major and skew-symmetric. */
@@ -178,35 +181,18 @@ int calculateMAll_child_fsz(const int *eleIdx,const int *eleSpn, const int qpSta
   //    printf("DEBUG: msi=%d msj=%d bufM %lf %lf \n",msi,msj,creal(bufM[msi+msj*n]),cimag(bufM[msi+msj*n]));
   //  }
   //}
-  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
+  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work/*, rwork*/, &lwork, &info);
   //printf("DEBUG: pfaff=%lf %lf\n",creal(pfaff),cimag(pfaff));
   if(info!=0) return info;
   if(!isfinite(creal(pfaff) + cimag(pfaff))) return qpidx+1;
   PfM[qpidx] = pfaff;
 
   /* DInv */
-  M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
-  if(info!=0) return info;
-  //for(msi=0;msi<nsize*nsize;msi++) {
-  //  printf("DEBUG: M_ZGETRF %d %lf %lf \n",msi,creal(bufM[msi]),cimag(bufM[msi]));
-  //}
+  // M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
+  // M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
 
-  M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
-  if(info!=0) return info;
-
-  /* store InvM */
-  /* BufM is column-major, InvM is row-major */
-#pragma loop noalias
-  for(msi=0;msi<nsize;msi++) {
-    invM_i = invM + msi*Nsize;
-    bufM_i = bufM + msi*Nsize;
-    bufM_i2 = bufM + msi;
-    for(msj=0;msj<nsize;msj++) {
-      invM_i[msj] = 0.5*(bufM_i2[msj*nsize] - bufM_i[msj]);
-      //printf("DEBUG: msj=%d invM=%lf %lf \n",msj,creal(invM_i[msj]),cimag(invM_i[msj]));
-      /* invM[i][j] = 0.5*(bufM[i][j]-bufM[j][i]) */
-    }
-  }
+  // InvM -> InvM(T) -> -InvM
+  M_ZSCAL(&nsq, &minus_one, InvM, &one);
 
   return info;
 }
@@ -388,8 +374,8 @@ int calculateMAll_child_fcmp(const int *eleIdx, const int qpStart, const int qpE
   int rsi,rsj;
 
   char uplo='U', mthd='P';
-  int m,n,lda,info=0;
-  double complex pfaff;
+  int m,n,nsq,lda,one,info=0;
+  double complex pfaff,minus_one;
 
   /* optimization for Kei */
   const int nsize = Nsize;
@@ -403,6 +389,9 @@ int calculateMAll_child_fcmp(const int *eleIdx, const int qpStart, const int qpE
   double complex *bufM_i, *bufM_i2;
 
   m=n=lda=Nsize;
+  nsq=n*n;
+  one=1;
+  minus_one=-1.0;
 
   /* store bufM */
   /* Note that bufM is column-major and skew-symmetric. */
@@ -426,6 +415,7 @@ int calculateMAll_child_fcmp(const int *eleIdx, const int qpStart, const int qpE
   for(msi=0;msi<nsize*nsize;msi++) {
     invM[msi] = bufM[msi];
   }
+  // [TODO] Now bufM is not needed. Remove.
   /* calculate Pf M */
   //printf("DEBUG: n=%d \n",n);
   //for(msi=0;msi<nsize;msi++){
@@ -433,35 +423,19 @@ int calculateMAll_child_fcmp(const int *eleIdx, const int qpStart, const int qpE
   //    printf("DEBUG: msi=%d msj=%d bufM %lf %lf \n",msi,msj,creal(bufM[msi+msj*n]),cimag(bufM[msi+msj*n]));
   //  }
   //}
-  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
-  //printf("DEBUG: pfaff=%lf %lf\n",creal(pfaff),cimag(pfaff));
+  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work/*, rwork*/, &lwork, &info);
+  // printf("DEBUG: pfaff=%lf %lf\n",creal(pfaff),cimag(pfaff));
   if(info!=0) return info;
   if(!isfinite(creal(pfaff) + cimag(pfaff))) return qpidx+1;
   PfM[qpidx] = pfaff;
 
   /* DInv */
-  M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
-  if(info!=0) return info;
-  //for(msi=0;msi<nsize*nsize;msi++) {
-  //  printf("DEBUG: M_ZGETRF %d %lf %lf \n",msi,creal(bufM[msi]),cimag(bufM[msi]));
-  //}
+  // M_ZGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
+  // M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
 
-  M_ZGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
-  if(info!=0) return info;
-
-  /* store InvM */
-  /* BufM is column-major, InvM is row-major */
-#pragma loop noalias
-  for(msi=0;msi<nsize;msi++) {
-    invM_i = invM + msi*Nsize;
-    bufM_i = bufM + msi*Nsize;
-    bufM_i2 = bufM + msi;
-    for(msj=0;msj<nsize;msj++) {
-      invM_i[msj] = 0.5*(bufM_i2[msj*nsize] - bufM_i[msj]);
-      //printf("DEBUG: msj=%d invM=%lf %lf \n",msj,creal(invM_i[msj]),cimag(invM_i[msj]));
-      /* invM[i][j] = 0.5*(bufM[i][j]-bufM[j][i]) */
-    }
-  }
+  /* mVMC's handling InvM as row-major,
+   * i.e. InvM needs a transpose, InvM -> -InvM according antisymmetric properties. */
+  M_ZSCAL(&nsq, &minus_one, InvM, &one);
 
   return info;
 }
@@ -569,7 +543,10 @@ int calculateMAll_BF_fcmp_child(
     invM[msi] = bufM[msi];
   }
   /* calculate Pf M */
-  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, rwork, &info); //TBC
+  // [R-Xu] Coverage-0 code. Skipping inverse only.
+  // NOTE: One may want to modify this according to calculateMAll_fcmp_child if he needs BF.
+  info = 1; // Skip inverse.
+  M_ZSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
   if(info!=0) return info;
   if(!(isfinite(creal(pfaff)) && isfinite(cimag(pfaff)))) return qpidx+1;
   PfM[qpidx] = pfaff;
@@ -651,8 +628,8 @@ int calculateMAll_child_real(const int *eleIdx, const int qpStart, const int qpE
   int rsi,rsj;
 
   char uplo='U', mthd='P';
-  int m,n,lda,info=0;
-  double pfaff;
+  int m,n,nsq,one,lda,info=0;
+  double pfaff,minus_one;
 
   /* optimization for Kei */
   const int nsize = Nsize;
@@ -666,6 +643,9 @@ int calculateMAll_child_real(const int *eleIdx, const int qpStart, const int qpE
   double *bufM_i, *bufM_i2;
 
   m=n=lda=Nsize;
+  nsq=n*n;
+  one=1;
+  minus_one=-1.0;
 
   /* store bufM */
   /* Note that bufM is column-major and skew-symmetric. */
@@ -708,25 +688,11 @@ int calculateMAll_child_real(const int *eleIdx, const int qpStart, const int qpE
 
   //  printf("Debug: M_DGETRF\n");
   /* DInv */
-  M_DGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
-  if(info!=0) return info;
+  // M_DGETRF(&m, &n, bufM, &lda, iwork, &info); /* ipiv = iwork */
+  // M_DGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
 
-  //  printf("Debug: M_DGETRI\n");
-  M_DGETRI(&n, bufM, &lda, iwork, work, &lwork, &info);
-  if(info!=0) return info;
-
-  /* store InvM */
-  /* BufM is column-major, InvM is row-major */
-#pragma loop noalias
-  for(msi=0;msi<nsize;msi++) {
-    invM_i = invM + msi*Nsize;
-    bufM_i = bufM + msi*Nsize;
-    bufM_i2 = bufM + msi;
-    for(msj=0;msj<nsize;msj++) {
-      invM_i[msj] = 0.5*(bufM_i2[msj*nsize] - bufM_i[msj]);
-      /* invM[i][j] = 0.5*(bufM[i][j]-bufM[j][i]) */
-    }
-  }
+  // InvM -> InvM' = -InvM
+  M_DSCAL(&nsq, &minus_one, invM, &one);
 
   return info;
 }
@@ -816,6 +782,11 @@ int calculateMAll_BF_real_child(const int *eleIdx, const int qpStart, const int 
     invM[msi] = bufM[msi];
   }
   /* calculate Pf M */
+  // [R-Xu]
+  // NOTE: This piece of code is coverage 0, i.e. cannot be tested
+  //       hence I'm keeping GETRF and GETRI to safety.
+  // TODO: If anyone'd like to utilize this, try to use Pfaffine's inv-mode and remove GETRF&GETRI.
+  info = 1; // Skip inverse.
   M_DSKPFA(&uplo, &mthd, &n, invM, &lda, &pfaff, iwork, work, &lwork, &info);
   if(info!=0) return info;
   if(!isfinite(pfaff)) return qpidx+1;

--- a/src/mVMC/pfupdate.c
+++ b/src/mVMC/pfupdate.c
@@ -351,8 +351,9 @@ double complex calculateNewPfMBFN4_child(const int qpidx, const int n, const int
   }
 
   /* calculate Pf M */
-  //TODO: CHECK rwork is real
-  M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+  //TODO: CHECK rwork is real <-- [R-Xu] Not needed anymore?
+  info = 1; // Skipping inverse.
+  M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
   //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;
@@ -588,7 +589,9 @@ double complex updateMAll_BF_fcmp_child(
   }
 
   /* calculate Pf M */
-  M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+  // [R-Xu] NOTE: Again coverage-0 code. Skipping.
+  info = 1; // Skip Pfaffine inverse.
+  M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
   //M_DSKPFA(&uplo, &mthd, &nn, invM, &lda, &pfaff, iwork, work, &lwork, &info);
   //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 

--- a/src/mVMC/pfupdate.c
+++ b/src/mVMC/pfupdate.c
@@ -350,10 +350,14 @@ double complex calculateNewPfMBFN4_child(const int qpidx, const int n, const int
     mat[n2*k + k] = 0.0; /* diagonal elements */
   }
 
-  /* calculate Pf M */
+  /* Calculate Pf M */
   //TODO: CHECK rwork is real <-- [R-Xu] Not needed anymore?
+#ifdef _pfaffine
   info = 1; // Skipping inverse.
   M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
+#else
+  M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+#endif
   //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;
@@ -588,10 +592,13 @@ double complex updateMAll_BF_fcmp_child(
     }
   }
 
-  /* calculate Pf M */
-  // [R-Xu] NOTE: Again coverage-0 code. Skipping.
+  /* Calculate Pf M */
+#ifdef _pfaffine
   info = 1; // Skip Pfaffine inverse.
   M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork/*, rwork*/, &info);
+#else
+  M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+#endif
   //M_DSKPFA(&uplo, &mthd, &nn, invM, &lda, &pfaff, iwork, work, &lwork, &info);
   //M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 

--- a/src/mVMC/pfupdate_real.c
+++ b/src/mVMC/pfupdate_real.c
@@ -362,6 +362,7 @@ double calculateNewPfMBFN4_real_child(const int qpidx, const int n, const int *m
 
   /* calculate Pf M */
   //M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+  info = 1; // Skip Pfaffine's inverse.
   M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;
@@ -543,6 +544,10 @@ double updateMAll_BF_real_child(const int qpidx, const int n, const int *msa,
     }
   }
   /* DInv */
+  // NOTE: This routines is not called in current version (i.e. lcoal coverage 0),
+  //       hence cannot be tested. I'm keeping GETRF and GETRI here.
+  // TODO: If anyone's interested in utilizing this routine, she or he might want to
+  //       utilize inverse feature of Pfaffine skpfa.
   m=nn=lda=n2;
   //M_ZGETRF(&m, &nn, invMat, &lda, iwork2, &info); /* ipiv = iwork */
   M_DGETRF(&m, &nn, invMat, &lda, iwork2, &info); /* ipiv = iwork */
@@ -596,6 +601,8 @@ double updateMAll_BF_real_child(const int qpidx, const int n, const int *msa,
   /* calculate Pf M */
   //M_ZSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
   //M_DSKPFA(&uplo, &mthd, &nn, invM, &lda, &pfaff, iwork, work, &lwork, &info);
+  // As stated above, I'm now only setting Pfaffine to skip optinal inverse.
+  info = 1; // This is parameter for skipping inversion.
   M_DSKPFA(&uplo, &mthd, &nn, mat, &lda, &pfaff, iwork, work, &lwork, &info);
 
   sgn = ( (n*(n-1)/2)%2==0 ) ? 1.0 : -1.0;

--- a/src/mVMC/vmcmake_fsz.c
+++ b/src/mVMC/vmcmake_fsz.c
@@ -77,17 +77,52 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
   } else {
     copyFromBurnSample_fsz(TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleProjCnt,TmpEleSpn) ;//fsz
   }
-  
+
+
+#ifdef _pf_block_update
+  // TODO: Compute from qpStart to qpEnd to support loop splitting.
+  void *pfOrbital[NQPFull];
+  void *pfUpdator[NQPFull];
+  // TODO: Make it input parameter.
+  if (NExUpdatePath == 0)
+    NBlockUpdateSize = 4;
+  else
+    NBlockUpdateSize = 20;
+
+  // Initialize with free spin configuration.
+  updated_tdi_v_init_z(NQPFull, Nsite, Nsite2, Nsize,
+                       SlaterElm, Nsite2*Nsite2,
+                       InvM, Nsize*Nsize,
+                       TmpEleIdx, TmpEleSpn,
+                       NBlockUpdateSize,
+                       pfUpdator, pfOrbital);
+  updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
   CalculateMAll_fsz(TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
 #ifdef _DEBUG_DETAIL
   printf("DEBUG: maker1: PfM=%lf\n",creal(PfM[0]));
 #endif
   logIpOld = CalculateLogIP_fcmp(PfM,qpStart,qpEnd,comm);
+
   if( !isfinite(creal(logIpOld) + cimag(logIpOld)) ) {
     if(rank==0) fprintf(stderr,"waring: VMCMakeSample remakeSample logIpOld=%e\n",creal(logIpOld)); //TBC
     makeInitialSample_fsz(TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleProjCnt,TmpEleSpn,
                       qpStart,qpEnd,comm);
+
+#ifdef _pf_block_update
+    // Clear and reinitialize.
+    updated_tdi_v_free_z(NQPFull, pfUpdator, pfOrbital);
+    updated_tdi_v_init_z(NQPFull, Nsite, Nsite2, Nsize,
+                         SlaterElm, Nsite2*Nsite2,
+                         InvM, Nsize*Nsize,
+                         TmpEleIdx, TmpEleSpn,
+                         NBlockUpdateSize,
+                         pfUpdator, pfOrbital);
+    updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
     CalculateMAll_fsz(TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
 #ifdef _DEBUG_DETAIL
     printf("DEBUG: maker2: PfM=%lf\n",creal(PfM[0]));
 #endif
@@ -151,8 +186,14 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
           UpdateProjCnt_fsz(ri,rj,s,t,projCntNew,TmpEleProjCnt,TmpEleNum);
         }   
         StopTimer(60);
+
         StartTimer(61);
+#ifdef _pf_block_update
+        updated_tdi_v_push_z(NQPFull, rj+t*Nsite, mi, 1, pfUpdator);
+        updated_tdi_v_get_pfa_z(NQPFull, pfMNew, pfUpdator);
+#else
         CalculateNewPfM2_fsz(mi,t,pfMNew,TmpEleIdx,TmpEleSpn,qpStart,qpEnd); // fsz: s->t 
+#endif
         StopTimer(61);
 
         StartTimer(62);
@@ -167,9 +208,14 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
         if( !isfinite(w) ) w = -1.0; /* should be rejected */
 
         if(w > genrand_real2()) { /* accept */
-          // UpdateMAll will change SlaterElm, InvM (including PfM)
           StartTimer(63);
+#ifdef _pf_block_update
+          // Inv already updated. Only need to get PfM again.
+          updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
+          // UpdateMAll will change SlaterElm, InvM (including PfM)
           UpdateMAll_fsz(mi,t,TmpEleIdx,TmpEleSpn,qpStart,qpEnd); // fsz : s->t
+#endif
           StopTimer(63);
 
           for(i=0;i<NProj;i++) TmpEleProjCnt[i] = projCntNew[i];
@@ -181,6 +227,9 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
             Counter[5]++;
           }
         } else { /* reject */ //(ri,s) <- (rj,t)
+#ifdef _pf_block_update
+          updated_tdi_v_pop_z(NQPFull, 0, pfUpdator);
+#endif
           revertEleConfig_fsz(mi,ri,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
         }
         StopTimer(32);
@@ -210,7 +259,15 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
         StopTimer(65);
         StartTimer(66);
 
+#ifdef _pf_block_update
+        updated_tdi_v_push_pair_z(NQPFull,
+                                  rj+s*Nsite, mi,
+                                  ri+t*Nsite, mj,
+                                  1, pfUpdator);
+        updated_tdi_v_get_pfa_z(NQPFull, pfMNew, pfUpdator);
+#else
         CalculateNewPfMTwo2_fsz(mi, s, mj, t, pfMNew, TmpEleIdx,TmpEleSpn, qpStart, qpEnd);
+#endif
         StopTimer(66);
         StartTimer(67);
 
@@ -226,7 +283,12 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
 
         if(w > genrand_real2()) { /* accept */
           StartTimer(68);
+#ifdef _pf_block_update
+          // Inv already updated. Only need to get PfM again.
+          updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
           UpdateMAllTwo_fsz(mi, s, mj, t, ri, rj, TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
           StopTimer(68);
 
           for(i=0;i<NProj;i++) TmpEleProjCnt[i] = projCntNew[i];
@@ -234,6 +296,10 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
           nAccept++;
           Counter[3]++;
         } else { /* reject */
+#ifdef _pf_block_update
+          updated_tdi_v_pop_z(NQPFull, 0, pfUpdator);
+          updated_tdi_v_pop_z(NQPFull, 0, pfUpdator);
+#endif
           revertEleConfig_fsz(mj,rj,ri,t,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
           revertEleConfig_fsz(mi,ri,rj,s,s,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
         }
@@ -256,8 +322,14 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
         updateEleConfig_fsz(mi,ri,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
         UpdateProjCnt_fsz(ri,rj,s,t,projCntNew,TmpEleProjCnt,TmpEleNum);
         StopTimer(600);
+
         StartTimer(601);
+#ifdef _pf_block_update
+        updated_tdi_v_push_z(NQPFull, rj+t*Nsite, mi, 1, pfUpdator);
+        updated_tdi_v_get_pfa_z(NQPFull, pfMNew, pfUpdator);
+#else
         CalculateNewPfM2_fsz(mi,t,pfMNew,TmpEleIdx,TmpEleSpn,qpStart,qpEnd); // fsz: s->t 
+#endif
         StopTimer(610);
 
         StartTimer(602);
@@ -277,9 +349,14 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
         //printf("%lf: %d %d, %d %d, %d %d, %d %d \n",w,TmpEleNum[0+0*Nsite],TmpEleNum[0+1*Nsite],TmpEleNum[1+0*Nsite],TmpEleNum[1+1*Nsite],TmpEleNum[2+0*Nsite],TmpEleNum[2+1*Nsite],TmpEleNum[3+0*Nsite],TmpEleNum[3+1*Nsite]);
         //printf("\n");
         if(w > genrand_real2()) { /* accept */
-          // UpdateMAll will change SlaterElm, InvM (including PfM)
           StartTimer(603);
+#ifdef _pf_block_update
+          // Inv already updated. Only need to get PfM again.
+          updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
+          // UpdateMAll will change SlaterElm, InvM (including PfM)
           UpdateMAll_fsz(mi,t,TmpEleIdx,TmpEleSpn,qpStart,qpEnd); // fsz : s->t
+#endif
           StopTimer(603);
 
           for(i=0;i<NProj;i++) TmpEleProjCnt[i] = projCntNew[i];
@@ -287,15 +364,30 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
           nAccept++;
           Counter[5]++;
         } else { /* reject */ //(ri,s) <- (rj,t)
+#ifdef _pf_block_update
+          updated_tdi_v_pop_z(NQPFull, 0, pfUpdator);
+#endif
           revertEleConfig_fsz(mi,ri,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
         }
         StopTimer(36);
       }
 
       if(nAccept>Nsite) {
+        // Recalculate PfM and InvM.
         StartTimer(34);
-        /* recal PfM and InvM */
+#ifdef _pf_block_update
+        // Clear and reinitialize.
+        updated_tdi_v_free_z(NQPFull, pfUpdator, pfOrbital);
+        updated_tdi_v_init_z(NQPFull, Nsite, Nsite2, Nsize,
+                             SlaterElm, Nsite2*Nsite2,
+                             InvM, Nsize*Nsize,
+                             TmpEleIdx, TmpEleSpn,
+                             NBlockUpdateSize,
+                             pfUpdator, pfOrbital);
+        updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
         CalculateMAll_fsz(TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
         //printf("DEBUG: maker3: PfM=%lf\n",creal(PfM[0]));
         logIpOld = CalculateLogIP_fcmp(PfM,qpStart,qpEnd,comm);
         StopTimer(34);
@@ -325,8 +417,13 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
 #ifdef _DEBUG_DETAIL
   fprintf(stdout, "Debug: Finish copyToBurnSample_fsz\n");
 #endif
-
   BurnFlag=1;
+
+#ifdef _pf_block_update
+  // Free-up updator space.
+  updated_tdi_v_free_z(NQPFull, pfUpdator, pfOrbital);
+#endif
+
   return;
 }
 

--- a/src/mVMC/vmcmake_real.c
+++ b/src/mVMC/vmcmake_real.c
@@ -172,12 +172,12 @@ void VMCMakeSample_real(MPI_Comm comm) {
         if (!isfinite(w)) w = -1.0; /* should be rejected */
 
         if (w > genrand_real2()) { /* accept */
-          // UpdateMAll will change SlaterElm, InvM (including PfM)
           StartTimer(63);
 #ifdef _pf_block_update
           // Inv already updated. Only need to get PfM again.
           updated_tdi_v_get_pfa_d(NQPFull, PfM_real, pfUpdator);
 #else
+          // UpdateMAll will change SlaterElm, InvM (including PfM)
           UpdateMAll_real(mi, s, TmpEleIdx, qpStart, qpEnd);
           //            UpdateMAll(mi,s,TmpEleIdx,qpStart,qpEnd);
 #endif

--- a/src/mVMC/vmcmake_real.c
+++ b/src/mVMC/vmcmake_real.c
@@ -76,7 +76,6 @@ void VMCMakeSample_real(MPI_Comm comm) {
   // TODO: Compute from qpStart to qpEnd to support loop splitting.
   void *pfOrbital[NQPFull];
   void *pfUpdator[NQPFull];
-  int NBlockUpdateSize;
   // TODO: Make it input parameter.
   if (NExUpdatePath == 0)
     NBlockUpdateSize = 4;

--- a/src/pfupdates/makefile_pfupdates
+++ b/src/pfupdates/makefile_pfupdates
@@ -1,0 +1,14 @@
+include ../make.sys
+
+OBJ = pfupdates.o
+SRC = pf_interface.cc
+HDR = pf_interface.h orbital_mat.tcc skmv.tcc updated_tdi.tcc
+
+$(OBJ): $(SRC) $(HDR) 
+	$(CXX) $(CXXFLAGS) -D_CC_IMPL -c $< -o $@ \
+		-I../pfaffine/src \
+		-I$(BLIS_ROOT)/include \
+		-I$(BLIS_ROOT)/include/blis
+
+clean:
+	rm -f $(OBJ)

--- a/src/pfupdates/orbital_mat.tcc
+++ b/src/pfupdates/orbital_mat.tcc
@@ -1,0 +1,85 @@
+/**
+ * \copyright Copyright (c) Dept. Phys., Univ. Tokyo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+#include "blis.h"
+#include "colmaj.tcc"
+#include <random>
+#ifdef UseBoost
+#include <boost/numeric/ublas/matrix.hpp>
+#include <boost/numeric/ublas/vector.hpp>
+#include <boost/numeric/ublas/io.hpp>
+template <typename T>
+using matrix_t = boost::numeric::ublas::matrix<T, boost::numeric::ublas::column_major>;
+template <typename T>
+using vector_t = boost::numeric::ublas::vector<T>;
+#else
+template <typename T>
+using matrix_t = colmaj<T>;
+#endif
+
+template <typename T>
+struct orbital_mat
+{
+  const uplo_t uplo;
+  const dim_t nsite;
+  matrix_t<T> X; ///< nsite*nsite.
+
+  orbital_mat(uplo_t uplo_, dim_t nsite_, T *X_, inc_t ldX)
+      : uplo(uplo_), nsite(nsite_),
+  #ifdef UseBoost
+        X(nsite, nsite) {
+    colmaj<T> X_tmp(X_, ldX);
+    for (dim_t j = 0; j < nsite; ++j)
+      for (dim_t i = 0; i < nsite; ++i)
+        X(i, j) = X_tmp(i, j);
+  }
+  #else
+        X(X_, ldX) { }
+  #endif
+
+  orbital_mat(uplo_t uplo_, dim_t nsite_, matrix_t<T> &X_)
+  : uplo(uplo_), nsite(nsite_), X(X_) { }
+
+  void randomize(double amplitude, unsigned seed) { 
+    using namespace std;
+    mt19937_64 rng(seed);
+    uniform_real_distribution<double> dist(-0.1, 1.0);
+
+    for (dim_t j = 0; j < nsite; ++j) {
+      for (dim_t i = 0; i < j; ++i) {
+        X(i, j) = T(dist(rng)) * amplitude;
+        X(j, i) = -X(i, j);
+      }
+      X(j, j) = T(0.0);
+    }
+  }
+
+  void randomize(double amplitude) { randomize(amplitude, 511); }
+
+  T operator()(dim_t osi, dim_t osj) {
+    if (osi == osj)
+      return T(0.0);
+
+    switch (uplo) {
+    case BLIS_UPPER:
+      if (osi < osj)
+        return X(osi, osj);
+      else
+        return -X(osj, osi);
+    
+    case BLIS_LOWER:
+      if (osi > osj)
+        return X(osi, osj);
+      else
+        return -X(osj, osi);
+
+    default:
+      return X(osi, osj);
+    }
+  }
+};

--- a/src/pfupdates/pf_interface.cc
+++ b/src/pfupdates/pf_interface.cc
@@ -7,6 +7,15 @@
 // In implementation, this should appear AFTER blis.h.
 #include "pf_interface.h"
 
+// Non-# Pragma support differs from compiler to compiler
+#if defined(__INTEL_COMPILER)
+#define OMP_PARALLEL_FOR_SHARED __pragma(omp parallel for default(shared))
+#elif defined(__GNUC__)
+#define OMP_PARALLEL_FOR_SHARED _Pragma("omp parallel for default(shared)")
+#else
+#error "Valid non-preprocessor _pragma() not found."
+#endif
+
 #define orbv( i, ctype ) ( (orbital_mat<ctype> *)orbv[i] )
 #define objv( i, ctype ) ( (updated_tdi<ctype> *)objv[i] )
 
@@ -28,7 +37,7 @@
       void     *objv[], \
       void     *orbv[] ) \
 { \
-  _Pragma("omp parallel for default(shared)") \
+  OMP_PARALLEL_FOR_SHARED \
   for (int iqp = 0; iqp < num_qp; ++iqp) { \
     orbv[iqp] = new orbital_mat<ctype>( \
         BLIS_UPPER, norbs, orbmat_base + iqp * orbmat_stride, norbs); \
@@ -89,7 +98,7 @@ GENIMPL( ccdcmplx, z )
       int64_t   cal_pfa, \
       void     *objv[] ) \
 { \
-  _Pragma("omp parallel for default(shared)") \
+  OMP_PARALLEL_FOR_SHARED \
   for (int iqp = 0; iqp < num_qp; ++iqp) \
     objv(iqp, ctype)->push_update_safe(osi, msj, cal_pfa!=0); \
 }
@@ -109,7 +118,7 @@ GENIMPL( ccdcmplx, z )
       int64_t   cal_pfa, \
       void     *objv[] ) \
 { \
-  _Pragma("omp parallel for default(shared)") \
+  OMP_PARALLEL_FOR_SHARED \
   for (int iqp = 0; iqp < num_qp; ++iqp) { \
     auto &from_i = objv(iqp, ctype)->from_idx; \
     if (from_i.size() > objv(iqp, ctype)->mmax - 2) \

--- a/src/pfupdates/pf_interface.cc
+++ b/src/pfupdates/pf_interface.cc
@@ -10,7 +10,7 @@
 #define orbv( i, ctype ) ( (orbital_mat<ctype> *)orbv[i] )
 #define objv( i, ctype ) ( (updated_tdi<ctype> *)objv[i] )
 
-#define EXPANDNAME( cblachar, funcname ) funcname##_##cblachar
+#define EXPANDNAME( funcname, cblachar ) funcname##_##cblachar
 
 #define GENIMPL( ctype, cblachar ) \
   void EXPANDNAME( updated_tdi_v_init, cblachar ) \
@@ -91,7 +91,7 @@ GENIMPL( ccdcmplx, z )
 { \
   _Pragma("omp parallel for default(shared)") \
   for (int iqp = 0; iqp < num_qp; ++iqp) \
-    objv(iqp, ctype)->push_update_safe(osi, msj, true); \
+    objv(iqp, ctype)->push_update_safe(osi, msj, cal_pfa!=0); \
 }
 GENIMPL( float,    s )
 GENIMPL( double,   d )
@@ -122,7 +122,7 @@ GENIMPL( ccdcmplx, z )
           break; \
         } \
     objv(iqp, ctype)->push_update(osi, msj, false); \
-    objv(iqp, ctype)->push_update(osk, msl, true); \
+    objv(iqp, ctype)->push_update(osk, msl, cal_pfa!=0); \
   } \
 }
 GENIMPL( float,    s )
@@ -138,7 +138,7 @@ GENIMPL( ccdcmplx, z )
       void     *objv[] ) \
 { \
   for (int iqp = 0; iqp < num_qp; ++iqp) { \
-    objv(iqp, ctype)->pop_update(false); \
+    objv(iqp, ctype)->pop_update(cal_pfa!=0); \
   } \
 }
 GENIMPL( float,    s )

--- a/src/pfupdates/pf_interface.cc
+++ b/src/pfupdates/pf_interface.cc
@@ -1,0 +1,151 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#include "updated_tdi.tcc"
+// In implementation, this should appear AFTER blis.h.
+#include "pf_interface.h"
+
+#define orbv( i, ctype ) ( (orbital_mat<ctype> *)orbv[i] )
+#define objv( i, ctype ) ( (updated_tdi<ctype> *)objv[i] )
+
+#define EXPANDNAME( cblachar, funcname ) funcname##_##cblachar
+
+#define GENIMPL( ctype, cblachar ) \
+  void EXPANDNAME( updated_tdi_v_init, cblachar ) \
+    ( uint64_t  num_qp, \
+      uint64_t  nsite, \
+      uint64_t  norbs, \
+      uint64_t  nelec, \
+      ctype    *orbmat_base, \
+      int64_t   orbmat_stride, \
+      ctype    *invmat_base, \
+      int64_t   invmat_stride, \
+      int32_t  *eleidx, \
+      int32_t  *elespn, \
+      uint64_t  mmax, \
+      void     *objv[], \
+      void     *orbv[] ) \
+{ \
+  _Pragma("omp parallel for default(shared)") \
+  for (int iqp = 0; iqp < num_qp; ++iqp) { \
+    orbv[iqp] = new orbital_mat<ctype>( \
+        BLIS_UPPER, norbs, orbmat_base + iqp * orbmat_stride, norbs); \
+    objv[iqp] = new updated_tdi<ctype>( \
+        *orbv(iqp, ctype), nelec, invmat_base + iqp * invmat_stride, nelec, mmax); \
+\
+    /* Compute initial. */ \
+    auto &cfg_i = objv(iqp, ctype)->elem_cfg; \
+    for (int msi = 0; msi < nelec; ++msi) \
+      cfg_i.at(msi) = eleidx[msi] + elespn[msi]*nsite; \
+    objv(iqp, ctype)->initialize(); \
+  } \
+}
+GENIMPL( float,    s )
+GENIMPL( double,   d )
+GENIMPL( ccscmplx, c )
+GENIMPL( ccdcmplx, z )
+#undef GENIMPL
+
+#define GENIMPL( ctype, cblachar ) \
+  void EXPANDNAME( updated_tdi_v_free, cblachar ) \
+    ( uint64_t  num_qp, \
+      void     *objv[], \
+      void     *orbv[] ) \
+{ \
+  for (int iqp = 0; iqp < num_qp; ++iqp) { \
+    delete orbv(iqp, ctype); \
+    delete objv(iqp, ctype); \
+  } \
+}
+GENIMPL( float,    s )
+GENIMPL( double,   d )
+GENIMPL( ccscmplx, c )
+GENIMPL( ccdcmplx, z )
+#undef GENIMPL
+
+#define GENIMPL( ctype, cblachar ) \
+  void EXPANDNAME( updated_tdi_v_get_pfa, cblachar ) \
+    ( uint64_t  num_qp, \
+      ctype     pfav[], \
+      void     *objv[] ) \
+{ \
+  /* Minus sign appears from that SlaterElm is in fact interpreted as row-major. */ \
+  for (int iqp = 0; iqp < num_qp; ++iqp) \
+    pfav[iqp] = -objv(iqp, ctype)->get_Pfa(); \
+}
+GENIMPL( float,    s )
+GENIMPL( double,   d )
+GENIMPL( ccscmplx, c )
+GENIMPL( ccdcmplx, z )
+#undef GENIMPL
+
+#define GENIMPL( ctype, cblachar ) \
+  void EXPANDNAME( updated_tdi_v_push, cblachar ) \
+    ( uint64_t  num_qp, \
+      int64_t   osi, \
+      int64_t   msj, \
+      int64_t   cal_pfa, \
+      void     *objv[] ) \
+{ \
+  _Pragma("omp parallel for default(shared)") \
+  for (int iqp = 0; iqp < num_qp; ++iqp) \
+    objv(iqp, ctype)->push_update_safe(osi, msj, true); \
+}
+GENIMPL( float,    s )
+GENIMPL( double,   d )
+GENIMPL( ccscmplx, c )
+GENIMPL( ccdcmplx, z )
+#undef GENIMPL
+
+#define GENIMPL( ctype, cblachar ) \
+  void EXPANDNAME( updated_tdi_v_push_pair, cblachar ) \
+    ( uint64_t  num_qp, \
+      int64_t   osi, \
+      int64_t   msj, \
+      int64_t   osk, \
+      int64_t   msl, \
+      int64_t   cal_pfa, \
+      void     *objv[] ) \
+{ \
+  _Pragma("omp parallel for default(shared)") \
+  for (int iqp = 0; iqp < num_qp; ++iqp) { \
+    auto &from_i = objv(iqp, ctype)->from_idx; \
+    if (from_i.size() > objv(iqp, ctype)->mmax - 2) \
+      objv(iqp, ctype)->merge_updates(); \
+    else \
+      for (int ik = 0; ik < from_i.size(); ++ik) \
+        if (from_i.at(ik) == msj || \
+            from_i.at(ik) == msl) { \
+          objv(iqp, ctype)->merge_updates(); \
+          break; \
+        } \
+    objv(iqp, ctype)->push_update(osi, msj, false); \
+    objv(iqp, ctype)->push_update(osk, msl, true); \
+  } \
+}
+GENIMPL( float,    s )
+GENIMPL( double,   d )
+GENIMPL( ccscmplx, c )
+GENIMPL( ccdcmplx, z )
+#undef GENIMPL
+
+#define GENIMPL( ctype, cblachar ) \
+  void EXPANDNAME( updated_tdi_v_pop, cblachar ) \
+    ( uint64_t  num_qp, \
+      int64_t   cal_pfa, \
+      void     *objv[] ) \
+{ \
+  for (int iqp = 0; iqp < num_qp; ++iqp) { \
+    objv(iqp, ctype)->pop_update(false); \
+  } \
+}
+GENIMPL( float,    s )
+GENIMPL( double,   d )
+GENIMPL( ccscmplx, c )
+GENIMPL( ccdcmplx, z )
+#undef GENIMPL
+
+#undef EXPANDNAME
+

--- a/src/pfupdates/pf_interface.h
+++ b/src/pfupdates/pf_interface.h
@@ -15,15 +15,17 @@
 #ifndef _CC_IMPL
 typedef _Complex double ccdcmplx;
 typedef _Complex float  ccscmplx;
+#else
+extern "C" {
 #endif
 
 // Function naming scheme:
 // updated_tdi_[v means ``operate on vector'']_[operation]_[datatype].
 
-#define EXPANDNAME( cblachar, funcname ) funcname##_##cblachar
+#define EXPANDNAME( funcname, cblachar ) funcname##_##cblachar
 
 #define GENDEF( ctype, cblachar ) \
-  extern "C" void EXPANDNAME( updated_tdi_v_init, cblachar ) \
+   void EXPANDNAME( updated_tdi_v_init, cblachar ) \
     ( uint64_t  num_qp, \
       uint64_t  nsite, \
       uint64_t  norbs, \
@@ -40,36 +42,36 @@ typedef _Complex float  ccscmplx;
 
 GENDEF( float,    s )
 GENDEF( double,   d )
-GENDEF( scomplex, c )
-GENDEF( dcomplex, z )
+GENDEF( ccscmplx, c )
+GENDEF( ccdcmplx, z )
 #undef GENDEF
 
 #define GENDEF( ctype, cblachar ) \
-  extern "C" void EXPANDNAME( updated_tdi_v_free, cblachar ) \
+   void EXPANDNAME( updated_tdi_v_free, cblachar ) \
     ( uint64_t  num_qp, \
       void     *objv[], \
       void     *orbv[] );
 
 GENDEF( float,    s )
 GENDEF( double,   d )
-GENDEF( scomplex, c )
-GENDEF( dcomplex, z )
+GENDEF( ccscmplx, c )
+GENDEF( ccdcmplx, z )
 #undef GENDEF
 
 #define GENDEF( ctype, cblachar ) \
-  extern "C" void EXPANDNAME( updated_tdi_v_get_pfa, cblachar ) \
+   void EXPANDNAME( updated_tdi_v_get_pfa, cblachar ) \
     ( uint64_t  num_qp, \
       ctype     pfav[], \
       void     *objv[] );
 
 GENDEF( float,    s )
 GENDEF( double,   d )
-GENDEF( scomplex, c )
-GENDEF( dcomplex, z )
+GENDEF( ccscmplx, c )
+GENDEF( ccdcmplx, z )
 #undef GENDEF
 
 #define GENDEF( ctype, cblachar ) \
-  extern "C" void EXPANDNAME( updated_tdi_v_push, cblachar ) \
+   void EXPANDNAME( updated_tdi_v_push, cblachar ) \
     ( uint64_t  num_qp, \
       int64_t   osi, \
       int64_t   msj, \
@@ -78,12 +80,12 @@ GENDEF( dcomplex, z )
 
 GENDEF( float,    s )
 GENDEF( double,   d )
-GENDEF( scomplex, c )
-GENDEF( dcomplex, z )
+GENDEF( ccscmplx, c )
+GENDEF( ccdcmplx, z )
 #undef GENDEF
 
 #define GENDEF( ctype, cblachar ) \
-  extern "C" void EXPANDNAME( updated_tdi_v_push_pair, cblachar ) \
+   void EXPANDNAME( updated_tdi_v_push_pair, cblachar ) \
     ( uint64_t  num_qp, \
       int64_t   osi, \
       int64_t   msj, \
@@ -94,21 +96,25 @@ GENDEF( dcomplex, z )
 
 GENDEF( float,    s )
 GENDEF( double,   d )
-GENDEF( scomplex, c )
-GENDEF( dcomplex, z )
+GENDEF( ccscmplx, c )
+GENDEF( ccdcmplx, z )
 #undef GENDEF
 
 #define GENDEF( ctype, cblachar ) \
-  extern "C" void EXPANDNAME( updated_tdi_v_pop, cblachar ) \
+   void EXPANDNAME( updated_tdi_v_pop, cblachar ) \
     ( uint64_t  num_qp, \
       int64_t   cal_pfa, \
       void     *objv[] );
 
 GENDEF( float,    s )
 GENDEF( double,   d )
-GENDEF( scomplex, c )
-GENDEF( dcomplex, z )
+GENDEF( ccscmplx, c )
+GENDEF( ccdcmplx, z )
 #undef GENDEF
 
 #undef EXPANDNAME
+
+#ifdef _CC_IMPL
+}
+#endif
 

--- a/src/pfupdates/pf_interface.h
+++ b/src/pfupdates/pf_interface.h
@@ -1,0 +1,114 @@
+/**
+ * To link to this module, the following C/C++-compiler feature is required
+ *  BEYOND C99/C++14 standard:
+ *  - all pointers has uint64 underlying datatype.
+ *  This is usually satisfied if one uses 64-bit compilers with compatible ABI.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+#include "stdint.h"
+
+// Redefine double complex for (future) non-C99 compatibility.
+#ifndef _CC_IMPL
+typedef _Complex double ccdcmplx;
+typedef _Complex float  ccscmplx;
+#endif
+
+// Function naming scheme:
+// updated_tdi_[v means ``operate on vector'']_[operation]_[datatype].
+
+#define EXPANDNAME( cblachar, funcname ) funcname##_##cblachar
+
+#define GENDEF( ctype, cblachar ) \
+  extern "C" void EXPANDNAME( updated_tdi_v_init, cblachar ) \
+    ( uint64_t  num_qp, \
+      uint64_t  nsite, \
+      uint64_t  norbs, \
+      uint64_t  nelec, \
+      ctype    *orbmat_base, \
+      int64_t   orbmat_stride, \
+      ctype    *invmat_base, \
+      int64_t   invmat_stride, \
+      int32_t  *eleidx, \
+      int32_t  *elespn, \
+      uint64_t  mmax, \
+      void     *objv[], \
+      void     *orbv[] );
+
+GENDEF( float,    s )
+GENDEF( double,   d )
+GENDEF( scomplex, c )
+GENDEF( dcomplex, z )
+#undef GENDEF
+
+#define GENDEF( ctype, cblachar ) \
+  extern "C" void EXPANDNAME( updated_tdi_v_free, cblachar ) \
+    ( uint64_t  num_qp, \
+      void     *objv[], \
+      void     *orbv[] );
+
+GENDEF( float,    s )
+GENDEF( double,   d )
+GENDEF( scomplex, c )
+GENDEF( dcomplex, z )
+#undef GENDEF
+
+#define GENDEF( ctype, cblachar ) \
+  extern "C" void EXPANDNAME( updated_tdi_v_get_pfa, cblachar ) \
+    ( uint64_t  num_qp, \
+      ctype     pfav[], \
+      void     *objv[] );
+
+GENDEF( float,    s )
+GENDEF( double,   d )
+GENDEF( scomplex, c )
+GENDEF( dcomplex, z )
+#undef GENDEF
+
+#define GENDEF( ctype, cblachar ) \
+  extern "C" void EXPANDNAME( updated_tdi_v_push, cblachar ) \
+    ( uint64_t  num_qp, \
+      int64_t   osi, \
+      int64_t   msj, \
+      int64_t   cal_pfa, \
+      void     *objv[] );
+
+GENDEF( float,    s )
+GENDEF( double,   d )
+GENDEF( scomplex, c )
+GENDEF( dcomplex, z )
+#undef GENDEF
+
+#define GENDEF( ctype, cblachar ) \
+  extern "C" void EXPANDNAME( updated_tdi_v_push_pair, cblachar ) \
+    ( uint64_t  num_qp, \
+      int64_t   osi, \
+      int64_t   msj, \
+      int64_t   osk, \
+      int64_t   msl, \
+      int64_t   cal_pfa, \
+      void     *objv[] );
+
+GENDEF( float,    s )
+GENDEF( double,   d )
+GENDEF( scomplex, c )
+GENDEF( dcomplex, z )
+#undef GENDEF
+
+#define GENDEF( ctype, cblachar ) \
+  extern "C" void EXPANDNAME( updated_tdi_v_pop, cblachar ) \
+    ( uint64_t  num_qp, \
+      int64_t   cal_pfa, \
+      void     *objv[] );
+
+GENDEF( float,    s )
+GENDEF( double,   d )
+GENDEF( scomplex, c )
+GENDEF( dcomplex, z )
+#undef GENDEF
+
+#undef EXPANDNAME
+

--- a/src/pfupdates/skmv.tcc
+++ b/src/pfupdates/skmv.tcc
@@ -1,0 +1,55 @@
+/**
+ * \copyright Copyright (c) Dept. Phys., Univ. Tokyo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+#include "colmaj.tcc"
+#include "blalink.hh"
+#include <vector>
+
+template <typename T>
+void skmv(uplo_t uploA,
+          dim_t m,
+          T alpha,
+          T *_A, inc_t ldA,
+          T *X,
+          T *Y) {
+  using namespace std;
+  colmaj<T> A(_A, ldA);
+
+  // Way 1:
+  // skmm(BLIS_LEFT, uploA, BLIS_NO_CONJUGATE, BLIS_NO_TRANSPOSE, m, 1,
+  //      T(1.0), &A(0, 0), A.ld, &X[0], ldA, T(0.0), &Y[0], ldA);
+
+  // Way 2:
+  vector<T> Z(m);
+  for (dim_t i = 0; i < m; ++i) {
+    Z[i] = X[i];
+    Y[i] = X[i];
+  }
+  trmv(uploA, BLIS_NO_TRANSPOSE,
+       m, alpha, &A(0, 0), A.ld, &Y[0], 1);
+  trmv(uploA, BLIS_TRANSPOSE,
+       m, alpha, &A(0, 0), A.ld, &Z[0], 1);
+  for (dim_t i = 0; i < m; ++i)
+    Y[i] -= Z[i];
+
+  // Way 3:
+  // for (dim_t i = 0; i < m; ++i)
+  //   Y[i] = 0.0;
+  // for (dim_t j = 0; j < m; ++j) {
+  //   T x_j = X[j];
+  //   for (dim_t i = 0; i < j; ++i) {
+  //     T A_ij = A(i, j);
+  //     Y[i] += A_ij * x_j;
+  //     Y[j] -= A_ij * X[i];
+  //   }
+  // }
+  // for (dim_t i = 0; i < m; ++i)
+  //   Y[i] *= alpha;
+  
+}
+

--- a/src/pfupdates/updated_tdi.tcc
+++ b/src/pfupdates/updated_tdi.tcc
@@ -1,0 +1,650 @@
+/**
+ * \copyright Copyright (c) Dept. Phys., Univ. Tokyo
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+#pragma once
+#include "orbital_mat.tcc"
+#include "blalink.hh"
+#include "skpfa.hh"
+#include "sktdi.hh"
+#include "skr2k.tcc"
+#include "skslc.tcc"
+#include "skmv.tcc"
+#include "optpanel.hh"
+#include <iostream>
+#include <vector>
+
+template <typename T> struct updated_tdi {
+  orbital_mat<T> &Xij;
+  uplo_t uplo; ///< Can be switched only with update_uplo().
+  const dim_t nelec;
+  const dim_t mmax;
+  dim_t nq_updated; // Update of Q(:, i) can be delayed against U.
+
+  // Performance tuning constants.
+  const bool single_hop_alpha; ///< Whether to simplify k=1 situations.
+  const dim_t npanel_big;
+  const dim_t npanel_sub;
+
+  // Matrix M.
+  matrix_t<T> M;
+
+  // Updator blocks U, inv(M)U and inv(M)V.
+  // Note that V is not stored.
+  matrix_t<T> U; ///< Serves also as B*inv
+  matrix_t<T> Q; ///< Contains the whole B buffer. Assert![ Q = M U ]
+  matrix_t<T> P; ///< Q(0, mmax)
+
+  // Central update buffer and its blocks.
+  matrix_t<T> W;
+  matrix_t<T> UMU, UMV, VMV;
+  matrix_t<T> Cp;       ///< C+BMB = [ W -I; I 0 ] + [ UMU UMV; -UMV VMV ]
+  matrix_t<T> Gc;       ///< Gaussian vectors when tri-diagonalizing C.
+  signed *const cPov; ///< Pivot when tri-diagonalizing C.
+  T Pfa;
+  T PfaRatio; //< Updated Pfaffian / Base Pfaffian.
+  // TODO: Maybe one should log all Pfaffian histories.
+
+  std::vector<dim_t> elem_cfg;
+  std::vector<dim_t> from_idx;
+  std::vector<dim_t> to_site;
+
+  void initialize() {
+    using namespace std;
+    auto &cfg = elem_cfg;
+    #ifdef UseBoost
+    matrix_t<T> G(nelec, nelec);
+    #else
+    matrix_t<T> G(new T[nelec * nelec], nelec);
+    #endif
+    from_idx.clear();
+    to_site.clear();
+    from_idx.reserve(mmax * sizeof(dim_t));
+    to_site.reserve(mmax * sizeof(dim_t));
+
+    switch (uplo) {
+    case BLIS_UPPER:
+      for (dim_t j = 0; j < nelec; ++j) {
+        for (dim_t i = 0; i < j; ++i) {
+          M(i, j) = Xij(cfg.at(i), cfg.at(j));
+        }
+        M(j, j) = T(0.0);
+      }
+      break;
+
+    default:
+      cerr << "updated_tdi<T>: BLIS_LOWER is not supported. The error is fetal."
+           << endl;
+    }
+
+    // Allocate scratchpad.
+    signed *iPovFull = new signed[nelec + 1];
+    dim_t lwork = nelec * npanel_big;
+    T *pfwork = new T[lwork];
+
+    #ifdef UseBoost
+    signed info = skpfa(uplo, nelec, &M(0, 0), M.size1(), &G(0, 0), G.size1(), iPovFull,
+                        true, &Pfa, pfwork, lwork);
+    #else
+    signed info = skpfa(uplo, nelec, &M(0, 0), M.ld, &G(0, 0), G.ld, iPovFull,
+                        true, &Pfa, pfwork, lwork);
+    #endif
+#ifdef _DEBUG
+    cerr << "SKPFA+INV: n=" << nelec << " info=" << info << endl;
+#endif
+
+    delete[] iPovFull;
+    delete[] pfwork;
+    #ifndef UseBoost
+    delete[](&G(0, 0));
+    #endif
+  }
+
+  ~updated_tdi() {
+    #ifndef UseBoost
+    delete[](&U(0, 0));
+    delete[](&Q(0, 0));
+
+    delete[](&Cp(0, 0));
+    delete[](&Gc(0, 0));
+
+    delete[](&W(0, 0));
+    delete[](&UMU(0, 0));
+    delete[](&UMV(0, 0));
+    delete[](&VMV(0, 0));
+    #endif
+
+    delete[] cPov;
+  }
+
+  updated_tdi(orbital_mat<T> &Xij_, std::vector<dim_t> &cfg, T *M_, inc_t ldM,
+              dim_t mmax_)
+      : Xij(Xij_), nelec(cfg.size()), mmax(mmax_), nq_updated(0),
+        single_hop_alpha(true), npanel_big(optpanel(nelec, 4)), npanel_sub(4),
+    #ifdef UseBoost
+        M(nelec, nelec),
+        U(nelec, mmax * 2), Q(nelec, mmax * 2),
+        P(nelec, mmax), W(mmax, mmax),
+        UMU(mmax, mmax), UMV(mmax, mmax),
+        VMV(mmax, mmax), Cp(2 * mmax, 2 * mmax),
+        Gc(2 * mmax, 2 * mmax),
+    #else
+        M(M_, ldM),
+        U(new T[nelec * mmax * 2], nelec), Q(new T[nelec * mmax * 2], nelec),
+        P(&Q(0, mmax), Q.ld), W(new T[mmax * mmax], mmax),
+        UMU(new T[mmax * mmax], mmax), UMV(new T[mmax * mmax], mmax),
+        VMV(new T[mmax * mmax], mmax), Cp(new T[2 * mmax * 2 * mmax], 2 * mmax),
+        Gc(new T[2 * mmax * 2 * mmax], 2 * mmax),
+    #endif
+        cPov(new signed[2 * mmax + 1]), Pfa(0.0), PfaRatio(1.0), elem_cfg(cfg),
+        from_idx(0), to_site(0), uplo(BLIS_UPPER) {
+    #ifdef UseBoost
+    colmaj<T> M_tmp(M_, ldM);
+    for (dim_t j = 0; j < nelec; ++j)
+      for (dim_t i = 0; i < nelec; ++i)
+        M(i, j) = M_tmp(i, j);
+    #endif
+    initialize();
+  }
+
+  /*
+  updated_tdi(orbital_mat<T> &Xij_, std::vector<dim_t> &cfg, matrix_t<T> &M_,
+              dim_t mmax_)
+      : Xij(Xij_), nelec(cfg.size()), mmax(mmax_), nq_updated(0),
+        single_hop_alpha(true), npanel_big(optpanel(nelec, 4)), npanel_sub(4),
+        M(M_),
+        U(new T[nelec * mmax * 2], nelec), Q(new T[nelec * mmax * 2], nelec),
+        P(&Q(0, mmax), Q.ld), W(new T[mmax * mmax], mmax),
+        UMU(new T[mmax * mmax], mmax), UMV(new T[mmax * mmax], mmax),
+        VMV(new T[mmax * mmax], mmax), Cp(new T[2 * mmax * 2 * mmax], 2 * mmax),
+        Gc(new T[2 * mmax * 2 * mmax], 2 * mmax),
+        cPov(new signed[2 * mmax + 1]), Pfa(0.0), PfaRatio(1.0), elem_cfg(cfg),
+        from_idx(0), to_site(0), uplo(BLIS_UPPER) {
+    initialize();
+  }*/
+
+  // Unsafe construction without initializaion.
+  updated_tdi(orbital_mat<T> &Xij_, dim_t nelec_, T *M_, inc_t ldM, dim_t mmax_) 
+      : Xij(Xij_), nelec(nelec_), mmax(mmax_), nq_updated(0),
+        single_hop_alpha(true), npanel_big(optpanel(nelec, 4)), npanel_sub(4),
+    #ifdef UseBoost
+        M(nelec, nelec),
+        U(nelec, mmax * 2), Q(nelec, mmax * 2),
+        P(nelec, mmax), W(mmax, mmax),
+        UMU(mmax, mmax), UMV(mmax, mmax),
+        VMV(mmax, mmax), Cp(2 * mmax, 2 * mmax),
+        Gc(2 * mmax, 2 * mmax),
+    #else
+        M(M_, ldM),
+        U(new T[nelec * mmax * 2], nelec), Q(new T[nelec * mmax * 2], nelec),
+        P(&Q(0, mmax), Q.ld), W(new T[mmax * mmax], mmax),
+        UMU(new T[mmax * mmax], mmax), UMV(new T[mmax * mmax], mmax),
+        VMV(new T[mmax * mmax], mmax), Cp(new T[2 * mmax * 2 * mmax], 2 * mmax),
+        Gc(new T[2 * mmax * 2 * mmax], 2 * mmax),
+    #endif
+        cPov(new signed[2 * mmax + 1]), Pfa(0.0), PfaRatio(1.0), elem_cfg(nelec, 0),
+        from_idx(0), to_site(0), uplo(BLIS_UPPER) { 
+    #ifdef UseBoost
+    colmaj<T> M_tmp(M_, ldM);
+    for (dim_t j = 0; j < nelec; ++j)
+      for (dim_t i = 0; i < nelec; ++i)
+        M(i, j) = M_tmp(i, j);
+    #endif
+  }
+
+  T get_Pfa() { return Pfa * PfaRatio; }
+
+  void assemble_C_BMB() {
+    using namespace std;
+    dim_t k = from_idx.size();
+
+    // Assemble (half of) C+BMB buffer.
+    switch (uplo) {
+    case BLIS_UPPER:
+      for (dim_t j = 0; j < k; ++j)
+        for (dim_t i = 0; i < j; ++i)
+          Cp(i, j) = W(i, j) + UMU(i, j);
+      for (dim_t j = 0; j < k; ++j) {
+        for (dim_t i = 0; i < k; ++i)
+          Cp(i, j + k) = +UMV(i, j);
+
+        Cp(j, j + k) -= T(1.0);
+      }
+      for (dim_t j = 0; j < k; ++j)
+        for (dim_t i = 0; i < j; ++i)
+          Cp(i + k, j + k) = VMV(i, j);
+      break;
+
+    default:
+      cerr << "updated_tdi<T>::assemble_C_BMB:"
+           << " Only upper-triangular storage is supported." << endl;
+    }
+  }
+
+  // Update Q rows buffer.
+  bool require_Q(bool all) {
+    const dim_t k = from_idx.size();
+    const dim_t n = nelec;
+    dim_t k_cal;
+    // Require all K columns instead of first K-1.
+    if (all)
+      k_cal = k;
+    else
+      k_cal = k - 1;
+
+    if (nq_updated >= k_cal)
+      // Do nothing if nothing is to be updated.
+      return false;
+
+    if (nq_updated == k_cal - 1) {
+      // Update single column. Use SKMV.
+      #ifdef UseBoost
+      skmv(uplo, n, T(1.0), &M(0, 0), M.size1(), &U(0, nq_updated), &Q(0, nq_updated));
+      #else
+      skmv(uplo, n, T(1.0), &M(0, 0), M.ld, &U(0, nq_updated), &Q(0, nq_updated));
+      #endif
+    } else {
+      // Update multiple columns. Use SKMM.
+      #ifdef UseBoost
+      skmm(BLIS_LEFT, uplo, BLIS_NO_CONJUGATE, BLIS_NO_TRANSPOSE, n, k_cal - nq_updated,
+           T(1.0), &M(0, 0), M.size1(), &U(0, nq_updated), U.size1(),
+           T(0.0), &Q(0, nq_updated), Q.size1());
+      #else
+      skmm(BLIS_LEFT, uplo, BLIS_NO_CONJUGATE, BLIS_NO_TRANSPOSE, n, k_cal - nq_updated,
+           T(1.0), &M(0, 0), M.ld, &U(0, nq_updated), U.ld,
+           T(0.0), &Q(0, nq_updated), Q.ld);
+      #endif
+    }
+    nq_updated = k_cal;
+    return true;
+  }
+
+  // UMU needs to be recalculated for hopping change.
+  // TODO: Find some way to avoid recalculating UQ?
+  bool require_UMU() {
+    const dim_t k = from_idx.size();
+    const dim_t n = nelec;
+
+    for (dim_t o = 0; o < k; ++o)
+      for (dim_t l = 0; l < o; ++l)
+        switch (uplo) {
+        case BLIS_UPPER:
+          UMU(l, o) = -dot(n, &U(0, o), 1, &Q(0, l), 1);
+          break;
+        case BLIS_LOWER:
+          // Always assume l < o to calculate one less column of Q.
+          UMU(o, l) = dot(n, &U(0, o), 1, &Q(0, l), 1);
+          break;
+        }
+    return true;
+  }
+
+  // Inverts a configuration from fermion index to site index.
+  void config_to_site(std::vector<dim_t> &cfg, std::vector<signed> &site, bool init) {
+    using namespace std;
+
+    if (site.size() != Xij.nsite || cfg.size() != nelec) {
+      cerr << "updated_tdi<T>::inv_config:"
+           << " Invalid config / invert config buffer." << endl;
+      return;
+    }
+
+    if (init)
+      for (dim_t i = 0; i < site.size(); ++i)
+        site.at(i) = -1;
+    for (dim_t i = 0; i < cfg.size(); ++i)
+      site.at(cfg.at(i)) = i;
+
+    return;
+  }
+
+  // Update osi <- os[msj].
+  // i.e. c+_i c_{x_j}.
+  void push_update(dim_t osi, dim_t msj, bool compute_pfa) {
+    using namespace std;
+
+    // This is the k-th hopping.
+    dim_t n = nelec;
+    dim_t k = from_idx.size();
+    dim_t osj = elem_cfg.at(msj);
+
+    // TODO: Check bounds, duplicates, etc.
+    from_idx.push_back(msj);
+    to_site.push_back(osi);
+
+    // TODO: Check for hopping-backs. 
+    // This can only be handled by cancellation.
+    // Singularity will emerge otherwise.
+
+    // Speed-up lookup of Xij.
+    std::vector<signed> sitecfg(Xij.nsite, -1);
+    config_to_site(elem_cfg, sitecfg, false);
+    for (dim_t i = 0; i < Xij.nsite; ++i)
+      // U(i, k) = Xij(elem_cfg.at(i), osi) - Xij(elem_cfg.at(i), osj);
+      if (sitecfg.at(i) >= 0)
+        // Direct access: special case when installed into VMC.
+        U(sitecfg.at(i), k) = Xij.X(i, osi) - Xij.X(i, osj);
+
+    skslc(uplo, n, msj, &P(0, k), &M(0, 0), M.ld);
+
+    // Updated the already logged U.
+    for (dim_t l = 0; l < k; ++l) {
+      dim_t msl = from_idx.at(l);
+      T U_jl_ = U(msj, l); ///< Backup this value before change.
+
+      // Write updates.
+      U(msl, k) = Xij(to_site.at(l), osi) - Xij(elem_cfg.at(msl), osj);
+      U(msj, l) = Xij(osi, to_site.at(l)) - Xij(osj, elem_cfg.at(msl));
+
+      // Change of Q[:, l] induced by change of U[msj, l];
+      // Utilize that P[:, k] = M[:, msj] ///< M is skew-symmetric.
+      axpy(n, U(msj, l) - U_jl_, &P(0, k), 1, &Q(0, l), 1);
+
+      // Change of UMV[l, k] induced by change of U[msj, l].
+      for (dim_t o = 0; o < k; ++o)
+        UMV(l, o) += (U(msj, l) - U_jl_) * P(msj, o);
+    }
+
+    // Update UMV and VMV. UMU is updated elsewhere.
+    switch (uplo) {
+    case BLIS_UPPER:
+      for (dim_t l = 0; l < k; ++l)
+        W(l, k) = -Xij(to_site.at(l), osi) + Xij(elem_cfg.at(from_idx.at(l)), osj);
+
+      for (dim_t l = 0; l < k; ++l) {
+        UMV(l, k) = dot(n, &U(0, l), 1, &P(0, k), 1);
+        UMV(k, l) = dot(n, &U(0, k), 1, &P(0, l), 1);
+      }
+      UMV(k, k) = dot(n, &U(0, k), 1, &P(0, k), 1);
+      for (dim_t l = 0; l < k; ++l)
+        VMV(l, k) /* -VMV(k, l) */ = -P(msj, l); ///< P(from_idx.at(l), k);
+      break;
+
+    default:
+      cerr << "updated_tdi<T>::push_update:"
+           << " Only upper-triangular storage is supported." << endl;
+    }
+
+    if (compute_pfa) {
+      // NOTE: Update k to be new size.
+      k += 1;
+      // Allocate scratchpad.
+      dim_t lwork = 2 * k * npanel_sub;
+      T *pfwork = new T[lwork];
+
+      // Calculate unupdated columns of U.
+      require_Q(false);
+
+      require_UMU();
+      // Assemble (half of) C+BMB buffer.
+      assemble_C_BMB();
+
+      // If it's the first update Pfafian can be directly read out.
+      if (k == 0) {
+        PfaRatio = -UMV(0, 0);
+        return;
+      }
+
+      // Compute pfaffian.
+      #ifdef UseBoost
+      signed info = skpfa(uplo, 2 * k, &Cp(0, 0), Cp.size1(), &Gc(0, 0), Gc.size1(), cPov,
+                          false, &PfaRatio, pfwork, lwork);
+      #else
+      signed info = skpfa(uplo, 2 * k, &Cp(0, 0), Cp.ld, &Gc(0, 0), Gc.ld, cPov,
+                          false, &PfaRatio, pfwork, lwork);
+      #endif
+#ifdef _DEBUG
+      cerr << "SKPFA: info=" << info << endl;
+#endif
+      // Pfaffian of C = [ W -I; I 0 ].
+      PfaRatio *= pow(-1.0, k * (k + 1) / 2);
+
+      delete[] pfwork;
+    } else
+      // Set to 0.0 to denote dirty.
+      PfaRatio = 0.0;
+  }
+
+  void push_update(dim_t osi, dim_t msj) { push_update(osi, msj, true); }
+
+  // Check duplicate and push.
+  void push_update_safe(dim_t osi, dim_t msj, bool compute_pfa) {
+    if (from_idx.size() >= mmax)
+      merge_updates();
+
+    // Check if already hopped out.
+    for (dim_t l = 0; l < from_idx.size(); ++l)
+      if (msj == from_idx.at(l)) {
+        merge_updates(); 
+        break;
+      }
+    push_update(osi, msj, compute_pfa);
+  }
+
+  void push_update_safe(dim_t osi, dim_t msj) {
+    push_update_safe(osi, msj, true);
+  }
+
+  void pop_update(bool compute_pfa) {
+    using namespace std;
+
+    // Pop out.
+    dim_t msj_ = from_idx.at(from_idx.size() - 1);
+    dim_t osi_ = to_site.at(to_site.size() - 1);
+    dim_t osj_ = elem_cfg.at(msj_);
+    from_idx.pop_back();
+    to_site.pop_back();
+
+    // New update size.
+    dim_t k = from_idx.size();
+
+    // Revert U[:, 1:k-1] update.
+    for (dim_t l = 0; l < k; ++l) {
+      dim_t msl = from_idx.at(l);
+      T U_jl_ = U(msj_, l);
+
+      // Revert U rows. (final column is popped out).
+      U(msj_, l) = Xij(osj_, to_site.at(l)) - Xij(osj_, elem_cfg.at(msl));
+
+      // Change of Q[:, l] induced by change of U[msj, l];
+      T U_diff_msj = U(msj_, l) - U_jl_;
+      switch (uplo) {
+      case BLIS_UPPER:
+        for (dim_t i = 0; i < msj_; ++i)
+          Q(i, l) += M(i, msj_) * U_diff_msj;
+        for (dim_t i = msj_ + 1; i < nelec; ++i)
+          Q(i, l) -= M(msj_, i) * U_diff_msj;
+        break;
+
+      default:
+        cerr << "updated_tdi<T>::pop_update:"
+             << " Only upper-triangular storage is supported." << endl;
+      }
+
+      // Change of UMV[l, k] induced by change of U[msj, l].
+      for (dim_t o = 0; o < k; ++o)
+        UMV(l, o) += (U(msj_, l) - U_jl_) * P(msj_, o);
+    }
+    // Pop out outdated Q.
+    if (nq_updated > k)
+      nq_updated = k;
+
+    // Compute new (previous, in fact) Pfaffian.
+    if (compute_pfa) {
+      // All compute_pfa requires first K-1 of Q.
+      require_Q(false);
+
+      // Recompute UMU.
+      require_UMU();
+      // Reassemble C and scratchpads.
+      assemble_C_BMB();
+      dim_t lwork = 2 * k * npanel_sub;
+      T *pfwork = new T[lwork];
+
+      #ifdef UseBoost
+      signed info = skpfa(uplo, 2 * k, &Cp(0, 0), Cp.size1(), &Gc(0, 0), Gc.size1(), cPov,
+                          false, &PfaRatio, pfwork, lwork);
+      #else
+      signed info = skpfa(uplo, 2 * k, &Cp(0, 0), Cp.ld, &Gc(0, 0), Gc.ld, cPov,
+                          false, &PfaRatio, pfwork, lwork);
+      #endif
+      PfaRatio *= pow(-1.0, k * (k + 1) / 2);
+
+      delete[] pfwork;
+    } else
+      // Set to 0.0 to denote dirty.
+      PfaRatio = 0.0;
+  }
+
+  void merge_updates() {
+    using namespace std;
+
+    dim_t n = nelec;
+    dim_t k = from_idx.size();
+    if (k == 0)
+      return;
+
+    // Allocate scratchpad.
+    dim_t lwork = 2 * k * npanel_sub;
+    T *pfwork = new T[lwork];
+    
+    // Update whole Q.
+    require_Q(true);
+
+    // If M is dirty, redo the tridiagonal factorization.
+    if (PfaRatio == T(0.0)) {
+      require_UMU();
+      assemble_C_BMB();
+      #ifdef UseBoost
+      signed info = skpfa(uplo, 2 * k, &Cp(0, 0), Cp.size1(), &Gc(0, 0), Gc.size1(), cPov,
+                          false, &PfaRatio, pfwork, lwork);
+      #else
+      signed info = skpfa(uplo, 2 * k, &Cp(0, 0), Cp.ld, &Gc(0, 0), Gc.ld, cPov,
+                          false, &PfaRatio, pfwork, lwork);
+      #endif
+      PfaRatio *= pow(-1.0, k * (k + 1) / 2);
+    }
+
+    if (k == 1) {
+      // Trivial inverse.
+      Cp(0, 1) = T(-1.0) / Cp(0, 1);
+      Cp(1, 0) = T(-1.0) / Cp(1, 0);
+    } else
+      #ifdef UseBoost
+      signed info = sktdi(uplo, 2 * k, &Cp(0, 0), Cp.size1(), &Gc(0, 0), Gc.size1(), cPov,
+                          pfwork, lwork);
+      #else
+      signed info = sktdi(uplo, 2 * k, &Cp(0, 0), Cp.ld, &Gc(0, 0), Gc.ld, cPov,
+                          pfwork, lwork);
+      #endif
+    inv_update(k, Cp);
+
+    // Apply hopping.
+    for (int j = 0; j < k; ++j)
+      elem_cfg.at(from_idx.at(j)) = to_site.at(j);
+    from_idx.clear();
+    to_site.clear();
+    nq_updated = 0;
+    Pfa *= PfaRatio;
+    PfaRatio = 1.0;
+
+    delete[] pfwork;
+  }
+
+  void inv_update(dim_t k, matrix_t<T> &C) {
+    #ifdef UseBoost
+    matrix_t<T> &ABC = U; ///< Use U as inv(A)*B*upper(C) buffer.
+    matrix_t<T> &AB = Q;
+    #else
+    matrix_t<T> ABC(&U(0, 0), U.ld); ///< Use U as inv(A)*B*upper(C) buffer.
+    matrix_t<T> AB(&Q(0, 0), Q.ld);
+    #endif
+
+    if (k == 1 && single_hop_alpha) {
+      // k == 1 requires no copying
+      #ifdef UseBoost
+      skr2k(uplo, BLIS_NO_TRANSPOSE, nelec, 1, C(0, 1), &Q(0, 0), Q.size1(),
+            &P(0, 0), P.size1(), T(1.0), &M(0, 0), M.size1());
+      #else
+      skr2k(uplo, BLIS_NO_TRANSPOSE, nelec, 1, C(0, 1), &Q(0, 0), Q.ld,
+            &P(0, 0), P.ld, T(1.0), &M(0, 0), M.ld);
+      #endif
+      // See below for reason of calling this procedule.
+      // update_uplo(uplo);
+      return;
+    }
+
+    // Close empty space between Q and P.
+    #ifndef UseBoost
+    if (k != mmax)
+    #endif
+      for (dim_t j = 0; j < k; ++j)
+        memcpy(&AB(0, k + j), &P(0, j), nelec * sizeof(T));
+
+    // Copy AB to ABC for TRMM interface.
+    for (dim_t j = 0; j < 2 * k - 1; ++j)
+      // inv(A)*U  [ 0 + + +
+      //             0 0 + +
+      //             0 0 0 +
+      //             0 0 0 0 ] => AB[:, 0:2] -> ABC[:, 1:3]
+      memcpy(&ABC(0, j + 1), &AB(0, j), nelec * sizeof(T));
+    #ifdef UseBoost
+    trmm(BLIS_RIGHT, BLIS_UPPER, BLIS_NO_TRANSPOSE, nelec, 2 * k - 1, T(1.0),
+         &C(0, 1), C.size1(), &ABC(0, 1), ABC.size1());
+    #else
+    trmm(BLIS_RIGHT, BLIS_UPPER, BLIS_NO_TRANSPOSE, nelec, 2 * k - 1, T(1.0),
+         &C(0, 1), C.ld, &ABC(0, 1), ABC.ld);
+    #endif
+
+    // Update: write to M.
+    #ifdef UseBoost
+    skr2k(uplo, BLIS_NO_TRANSPOSE, nelec, 2 * k - 1, T(1.0), &ABC(0, 1), ABC.size1(),
+          &AB(0, 1), AB.size1(), T(1.0), &M(0, 0), M.size1());
+    #else
+    skr2k(uplo, BLIS_NO_TRANSPOSE, nelec, 2 * k - 1, T(1.0), &ABC(0, 1), ABC.ld,
+          &AB(0, 1), AB.ld, T(1.0), &M(0, 0), M.ld);
+    #endif
+
+    // Identity update to complete antisymmetric matrix.
+    // This called due to lack of skmm support at the moment.
+    // update_uplo(uplo);
+  }
+
+  /**
+   * Complete antisymmetric matrix.
+   */
+  void skcomplete(uplo_t uplo_, dim_t n, matrix_t<T> &A) {
+    for (dim_t j = 0; j < n; ++j) {
+      for (dim_t i = 0; i < j; ++i) {
+        switch (uplo_) {
+        case BLIS_UPPER:
+          A(j, i) = -A(i, j);
+          break;
+
+        case BLIS_LOWER:
+          A(i, j) = -A(j, i);
+          break;
+
+        default:
+          break;
+        }
+      }
+      A(j, j) = T(0.0);
+    }
+  }
+
+  void update_uplo(uplo_t uplo_new) {
+    skcomplete(uplo /* NOTE: old uplo */, nelec, M);
+    if (from_idx.size()) {
+      skcomplete(uplo, from_idx.size(), UMU);
+      skcomplete(uplo, from_idx.size(), VMV);
+      skcomplete(uplo, from_idx.size(), W);
+    }
+
+    uplo = uplo_new;
+  }
+
+}; 


### PR DESCRIPTION
**What is done**
- Installed optimized antisymmetric matrix kit Pfaffine to mVMC. This library is based on an extended fork of [BLIS](/flame/blis), which is [xrq-phys/blis](/xrq-phys/blis).
- Blocked Pfaffian (and inverse matrix) update in all 4 variants of VMCMakeSample routines (real, complex, real-fsz and complex-fsz).
- Blocked update does *NOT* change the original Markov chain.
- Simple tests passed on Xeon(R) Gold 5118 (AVX2 mode).

**How to enable**
The optimization is not enabled by default as BLIS is not guaranteed to work on some platforms (e.g. macOS has a strange threading strategy that sometimes breaks down. Linux/MinGW should be always OK though.). To enable optimization, the current switch is to add `-D_pfaffine -D_pf_block_update` in `src/make.sys` and do a traditional `make mvmc`.

**What to be done**
- [ ] CMake compilation of this optimization.
- [ ] More tests & Vendor tests within this repository.
