### PR TITLE
Debug uhf readdef

### DIFF
--- a/src/ComplexUHF/readdef.c
+++ b/src/ComplexUHF/readdef.c
@@ -71,7 +71,7 @@ int ReadDefFileError(
 	const char *defname
 ){
 	printf("Error: %s (Broken file or Not exist)\n", defname);
-	return 0;
+	return 1;
 }
 
 int CheckPairSite(
@@ -437,7 +437,6 @@ int ReadDefFileIdxPara(
     fp = fopen(defname, "r");
     if (fp == NULL) {
       info = ReadDefFileError(defname);
-      fclose(fp);
       continue;
     }
 
@@ -740,6 +739,7 @@ int ReadDefFileIdxPara(
         if (X->NInitial > 0) {
           idx = 0;
           while (fgets(ctmp2, sizeof(ctmp2) / sizeof(char), fp) != NULL) {
+            if (idx >= X->NInitial) break;
             dImValue = 0;
             sscanf(ctmp2, "%d %d %d %d %lf %lf\n",
                    &(X->Initial[idx][0]),


### PR DESCRIPTION
## Summary

Fix three bugs in `src/ComplexUHF/readdef.c` that cause UHF tests (`UHF_HubbardSquare`, `UHF_HubbardTriangular`) to segfault (exit code 139) on GCC 15 / macOS 26.

## Bug details

### 1. `ReadDefFileError` always returns `0` (line 74)

`ReadDefFileError` prints an error message but returns `0` (success). Since callers use `info = ReadDefFileError(defname)`, `info` is never set to a non-zero value, and errors are silently ignored.

**Fix**: `return 0` -> `return 1`

### 2. Missing bounds check in `KWInitial` loop (line 742)

When reading `initial.def`, the `fgets` loop continues reading past `NInitial` entries due to trailing empty lines in the file. This causes an out-of-bounds write to `Initial[NInitial]` (buffer overflow), which is the direct cause of the segfault.

**Fix**: Add `if (idx >= X->NInitial) break;` inside the loop.

### 3. `fclose(NULL)` undefined behavior (line 440)

In `ReadDefFileIdxPara`, when `fopen` fails (`fp == NULL`), `fclose(fp)` is called with a NULL pointer, which is undefined behavior.

**Fix**: Remove the `fclose(fp)` call.

## Note

These bugs have existed in the codebase for a long time but were latent due to undefined behavior. The buffer overflow happened to be harmless on previous compiler/OS combinations. With GCC 15 / macOS 26, changes in memory layout caused the overflow to corrupt heap metadata, resulting in a segfault at program exit.

## Test plan

- [x] All 4 UHF tests pass (`ctest -R UHF`)