### PR TITLE
Pre-release fixes for v1.4 from the develop branch review

### DIFF
--- a/src/ComplexUHF/readdef.c
+++ b/src/ComplexUHF/readdef.c
@@ -939,8 +939,10 @@ int GetFileName(
 	if(fplist==NULL) return ReadDefFileError(cFileListNameFile);
 
 	while(fgets(ctmp2, 256, fplist) != NULL){
-        memset(ctmpKW, '\0', strlen(ctmpKW));
-        memset(ctmpFileName, '\0', strlen(ctmpFileName));
+        /* strlen on the uninitialized buffers was undefined behavior;
+           clearing the first byte is enough for the empty-string checks. */
+        ctmpKW[0] = '\0';
+        ctmpFileName[0] = '\0';
         sscanf(ctmp2,"%s %s\n", ctmpKW, ctmpFileName);
 		if(strncmp(ctmpKW, "#", 1)==0 || *ctmp2=='\n' || (strcmp(ctmpKW, "")&&strcmp(ctmpFileName,""))==0)
         {

--- a/src/ComplexUHF/readdef.c
+++ b/src/ComplexUHF/readdef.c
@@ -962,6 +962,8 @@ int GetFileName(
 			fclose(fplist);
 			return(-1);
 			*/
+			/* itmpKWidx is -1 here; skip to avoid writing cFileNameList[-1] */
+			continue;
         }
         else {
             /*!< Check cFileNameList to prevent from double registering the file name */

--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -995,6 +995,23 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
   }
   /* [e] For BackFlow */
 
+  /* BackFlow is experimental: VMC_BF_MainCal/CalculateGreenFuncBF do not
+     implement reweight or Twist yet, so warn instead of silently ignoring. */
+  if (NProjBF > 0 && rank == 0) {
+    if (NTwist > 0) {
+      fprintf(stderr,
+              "warning: Twist operators are not implemented in the BackFlow "
+              "measurement path (NTwist=%d, NBackFlowIdx=%d); "
+              "zvo_twist output will be all zeros.\n",
+              NTwist, NBackFlowIdx);
+    }
+    if (reweight == 1) {
+      fprintf(stderr,
+              "warning: reweight is not implemented in the BackFlow "
+              "calculation path; sample weights stay w=1 (reweight ignored).\n");
+    }
+  }
+
   NPara = NProj + NSlater + NOptTrans + NProjBF + NRBM * FlagRBM;
   NQPFix = NSPGaussLeg * NMPTrans;
   NQPFull = NQPFix * NQPOptTrans;

--- a/src/mVMC/stcopt_cg_impl.c
+++ b/src/mVMC/stcopt_cg_impl.c
@@ -776,8 +776,14 @@ void fn_Rescale4SRCG(MPI_Comm comm) {
   
   const int nPara=NPara;
   const int srOptSize=SROptSize;
+  /* The rescale reparametrizes only the Slater block: Para is laid out as
+     Proj | RBM | ProjBF | Slater | OptTrans (see SetMemory in setmemory.c).
+     RBM/ProjBF/OptTrans parameters enter lnPsi non-linearly or are not
+     divided below, so their O columns must not be scaled. */
+  const int sltStart = NProj + FlagRBM*NRBM + NProjBF;
+  const int sltEnd   = sltStart + NSlater;
   MPI_Comm_rank(comm, &rank);
-  if (NProj <= 0 || NProj >= nPara) {
+  if (NProj <= 0 || NProj >= nPara || NSlater <= 0) {
     return;
   }
   #ifdef MVMC_SRCG_REAL
@@ -829,8 +835,8 @@ void fn_Rescale4SRCG(MPI_Comm comm) {
 #endif
   }	
   
-  srOptOO_ProjMax   = get_absmax(0,            OFFSET*NProj, r);
-  srOptOO_SlaterMax = get_absmax(OFFSET*NProj, OFFSET*nPara, r);
+  srOptOO_ProjMax   = get_absmax(0,                OFFSET*NProj, r);
+  srOptOO_SlaterMax = get_absmax(OFFSET*sltStart, OFFSET*sltEnd, r);
   if(srOptOO_ProjMax < 1e-10 ) {
      ReleaseWorkSpaceDouble();
      return;
@@ -843,16 +849,16 @@ void fn_Rescale4SRCG(MPI_Comm comm) {
   
   #pragma omp parallel for default(shared) private(i)
   #pragma loop noalias
-  for(i = OFFSET*NProj; i < OFFSET*nPara; i ++ ) {
+  for(i = OFFSET*sltStart; i < OFFSET*sltEnd; i ++ ) {
      srOptOO[i+OFFSET] *= rescaleOO_SlaterRatio;
      srOptO[i+OFFSET]  *= rescaleO_SlaterRatio;
      srOptHO[i+OFFSET] *= rescaleO_SlaterRatio;
-  } 
+  }
 
   #pragma omp parallel for default(shared) private(ismp, i)
   #pragma loop noalias
   for(ismp = 0; ismp < NVMCSample; ismp ++ ) {
-    for(i = OFFSET*NProj; i < OFFSET*nPara; i ++ ) {
+    for(i = OFFSET*sltStart; i < OFFSET*sltEnd; i ++ ) {
      srOptO_Store[i+OFFSET + ismp*OFFSET*srOptSize] *= rescaleO_SlaterRatio;
     }
   }

--- a/src/mVMC/vmccal.c
+++ b/src/mVMC/vmccal.c
@@ -687,6 +687,21 @@ void calculateOO_Store_real(double *srOptOO_real, double *srOptHO_real, double *
       srOptOO_real[i] = 0.0;
       srOptOO_real[i+srOptSize] = 0.0;
     }
+    if(reweight==1){
+    for(j=0; j<sampleSize; ++j){
+      /* Store holds sqrt(w_j)*O; row 0 (O_0 = 1) gives sqrt(w_j),
+         so multiplying once more by it makes <O> w-weighted,
+         consistent with the dposv/GEMM paths. With reweight off
+         (w_j = 1) the original loop below is kept bit-identical. */
+      const double sqrtw = srOptO_Store_real[j*srOptSize];
+#pragma omp parallel for default(shared) private(i,o)
+#pragma loop noalias
+    for(i=0; i<srOptSize; ++i){
+      o = srOptO_Store_real[i+j*srOptSize];
+      srOptOO_real[i] += sqrtw*o;
+      srOptOO_real[i+srOptSize] += o*o;
+    }}
+    }else{
     for(j=0; j<sampleSize; ++j){
 #pragma omp parallel for default(shared) private(i,o)
 #pragma loop noalias
@@ -695,6 +710,7 @@ void calculateOO_Store_real(double *srOptOO_real, double *srOptHO_real, double *
       srOptOO_real[i] += o;
       srOptOO_real[i+srOptSize] += o*o;
     }}
+    }
   }
 
   return;
@@ -723,6 +739,21 @@ void calculateOO_Store(double complex *srOptOO, double complex *srOptHO, double 
       srOptOO[i] = 0.0;
       srOptOO[i+srOptSize] = 0.0;
     }
+    if(reweight==1){
+    for(j=0; j<sampleSize; ++j){
+      /* Store holds sqrt(w_j)*O; row 0 (O_0 = 1) gives sqrt(w_j),
+         so multiplying once more by it makes <O> w-weighted,
+         consistent with the dposv/GEMM paths. With reweight off
+         (w_j = 1) the original loop below is kept bit-identical. */
+      const double sqrtw = creal(srOptO_Store[j*srOptSize]);
+#pragma omp parallel for default(shared) private(i,o)
+#pragma loop noalias
+    for(i=0; i<srOptSize; ++i){
+      o = srOptO_Store[i+j*srOptSize];
+      srOptOO[i] += sqrtw*o;
+      srOptOO[i+srOptSize] += creal(o)*creal(o)+cimag(o)*cimag(o);
+    } }
+    }else{
     for(j=0; j<sampleSize; ++j){
 #pragma omp parallel for default(shared) private(i,o)
 #pragma loop noalias
@@ -731,6 +762,7 @@ void calculateOO_Store(double complex *srOptOO, double complex *srOptHO, double 
       srOptOO[i] += o;
       srOptOO[i+srOptSize] += creal(o)*creal(o)+cimag(o)*cimag(o);
     } }
+    }
   }
 
   return;

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -202,6 +202,15 @@ endforeach(model)
 add_python_vmc_test_rescale(RescaleSmat_DiagCG HubbardChain_DiagCG)
 add_python_vmc_test_rescale(RescaleSmat_GeneralRBM_smoke GeneralRBM_cmp)
 
+# reweight=1 must give consistent results between the direct (dposv) SR
+# solver and the SR-CG Store path (w-weighted <O> accumulation).
+add_test(NAME HubbardChain_DiagCG_reweight
+         COMMAND ${PYTHON_EXECUTABLE} runtest_sr.py HubbardChain_DiagCG --reweight)
+set_tests_properties(HubbardChain_DiagCG_reweight PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME HubbardChain_cmp_DiagCG_reweight
+         COMMAND ${PYTHON_EXECUTABLE} runtest_sr.py HubbardChain_cmp_DiagCG --reweight)
+set_tests_properties(HubbardChain_cmp_DiagCG_reweight PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+
 add_python_vmc_test_invalid_expert(SpinJastrow_InvalidClassRange "class index")
 add_python_vmc_test_invalid_expert(SpinJastrow_InvalidSymmetry "inconsistent class for pair")
 add_python_vmc_test_invalid_expert(SpinJastrow_NegativeNIdx "non-negative")

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -10,6 +10,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_expert_phys.py DESTINATION ${CMAKE
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_expert_mpi.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_doublon_only.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_reweight.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_rescale.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 
 function(add_python_vmc_test model)
     add_test(NAME ${model} COMMAND ${PYTHON_EXECUTABLE} runtest.py ${model})
@@ -71,6 +72,11 @@ function(add_python_vmc_test_sr model)
     add_test(NAME ${model} COMMAND ${PYTHON_EXECUTABLE} runtest_sr.py ${model})
     set_tests_properties(${model} PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
 endfunction(add_python_vmc_test_sr)
+
+function(add_python_vmc_test_rescale test_name model)
+    add_test(NAME ${test_name} COMMAND ${PYTHON_EXECUTABLE} runtest_rescale.py ${model})
+    set_tests_properties(${test_name} PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+endfunction(add_python_vmc_test_rescale)
 
 
 function(add_python_uhf_test model)
@@ -192,6 +198,9 @@ add_python_vmc_test_doublon_only_mpi(DoublonOnly_GreenFunc2_mpi DoublonOnly_Gree
 foreach(model ${python_test_vmc_model_sr})
     add_python_vmc_test_sr(${model})
 endforeach(model)
+
+add_python_vmc_test_rescale(RescaleSmat_DiagCG HubbardChain_DiagCG)
+add_python_vmc_test_rescale(RescaleSmat_GeneralRBM_smoke GeneralRBM_cmp)
 
 add_python_vmc_test_invalid_expert(SpinJastrow_InvalidClassRange "class index")
 add_python_vmc_test_invalid_expert(SpinJastrow_InvalidSymmetry "inconsistent class for pair")

--- a/test/python/runtest_rescale.py
+++ b/test/python/runtest_rescale.py
@@ -1,0 +1,118 @@
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+import sys
+
+import numpy as np
+
+
+# Expert-mode smoke models: RescaleSmat=1 together with an RBM block must
+# complete normally. Before the sltStart/sltEnd fix in fn_Rescale4SRCG the
+# RBM O-columns were rescaled without the compensating parameter division,
+# which made the optimization blow up and abort within a few SR steps.
+SMOKE_MODELS = {
+    "GeneralRBM_cmp": {
+        "NSRCG": 1,
+        "RescaleSmat": 1,
+        "NSROptCGMaxIter": 5000,
+        "NSROptItrStep": 200,
+        "NSROptItrSmp": 50,
+    },
+}
+
+
+def read_out(filename):
+    # drop the first two columns
+    array = np.loadtxt(filename, dtype="float")
+    if array.ndim == 1:
+        array = array[2:]
+    else:
+        array = array[:, 2:]
+    return array.astype("float")
+
+
+def update_modpara(filename, values):
+    found = set()
+    lines = []
+    with open(filename) as f:
+        for line in f:
+            words = line.split()
+            if words and words[0] in values:
+                lines.append("{:<15} {}\n".format(words[0], values[words[0]]))
+                found.add(words[0])
+            else:
+                lines.append(line)
+
+    for key, value in values.items():
+        if key not in found:
+            lines.append("{:<15} {}\n".format(key, value))
+
+    with open(filename, "w") as f:
+        f.writelines(lines)
+
+
+def copy_def_files(srcdir, dstdir):
+    for name in os.listdir(srcdir):
+        if name.endswith(".def"):
+            shutil.copy(os.path.join(srcdir, name), os.path.join(dstdir, name))
+
+
+if len(sys.argv) == 1:
+    print("usage: {} <model name>".format(sys.argv[0]))
+    sys.exit(-1)
+
+rootdir = os.getcwd()
+refdir = os.path.join(rootdir, "data", sys.argv[1])
+workdir = os.path.join(rootdir, "work", "Rescale_" + sys.argv[1])
+if os.path.exists(workdir):
+    shutil.rmtree(workdir)
+os.makedirs(workdir)
+os.chdir(workdir)
+
+bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
+dry_bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmcdry.out")
+
+if sys.argv[1] in SMOKE_MODELS:
+    # expert-mode smoke test: the run must finish without SR-CG abort
+    copy_def_files(refdir, ".")
+    update_modpara("modpara.def", SMOKE_MODELS[sys.argv[1]])
+    result = subprocess.call([bin_to_test, "-e", "namelist.def"])
+    if result != 0:
+        print("RescaleSmat smoke run failed with exit code {}".format(result))
+    sys.exit(result)
+
+# standard-mode equivalence test: RescaleSmat is a pure reparametrization of
+# the Slater block, so the optimized parameters must agree with the
+# RescaleSmat=0 run up to the SR-CG solver tolerance.
+result = subprocess.call([bin_to_test, "-s", "%s/StdFace_CG.def" % refdir])
+if result != 0:
+    sys.exit(result)
+
+array_calc_rs0 = read_out("./output/zqp_opt.dat")[4:]
+subprocess.call(["mv", "output", "output_rs0"])
+
+result = subprocess.call([dry_bin_to_test, "%s/StdFace_CG.def" % refdir])
+if result != 0:
+    sys.exit(result)
+update_modpara("modpara.def", {"RescaleSmat": 1})
+result = subprocess.call([bin_to_test, "-e", "namelist.def"])
+if result != 0:
+    sys.exit(result)
+
+array_calc_rs1 = read_out("./output/zqp_opt.dat")[4:]
+
+result = 0
+if array_calc_rs0.shape != array_calc_rs1.shape:
+    print("shape mismatch: rs0={} rs1={}".format(array_calc_rs0.shape, array_calc_rs1.shape))
+    sys.exit(-1)
+
+abs_diff = np.abs(array_calc_rs0 - array_calc_rs1)
+mean_abs_diff = np.mean(abs_diff)
+max_abs_diff = np.max(abs_diff)
+if mean_abs_diff >= 1e-8:
+    print("RescaleSmat mismatch: mean_abs_diff={:.3e}, max_abs_diff={:.3e}".format(mean_abs_diff, max_abs_diff))
+    result = -1
+
+sys.exit(result)

--- a/test/python/runtest_sr.py
+++ b/test/python/runtest_sr.py
@@ -56,12 +56,19 @@ def run_vmc(bin_to_test, dry_bin_to_test, stdef, modpara_updates=None):
 
 
 if len(sys.argv) == 1:
-    print("usage: {} <model name>".format(sys.argv[0]))
+    print("usage: {} <model name> [--reweight]".format(sys.argv[0]))
     sys.exit(-1)
+
+# with --reweight, run both the direct-SR and the SR-CG side with
+# reweight=1 so the w-weighted <O> accumulation of the CG Store path
+# is compared against the dposv path
+with_reweight = "--reweight" in sys.argv[2:]
+common_modpara_updates = {"reweight": 1} if with_reweight else {}
 
 rootdir = os.getcwd()
 refdir = os.path.join(rootdir, "data", sys.argv[1])
-workdir = os.path.join(rootdir, "work", sys.argv[1])
+workname = sys.argv[1] + ("_reweight" if with_reweight else "")
+workdir = os.path.join(rootdir, "work", workname)
 if os.path.exists(workdir):
     shutil.rmtree(workdir)
 os.makedirs(workdir)
@@ -70,7 +77,8 @@ os.chdir(workdir)
 bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
 dry_bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmcdry.out")
 
-result = run_vmc(bin_to_test, dry_bin_to_test, "%s/StdFace.def" % refdir)
+result = run_vmc(bin_to_test, dry_bin_to_test, "%s/StdFace.def" % refdir,
+                 dict(common_modpara_updates))
 if result != 0:
     sys.exit(result)
 
@@ -78,7 +86,7 @@ array_calc_sr = read_out("./output/zqp_opt.dat")[4:]
 subprocess.call(["mv", "output", "output_sr"])
 
 
-cg_modpara_updates = {}
+cg_modpara_updates = dict(common_modpara_updates)
 if sys.argv[1] in CG_MAX_ITER_OVERRIDES:
     cg_modpara_updates["NSROptCGMaxIter"] = CG_MAX_ITER_OVERRIDES[sys.argv[1]]
 


### PR DESCRIPTION
## Summary

Fixes for issues found in a systematic pre-release review of `develop` (124 commits since `master`) ahead of the v1.4 release, plus follow-ups from an independent review of this branch. All issues affect combinations of the new v1.4 features (reweight, RescaleSmat, SR-CG) with existing ones, and none are covered by the existing test suite.

## Fixes

### 1. `964d779` — w-weighting of ⟨O⟩ in the SR-CG Store accumulation (reweight × NSRCG)

`calculateOO_Store/_real` accumulated the ⟨O⟩ block as Σ√w·O while ⟨OO⟩ and ⟨HO⟩ are w-weighted, biasing the SR gradient and the S-matrix mean subtraction whenever `reweight=1` is combined with `NSRCG!=0`. Each sample is now multiplied by its √w_j (taken from Store row 0, where O_0 = 1), matching the dposv/GEMM paths. The corrected loop is only used when `reweight==1`; with reweight off the original loop is kept, so **default runs are bit-identical** (verified on the complex and real DiagCG models).

### 2. `4e6221a` — RescaleSmat rescaled non-Slater parameter blocks

`fn_Rescale4SRCG` rescaled the O-matrix over the whole non-projection range `[NProj, NPara)` — which also covers the RBM, backflow and OptTrans blocks — while the compensating parameter division applies to the Slater block only. With `RescaleSmat=1` plus any of those blocks, the solver returned updates in a basis the parameters were never moved to: the bundled GeneralRBM model blows up and aborts within ~30 SR steps. The max search and both rescale loops are now restricted to the actual Slater block offsets (mirroring the `SetMemory` layout `Proj | RBM | ProjBF | Slater | OptTrans`).

Two new tests: `RescaleSmat_DiagCG` (RescaleSmat=1 reproduces the RescaleSmat=0 optimum within solver tolerance; observed diff ~3e-10) and `RescaleSmat_GeneralRBM_smoke` (**fails with the old code, passes with the fix**). With no RBM/BF/OptTrans the new range coincides with the old one — verified bit-identical.

### 3. `35ff507` — warn when Twist or reweight is combined with BackFlow

The BackFlow paths implement neither reweight nor the Twist measurement (zvo_twist stays all zeros, weights stay w=1). Default builds define `_NOTBACKFLOW` and reject BF input outright, so this only affects BF-enabled builds; a rank-0 warning is emitted there instead of silently ignoring the settings.

### 4. `67716af`, `f08349a` — ComplexUHF `GetFileName` robustness

An unknown namelist keyword left the keyword index at −1 and the subsequent `strcpy` wrote to `cFileNameList[-1]` (heap corruption). v1.4 adds namelist keywords (`SpinJastrow`, `Lattice`, `Twist`, …) that UHF does not know, making this easy to hit by feeding the same expert namelist to UHF — now warned and skipped. Also removed `strlen` on uninitialized stack buffers (undefined behavior) in the same loop.

### 5. `68af8b1` — permanent regression test for fix 1

`runtest_sr.py` gains a `--reweight` flag (reweight=1 in both the dposv and the SR-CG run); registered for `HubbardChain_DiagCG` and `HubbardChain_cmp_DiagCG`. The fsz variant is left out because its margin to the 1e-8 criterion is only ~2×.

## Verification

- `ctest` 68/68 PASS (`OMP_NUM_THREADS=1`, mac gcc build): 64 existing + 2 RescaleSmat + 2 reweight-SR tests
- Bit-identity against `develop` (`7d6bc3f`) confirmed for default configurations (no reweight / no RescaleSmat / no RBM), including RescaleSmat=1 on a Proj+Slater wavefunction
- GeneralRBM + `NSRCG=1` + `RescaleSmat=1`: before — energy diverges and aborts at step 33; after — completes 1500 steps, E = −3.26 vs −3.29 for the RescaleSmat=0 reference (statistically consistent)
- `mpiexec -np 2` smoke (RescaleSmat=1 + RBM): PASS
- UHF with v1.4 keywords in namelist: warnings + normal completion, `zvo_eigen.dat` matches reference exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)