### PR TITLE
update CI script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '0 0 1,15 * *' # JST 9:00 on 1st and 15th every month
 
 jobs:
   ctest:
@@ -12,7 +15,7 @@ jobs:
         ompsize: [1, 4]
         exclude:
           - os: "macos-latest"
-            ompsize: 4
+            ompsize: 4 # OMP on macOS is too slow
       fail-fast: false
     env:
       OMP_NUM_THREADS: ${{ matrix.ompsize }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,3 +60,5 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: ctest -V
+        env:
+          OMP_NUM_THREADS: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "ubuntu-20.04", "macos-latest", "macos-13"]
+        os: ["ubuntu-22.04", "ubuntu-20.04", "macos-latest"]
       fail-fast: false
 
     steps:
@@ -44,10 +44,12 @@ jobs:
           if [ ${{ runner.os }} = "macOS" ] ; then
             # CONFIG=apple requires gfortran but macOS runner has not, but gfortran-11, 12, ...
             ln -s `which gfortran-11` gfortran
-            env PATH=`pwd`:$PATH HOMEBREW_PREFIX=/opt/homebrew cmake -DCONFIG=apple -DCMAKE_VERBOSE_MAKEFILE=ON $GITHUB_WORKSPACE
+            env PATH=`pwd`:$PATH cmake -DCONFIG=apple -DCMAKE_VERBOSE_MAKEFILE=ON $GITHUB_WORKSPACE
           else
             cmake -DCMAKE_VERBOSE_MAKEFILE=ON $GITHUB_WORKSPACE
           fi
+        env:
+          HOMEBREW_PREFIX: /opt/homebrew
 
       - name: build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,13 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-22.04", "ubuntu-20.04", "macos-latest"]
+        ompsize: [1, 4]
+        exclude:
+          - os: "macos-latest"
+            ompsize: 4
       fail-fast: false
+    env:
+      OMP_NUM_THREADS: ${{ matrix.ompsize }}
 
     steps:
       - uses: actions/checkout@v4
@@ -60,5 +66,3 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: ctest -V
-        env:
-          OMP_NUM_THREADS: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "macos-11", "ubuntu-20.04"]
+        os: ["ubuntu-22.04", "ubuntu-20.04", "macos-latest", "macos-13"]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: apt
         if: ${{ runner.os == 'Linux' }}
@@ -25,9 +25,13 @@ jobs:
         run: |
           brew install openmpi scalapack libomp
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: pip
         run: |
-          python -m pip install numpy
           python3 -m pip install numpy
 
       - name: make workspace
@@ -40,7 +44,7 @@ jobs:
           if [ ${{ runner.os }} = "macOS" ] ; then
             # CONFIG=apple requires gfortran but macOS runner has not, but gfortran-11, 12, ...
             ln -s `which gfortran-11` gfortran
-            env PATH=`pwd`:$PATH HOMEBREW_PREFIX=/usr/local cmake -DCONFIG=apple -DCMAKE_VERBOSE_MAKEFILE=ON $GITHUB_WORKSPACE
+            env PATH=`pwd`:$PATH HOMEBREW_PREFIX=/opt/homebrew cmake -DCONFIG=apple -DCMAKE_VERBOSE_MAKEFILE=ON $GITHUB_WORKSPACE
           else
             cmake -DCMAKE_VERBOSE_MAKEFILE=ON $GITHUB_WORKSPACE
           fi


### PR DESCRIPTION
- update the version of macos from 11 to latest (14)
	- macos-11 is already EOL, and so Homebrew does not serve some packages (open-mpi) in the binary format
- set `OMP_NUM_THREADS=1` for macOS
	- OpenMP on macOS is too slow (at least the default setting (16?))
- enable scheduled CI
	- 9 am (JST) on the 1st and 15th of every month