### PR TITLE
Adaptive Blocking (Auto) for Exchange

### DIFF
--- a/src/mVMC/vmcmake.c
+++ b/src/mVMC/vmcmake.c
@@ -81,9 +81,22 @@ void VMCMakeSample(MPI_Comm comm) {
   // Fall back to default if input is invalid.
   if (NBlockUpdateSize < 1 || NBlockUpdateSize > 100)
     if (NExUpdatePath == 0)
+      // Simple stragegy for hopping.
       NBlockUpdateSize = 4;
-    else
-      NBlockUpdateSize = 20;
+    else {
+      const char *adaptiveBlocking = getenv("VMC_EXCHANGE_ADAPTIVE_BLOCKING");
+      const int adjustBlock = adaptiveBlocking && atoi(adaptiveBlocking) && Counter[2] != 0;
+      const double acceptance = adjustBlock ? (double)Counter[3] / Counter[2] : 1.0;
+      // Exchange updates may yield very low acc-ratio. Adjust block size accordingly.
+      if (acceptance < 0.01)
+        NBlockUpdateSize = 2;
+      else if (acceptance < 0.05)
+        NBlockUpdateSize = 4;
+      else if (acceptance < 0.10)
+        NBlockUpdateSize = 8;
+      else
+        NBlockUpdateSize = 20;
+    }
 
   // Set one universal EleSpn.
   for (mi=0; mi<Ne;  mi++) EleSpn[mi] = 0;

--- a/src/mVMC/vmcmake_fsz_real.c
+++ b/src/mVMC/vmcmake_fsz_real.c
@@ -79,11 +79,29 @@ void VMCMakeSample_fsz_real(MPI_Comm comm) {
   // TODO: Compute from qpStart to qpEnd to support loop splitting.
   void *pfOrbital[NQPFull];
   void *pfUpdator[NQPFull];
-  // TODO: Make it input parameter.
-  if (NExUpdatePath == 0)
-    NBlockUpdateSize = 4;
-  else
-    NBlockUpdateSize = 20;
+  // Read block size from input.
+  const char *optBlockSize = getenv("VMC_BLOCK_UPDATE_SIZE");
+  if (optBlockSize)
+    NBlockUpdateSize = atoi(optBlockSize);
+  // Fall back to default if input is invalid.
+  if (NBlockUpdateSize < 1 || NBlockUpdateSize > 100)
+    if (NExUpdatePath == 0)
+      // Simple stragegy for hopping.
+      NBlockUpdateSize = 2;
+    else {
+      const char *adaptiveBlocking = getenv("VMC_EXCHANGE_ADAPTIVE_BLOCKING");
+      const int adjustBlock = adaptiveBlocking && atoi(adaptiveBlocking) && Counter[2] != 0;
+      const double acceptance = adjustBlock ? (double)Counter[3] / Counter[2] : 1.0;
+      // Exchange updates may yield very low acc-ratio. Adjust block size accordingly.
+      if (acceptance < 0.01)
+        NBlockUpdateSize = 2;
+      else if (acceptance < 0.05)
+        NBlockUpdateSize = 4;
+      else if (acceptance < 0.10)
+        NBlockUpdateSize = 8;
+      else
+        NBlockUpdateSize = 20;
+    }
 
   // Initialize with free spin configuration.
   updated_tdi_v_init_d(NQPFull, Nsite, Nsite2, Nsize,

--- a/src/mVMC/vmcmake_real.c
+++ b/src/mVMC/vmcmake_real.c
@@ -83,9 +83,22 @@ void VMCMakeSample_real(MPI_Comm comm) {
   // Fall back to default if input is invalid.
   if (NBlockUpdateSize < 1 || NBlockUpdateSize > 100)
     if (NExUpdatePath == 0)
+      // Simple stragegy for hopping.
       NBlockUpdateSize = 2;
-    else
-      NBlockUpdateSize = 20;
+    else {
+      const char *adaptiveBlocking = getenv("VMC_EXCHANGE_ADAPTIVE_BLOCKING");
+      const int adjustBlock = adaptiveBlocking && atoi(adaptiveBlocking) && Counter[2] != 0;
+      const double acceptance = adjustBlock ? (double)Counter[3] / Counter[2] : 1.0;
+      // Exchange updates may yield very low acc-ratio. Adjust block size accordingly.
+      if (acceptance < 0.01)
+        NBlockUpdateSize = 2;
+      else if (acceptance < 0.05)
+        NBlockUpdateSize = 4;
+      else if (acceptance < 0.10)
+        NBlockUpdateSize = 8;
+      else
+        NBlockUpdateSize = 20;
+    }
 
   // Set one universal EleSpn.
   for (mi=0; mi<Ne;  mi++) EleSpn[mi] = 0;


### PR DESCRIPTION
We frequently encounter very-low-acceptance situations when working with spin systems.

This patch lowers block size when last step's acceptance ratio becomes low.