### PR TITLE
vmcdry's was not printing correctly the err msg

### DIFF
--- a/src/mVMC/vmcdry.c
+++ b/src/mVMC/vmcdry.c
@@ -29,7 +29,7 @@ void StdFace_main(char *fname);
 int main(int argc, char *argv[])
 {
   if (argc == 1){
-    printf("Usage: %s StdFace.def\n");
+    printf("Usage: %s StdFace.def\n", argv[0]);
     return 1;
   }
 


### PR DESCRIPTION
Currently due to this wrong formatting, calling `vmcdry.out` without parameters would cause segfault.

This fixes the problem and let the error message print correctly.