### PR TITLE
Stabilize DiagCG SR-CG comparison

### DIFF
--- a/test/python/runtest_sr.py
+++ b/test/python/runtest_sr.py
@@ -8,6 +8,12 @@ import sys
 import numpy as np
 
 
+CG_MAX_ITER_OVERRIDES = {
+    # The default max_iter=nSmat is too tight for this direct-vs-CG comparison.
+    "HubbardChain_cmp_DiagCG": 128,
+}
+
+
 def read_out(filename):
     # drop the first two columns
     array = np.loadtxt(filename, dtype="float")
@@ -16,6 +22,37 @@ def read_out(filename):
     else:
         array = array[:, 2:]
     return array.astype("float")
+
+
+def update_modpara(filename, values):
+    found = set()
+    lines = []
+    with open(filename) as f:
+        for line in f:
+            words = line.split()
+            if words and words[0] in values:
+                lines.append("{:<15} {}\n".format(words[0], values[words[0]]))
+                found.add(words[0])
+            else:
+                lines.append(line)
+
+    for key, value in values.items():
+        if key not in found:
+            lines.append("{:<15} {}\n".format(key, value))
+
+    with open(filename, "w") as f:
+        f.writelines(lines)
+
+
+def run_vmc(bin_to_test, dry_bin_to_test, stdef, modpara_updates=None):
+    if not modpara_updates:
+        return subprocess.call([bin_to_test, "-s", stdef])
+
+    result = subprocess.call([dry_bin_to_test, stdef])
+    if result != 0:
+        return result
+    update_modpara("modpara.def", modpara_updates)
+    return subprocess.call([bin_to_test, "-e", "namelist.def"])
 
 
 if len(sys.argv) == 1:
@@ -31,8 +68,9 @@ os.makedirs(workdir)
 os.chdir(workdir)
 
 bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
+dry_bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmcdry.out")
 
-result = subprocess.call([bin_to_test, "-s", "%s/StdFace.def" % refdir])
+result = run_vmc(bin_to_test, dry_bin_to_test, "%s/StdFace.def" % refdir)
 if result != 0:
     sys.exit(result)
 
@@ -40,7 +78,16 @@ array_calc_sr = read_out("./output/zqp_opt.dat")[4:]
 subprocess.call(["mv", "output", "output_sr"])
 
 
-result_cg = subprocess.call([bin_to_test, "-s", "%s/StdFace_CG.def" % refdir])
+cg_modpara_updates = {}
+if sys.argv[1] in CG_MAX_ITER_OVERRIDES:
+    cg_modpara_updates["NSROptCGMaxIter"] = CG_MAX_ITER_OVERRIDES[sys.argv[1]]
+
+result_cg = run_vmc(
+    bin_to_test,
+    dry_bin_to_test,
+    "%s/StdFace_CG.def" % refdir,
+    cg_modpara_updates,
+)
 if result_cg != 0:
     sys.exit(result_cg)
 


### PR DESCRIPTION
## Summary

This PR stabilizes `HubbardChain_cmp_DiagCG` by giving the CG-diag comparison leg a small explicit SR-CG iteration margin.

The direct-SR leg remains unchanged. The CG-diag leg is now run through generated expert-mode inputs so the test can set:

```text
NSROptCGMaxIter 128
```

## Background

The default `NSROptCGMaxIter=0` means `max_iter=nSmat`. For `HubbardChain_cmp_DiagCG`, `nSmat=31`, so CG-diag was capped at 31 iterations.

In exact arithmetic, CG should converge within `nSmat` steps for an SPD system. In this regression test, however, finite-precision effects and OpenMP reduction-order differences can leave the residual just above the strict SR-CG tolerance at that boundary. Linux OMP=4 can then fail with:

```text
warning: SR-CG-diag did not converge at iter=31 (max_iter=31).
error: SR-CG fallback is disabled. Abort.
```

Previous diagnostics showed that the direct and CG paths build the same linear problem (`S` and `g` match to roundoff). The issue is the test's convergence budget, not SR matrix construction.

## Changes

- Add a small `NSROptCGMaxIter` override mechanism to `test/python/runtest_sr.py`.
- Apply `NSROptCGMaxIter=128` only to `HubbardChain_cmp_DiagCG`.
- Use `vmcdry.out` for the CG leg to generate expert inputs, patch `modpara.def`, then run `vmc.out -e namelist.def`.
- Keep other SR tests on the existing standard-mode path.

## Verification

- `python -m py_compile test/python/runtest_sr.py`
- `git diff --check`
- macOS OMP=4:
  - `ctest --test-dir build-srcg-diagcg-current --output-on-failure -R 'HubbardChain.*DiagCG'`
  - 3/3 passed
- Docker Linux amd64 OMP=4:
  - `HubbardChain_cmp_DiagCG` normal `NVMCSample=1000`: 100/100 passed on baseline
  - stress `NVMCSample=100` without override: reproduced `max_iter=31` non-convergence
  - stress `NVMCSample=100` with `NSROptCGMaxIter=128`: passed with `info=32`
  - `HubbardChain.*DiagCG`: 3/3 passed
