### PR TITLE
spack package for mVMC

### DIFF
--- a/spack_repo/mvmc/packages/mvmc/package.py
+++ b/spack_repo/mvmc/packages/mvmc/package.py
@@ -20,7 +20,6 @@ class Mvmc(CMakePackage):
     version("1.2.0", tag="v1.2.0", submodules=True)
     version("develop", branch="master", submodules=True)
 
-    variant("mpi", default=True, description="Enable MPI support")
     variant("scalapack", default=False, description="Enable ScaLAPACK support")
     variant(
         "pfaffian_blocked",
@@ -39,7 +38,7 @@ class Mvmc(CMakePackage):
     depends_on("fortran", type="build")
 
     depends_on("cmake@3.5:", type="build")
-    depends_on("mpi", when="+mpi")
+    depends_on("mpi")
     depends_on("lapack")
     depends_on("blas")
     depends_on("scalapack", when="+scalapack")

--- a/spack_repo/mvmc/packages/mvmc/package.py
+++ b/spack_repo/mvmc/packages/mvmc/package.py
@@ -1,0 +1,56 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+from spack.package import *
+
+
+class Mvmc(CMakePackage):
+    """mVMC: many-variable Variational Monte Carlo method for quantum lattice models."""
+
+    homepage = "https://www.pasums.issp.u-tokyo.ac.jp/mvmc/en/"
+    git = "https://github.com/issp-center-dev/mVMC.git"
+
+    maintainers("issp-center-dev")
+
+    license("GPL-3.0", checked_by="freifrauvonbleifrei")
+
+    version("1.3.0", tag="v1.3.0", submodules=True)
+    version("1.2.0", tag="v1.2.0", submodules=True)
+    version("develop", branch="master", submodules=True)
+
+    variant("mpi", default=True, description="Enable MPI support")
+    variant("scalapack", default=False, description="Enable ScaLAPACK support")
+    variant(
+        "pfaffian_blocked",
+        default=False,
+        description="Use blocked Pfaffian",
+    )
+    variant(
+        "gemmt",
+        default=True,
+        description="Use GEMMT",
+    )
+    variant("shared", default=True, description="Build shared libraries")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
+    depends_on("cmake@3.5:", type="build")
+    depends_on("mpi", when="+mpi")
+    depends_on("lapack")
+    depends_on("blas")
+    depends_on("scalapack", when="+scalapack")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("USE_SCALAPACK", "scalapack"),
+            self.define_from_variant("PFAFFIAN_BLOCKED", "pfaffian_blocked"),
+            self.define_from_variant("USE_GEMMT", "gemmt"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define("GIT_SUBMODULE_UPDATE", False),
+            self.define("Testing", self.run_tests),
+        ]
+        return args

--- a/spack_repo/mvmc/packages/mvmc/package.py
+++ b/spack_repo/mvmc/packages/mvmc/package.py
@@ -18,7 +18,7 @@ class Mvmc(CMakePackage):
 
     version("1.3.0", tag="v1.3.0", submodules=True)
     version("1.2.0", tag="v1.2.0", submodules=True)
-    version("develop", branch="master", submodules=True)
+    version("develop", branch="develop", submodules=True)
 
     variant("scalapack", default=False, description="Enable ScaLAPACK support")
     variant(

--- a/spack_repo/mvmc/repo.yaml
+++ b/spack_repo/mvmc/repo.yaml
@@ -1,0 +1,3 @@
+repo:
+  namespace: mvmc
+  version: 2.2


### PR DESCRIPTION
Hi, here is a pull request for a spack package. It should help to make automatic HPC installation a bit easier
(for example in continuous benchmarking for FugakuNEXT).

this is how you can set up spack:
```cmd
git clone git@github.com:spack/spack.git

export SPACK_PATH=$(pwd)/spack && export SPACK_USER_CONFIG_PATH="${SPACK_PATH}/user_config" && export SPACK_SYSTEM_CONFIG_PATH="${SPACK_PATH}/sys_config" && export SPACK_USER_CACHE_PATH="${SPACK_PATH}/user_cache" && . ${SPACK_PATH}/share/spack/setup-env.sh
 #...load all the usually used modules ...
spack compiler find
spack external find
```

and then add this repo to tell spack about `mVMC` and try to install:
```cmd
git clone git@github.com:freifrauvonbleifrei/mVMC
cd mVMC/
spack repo add spack_repo/mvmc/
spack spec mvmc  # <- shows the dependency tree

# spack dev-build uses the working directory as source, 
# can later be replaced by `spack install mvmc`
spack dev-build mvmc@main +pfaffian_blocked  # also to test: +scalapack ~gemmt ~shared
# this last command should be executed on the compute node -> re-execute the `export...` command there
```

I hope this is the right place to put this -- if it should go somewhere else, for example the upstream [spack-packages](https://github.com/spack/spack-packages/), please let me know.

please do let me know 
- if the options look right to you
- which configuration you are currently using  (in particular, `+scalapack` didn't compile for me, it might be deprecated)
- if there's any hardware that's particularly important to get right. 
thanks!

it would be lovely if you could try it with your setup. please let me know if you run into any issues! :)