### PR TITLE
Reject stored-O SR with NSplitSize > 1

### DIFF
--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -988,6 +988,18 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
   NSRCGFallback = (NSRCGFallback != 0);
   NSRCGAbortOnFail = (NSRCGAbortOnFail != 0);
 
+  if (NSplitSize > 1 && (NStoreO != 0 || NSRCG != 0)) {
+    if (rank == 0) {
+      fprintf(stderr,
+              "error: NSplitSize > 1 cannot be combined with NStore != 0 "
+              "or NSRCG != 0 because the stored-O SR path is not supported "
+              "for inner MPI splitting (NSplitSize=%d, NStore=%d, NSRCG=%d).\n",
+              NSplitSize, NStoreO, NSRCG);
+      fprintf(stderr, "       Use NSplitSize=1, or set NStore=0 and NSRCG=0.\n");
+    }
+    MPI_Abort(comm, EXIT_FAILURE);
+  }
+
   if (useDiagScale){
     if(NSRCG == 1){
       if (rank == 0) printf("remark: use preconditioned CG (Diag Scale)\n");

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -262,6 +262,14 @@ add_python_vmc_test_invalid_expert(DoublonOnly_InvalidRBM "not compatible with R
 add_python_vmc_test_invalid_expert(TJChainL4_Ncond2_J_path4_InvalidRBM "does not support RBM")
 add_python_vmc_test_invalid_expert(TJChainL4_Ncond2_J_path5_InvalidRBM "does not support RBM")
 add_python_vmc_test_invalid_expert(TJChainL4_Ncond4_J_path4_InvalidFullFilling "requires 2*Ne < Nsite")
+add_test(NAME NSplitSize_Store_Invalid
+         COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
+                 "NSplitSize > 1 cannot be combined" NSplitSize=2)
+set_tests_properties(NSplitSize_Store_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME NSplitSize_SRCG_Invalid
+         COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
+                 "NSplitSize > 1 cannot be combined" NSplitSize=2 NStore=0 NSRCG=1)
+set_tests_properties(NSplitSize_SRCG_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
 add_python_vmc_test_nbodyg(NBodyG_Compare)
 add_python_vmc_test_nbodyg_mpi(NBodyG_Compare_mpi NBodyG_Compare)
 add_python_vmc_test_nbodyg(NBodyG_fsz_Compare)

--- a/test/python/runtest_invalid_expert.py
+++ b/test/python/runtest_invalid_expert.py
@@ -6,6 +6,23 @@ import subprocess
 import sys
 
 
+def safe_path_component(value):
+    chars = []
+    for ch in value:
+        if ch.isalnum() or ch in ("-", "_", "."):
+            chars.append(ch)
+        else:
+            chars.append("_")
+    return "".join(chars) or "case"
+
+
+def make_workdir_name(model, updates):
+    pieces = [model]
+    for key in sorted(updates):
+        pieces.append("{}_{}".format(key, updates[key]))
+    return safe_path_component("__".join(pieces))
+
+
 def update_modpara(filename, updates):
     found = set()
     lines = []
@@ -48,7 +65,11 @@ def main():
 
     rootdir = os.getcwd()
     refdir = os.path.join(rootdir, "data", model)
-    workdir = os.path.join(rootdir, "work", model)
+    workroot = os.path.join(rootdir, "work")
+    if not os.path.exists(workroot):
+        os.makedirs(workroot)
+    case_name = make_workdir_name(model, modpara_updates)
+    workdir = os.path.join(workroot, "{}_{}".format(case_name, os.getpid()))
     if os.path.exists(workdir):
         shutil.rmtree(workdir)
     os.makedirs(workdir)

--- a/test/python/runtest_invalid_expert.py
+++ b/test/python/runtest_invalid_expert.py
@@ -6,14 +6,45 @@ import subprocess
 import sys
 
 
+def update_modpara(filename, updates):
+    found = set()
+    lines = []
+    with open(filename) as f:
+        for line in f:
+            words = line.split()
+            if words and words[0] in updates:
+                lines.append("{:<15} {}\n".format(words[0], updates[words[0]]))
+                found.add(words[0])
+            else:
+                lines.append(line)
+    for key, value in updates.items():
+        if key not in found:
+            lines.append("{:<15} {}\n".format(key, value))
+    with open(filename, "w") as f:
+        f.writelines(lines)
+
+
 def main():
     if len(sys.argv) < 3:
-        print("usage: {} <model name> <expected_error_substring> [allow_success]".format(sys.argv[0]))
+        print(
+            "usage: {} <model name> <expected_error_substring> "
+            "[allow_success] [KEY=VALUE ...]".format(sys.argv[0])
+        )
         return -1
 
     model = sys.argv[1]
     expected = sys.argv[2]
-    allow_success = (len(sys.argv) >= 4 and sys.argv[3] == "allow_success")
+    allow_success = False
+    modpara_updates = {}
+    for arg in sys.argv[3:]:
+        if arg == "allow_success":
+            allow_success = True
+        elif "=" in arg:
+            key, value = arg.split("=", 1)
+            modpara_updates[key] = value
+        else:
+            print("ERROR: unknown extra argument: {}".format(arg))
+            return -1
 
     rootdir = os.getcwd()
     refdir = os.path.join(rootdir, "data", model)
@@ -27,6 +58,9 @@ def main():
     for fn in os.listdir(refdir):
         if fn.endswith(".def"):
             shutil.copy(os.path.join(refdir, fn), os.path.join(workdir, fn))
+
+    if modpara_updates:
+        update_modpara("modpara.def", modpara_updates)
 
     bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
     proc = subprocess.run(


### PR DESCRIPTION
## Summary

This PR rejects the unsupported combination:

```text
NSplitSize > 1 && (NStore != 0 || NSRCG != 0)
```

The stored-O SR path is not currently valid with inner MPI splitting, and this configuration can otherwise produce silently wrong SR updates. This PR adds an explicit input-time error instead.

## Changes

- Add a hard reject in `readdef.c` after `NSRCG=2` is normalized to `NSRCG=1`.
- Extend `runtest_invalid_expert.py` so invalid-input tests can temporarily override `modpara.def` entries with `KEY=VALUE` arguments.
- Add invalid-input tests for:
  - `NSplitSize=2, NStore=1, NSRCG=0`
  - `NSplitSize=2, NStore=0, NSRCG=1`

Users can avoid the rejected path by using `NSplitSize=1`, or by setting both `NStore=0` and `NSRCG=0`.

## Tests

```bash
python3 -m py_compile test/python/runtest_invalid_expert.py
git diff --check
cmake -S . -B build-nsplit-reject -DCONFIG=mac_gcc -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DTesting=ON
cmake --build build-nsplit-reject -j 4
env OMP_NUM_THREADS=1 ctest --test-dir build-nsplit-reject -R 'NSplitSize_(Store|SRCG)_Invalid' --output-on-failure
env OMP_NUM_THREADS=1 ctest --test-dir build-nsplit-reject -R 'Invalid|^HubbardChain_SpinJastrow$' --output-on-failure
env OMP_NUM_THREADS=1 ctest --test-dir build-nsplit-reject -R 'DiagCG' --output-on-failure
```