### PR TITLE
parallel ctest in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
   ctest:
     runs-on: ${{ matrix.os }}
 
+    name: "OS: ${{ matrix.os }}, mpitest: ${{ mpi }}, OMP: ${{ ompsize }}"
+
     strategy:
       matrix:
         os: ["ubuntu-latest"]
@@ -75,7 +77,12 @@ jobs:
         if: ${{ matrix.mpi == false }}
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: ctest --parallel 4 --output-on-failure -E '_mpi$'
+        run: |
+          if [ ${{ matrix.ompsize }} == 1 ]; then
+            ctest --parallel 4 --output-on-failure -E '_mpi$'
+          else
+            ctest --output-on-failure -E '_mpi$'
+          fi
 
       - name: ctest with MPI
         if: ${{ matrix.mpi == true }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,17 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest"]
+        mpi: [true, false]
         ompsize: [1, 4]
-        exclude:
+        include:
           - os: "macos-latest"
-            ompsize: 4 # OMP on macOS is too slow
+            mpi: false
+            ompsize: 1
+        exclude:
+          - os: "ubuntu-latest"
+            mpi: true
+            ompsize: 4
       fail-fast: false
 
     env:
@@ -52,6 +58,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: |
+          cmake --version
           if [ ${{ runner.os }} = "macOS" ] ; then
             # CONFIG=apple requires gfortran but macOS runner has not, but gfortran-11, 12, ...
             cmake -DCONFIG=apple -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_Fortran_COMPILER=gfortran-14 $GITHUB_WORKSPACE
@@ -64,7 +71,14 @@ jobs:
         shell: bash
         run: cmake --build ./ -j4
 
-      - name: ctest
+      - name: ctest without MPI
+        if: ${{ matrix.mpi == false }}
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: ctest -V
+        run: ctest --parallel 4 --output-on-failure -E '_mpi$'
+
+      - name: ctest with MPI
+        if: ${{ matrix.mpi == true }}
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: ctest --output-on-failure -R '_mpi$'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
   ctest:
     runs-on: ${{ matrix.os }}
 
-    name: "OS: ${{ matrix.os }}, mpitest: ${{ mpi }}, OMP: ${{ ompsize }}"
+    name: "OS: ${{ matrix.os }}, mpitest: ${{ matrix.mpi }}, OMP: ${{ matrix.ompsize }}"
 
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,4 +88,6 @@ jobs:
         if: ${{ matrix.mpi == true }}
         working-directory: ${{runner.workspace}}/build
         shell: bash
+        env:
+          OMPI_MCA_rmaps_base_oversubscribe: "1"
         run: ctest --output-on-failure -R '_mpi$'


### PR DESCRIPTION
Speed up ctest on github actions by

- Split ctest into MPI test (name ends with `_mpi`) and non-MPI test (without `_mpi`)
    - run MPI test only when `ompsize=1`
- Use `ctest --parallel 4` for non-MPI test with `ompsize=1`