### PR TITLE
Allow NStore with NSplitSize for direct SR

### DIFF
--- a/doc/en/source/expert.rst
+++ b/doc/en/source/expert.rst
@@ -707,8 +707,9 @@ Keywords and parameters
 
    ``NSplitSize`` must be greater than or equal to 1. If the total number
    of MPI processes is not divisible by ``NSplitSize``, the last group is
-   smaller and load imbalance can occur. For ``NSplitSize > 1``, set
-   ``NStore=0`` and ``NSRCG=0`` because the stored :math:`O` SR path does
+   smaller and load imbalance can occur. Direct SR with ``NStore=0`` or
+   ``NStore=1`` supports ``NSplitSize > 1``. Set ``NSRCG=0`` for
+   ``NSplitSize > 1`` because the SR-CG stored :math:`O` matvec path does
    not support the inner MPI split.
 
 -  ``NStore``
@@ -721,7 +722,8 @@ Keywords and parameters
    usage from :math:`O(N_\text{p}^2)` to
    :math:`O(N_\text{p}^2) + O(N_\text{p}N_\text{MCS})`, where
    :math:`N_\text{p}` is the number of the variational parameters and
-   :math:`N_\text{MCS}` is the number of Monte Carlo sampling.
+   :math:`N_\text{MCS}` is the number of Monte Carlo sampling. For direct
+   SR (``NSRCG=0``), this option can be used with ``NSplitSize > 1``.
 
 -  ``NSRCG``
 
@@ -733,7 +735,8 @@ Keywords and parameters
    This reduces the amount of memory usage from
    :math:`O(N_\text{p}^2) + O(N_\text{p}N_\text{MCS})` to
    :math:`O(N_\text{p}) + O(N_\text{p}N_\text{MCS})` when
-   :math:`N_\text{p} > N_\text{MCS}`.
+   :math:`N_\text{p} > N_\text{MCS}`. ``NSRCG`` cannot be combined with
+   ``NSplitSize > 1``.
 
 -  ``useDiagScale``
 

--- a/doc/en/source/expert.rst
+++ b/doc/en/source/expert.rst
@@ -736,7 +736,9 @@ Keywords and parameters
    :math:`O(N_\text{p}^2) + O(N_\text{p}N_\text{MCS})` to
    :math:`O(N_\text{p}) + O(N_\text{p}N_\text{MCS})` when
    :math:`N_\text{p} > N_\text{MCS}`. ``NSRCG`` cannot be combined with
-   ``NSplitSize > 1``.
+   ``NSplitSize > 1``. This restriction is specific to the inner MPI
+   split; when ``NSplitSize=1``, SR-CG still uses the stored
+   :math:`O` path internally.
 
 -  ``useDiagScale``
 

--- a/doc/en/source/standard.rst
+++ b/doc/en/source/standard.rst
@@ -769,8 +769,9 @@ Parameters for the numerical condition
 
    ``NSplitSize`` must be greater than or equal to 1. If the total number
    of MPI processes is not divisible by ``NSplitSize``, the last group is
-   smaller and load imbalance can occur. For ``NSplitSize > 1``, set
-   ``NStore=0`` and ``NSRCG=0`` because the stored :math:`O` SR path does
+   smaller and load imbalance can occur. Direct SR with ``NStore=0`` or
+   ``NStore=1`` supports ``NSplitSize > 1``. Set ``NSRCG=0`` for
+   ``NSplitSize > 1`` because the SR-CG stored :math:`O` matvec path does
    not support the inner MPI split.
 
 -  ``NStore``
@@ -783,7 +784,8 @@ Parameters for the numerical condition
    usage from :math:`O(N_\text{p}^2)` to
    :math:`O(N_\text{p}^2) + O(N_\text{p}N_\text{MCS})`, where
    :math:`N_\text{p}` is the number of the variational parameters and
-   :math:`N_\text{MCS}` is the number of Monte Carlo sampling.
+   :math:`N_\text{MCS}` is the number of Monte Carlo sampling. For direct
+   SR (``NSRCG=0``), this option can be used with ``NSplitSize > 1``.
 
 -  ``NSRCG``
 
@@ -795,7 +797,8 @@ Parameters for the numerical condition
    This reduces the amount of memory usage from
    :math:`O(N_\text{p}^2) + O(N_\text{p}N_\text{MCS})` to
    :math:`O(N_\text{p}) + O(N_\text{p}N_\text{MCS})` when
-   :math:`N_\text{p} > N_\text{MCS}`.
+   :math:`N_\text{p} > N_\text{MCS}`. ``NSRCG`` cannot be combined with
+   ``NSplitSize > 1``.
 
 -  ``ComplexType``
 

--- a/doc/en/source/standard.rst
+++ b/doc/en/source/standard.rst
@@ -798,7 +798,9 @@ Parameters for the numerical condition
    :math:`O(N_\text{p}^2) + O(N_\text{p}N_\text{MCS})` to
    :math:`O(N_\text{p}) + O(N_\text{p}N_\text{MCS})` when
    :math:`N_\text{p} > N_\text{MCS}`. ``NSRCG`` cannot be combined with
-   ``NSplitSize > 1``.
+   ``NSplitSize > 1``. This restriction is specific to the inner MPI
+   split; when ``NSplitSize=1``, SR-CG still uses the stored
+   :math:`O` path internally.
 
 -  ``ComplexType``
 

--- a/doc/ja/source/expert.rst
+++ b/doc/ja/source/expert.rst
@@ -688,9 +688,10 @@ ModParaファイル (modpara.def)
 
    ``NSplitSize`` は1以上である必要があります。全MPIプロセス数が
    ``NSplitSize`` で割り切れない場合、最後のグループが小さくなり
-   load imbalance が起こり得ます。 ``NSplitSize > 1`` の場合、
-   stored :math:`O` を使うSR経路は内部MPI分割に対応していないため、
-   ``NStore=0`` かつ ``NSRCG=0`` を指定してください。
+   load imbalance が起こり得ます。直接SRでは ``NStore=0`` と
+   ``NStore=1`` のどちらも ``NSplitSize > 1`` に対応しています。
+   SR-CG の stored :math:`O` 行列ベクトル積は内部MPI分割に対応していないため、
+   ``NSplitSize > 1`` の場合は ``NSRCG=0`` を指定してください。
 
 -  ``NStore``
 
@@ -699,6 +700,7 @@ ModParaファイル (modpara.def)
    **説明 :**
    期待値 :math:`\langle O_k O_l \rangle` を計算するとき行列-行列積にして高速化するオプション
    (1で機能On、モンテカルロサンプリング数に応じてメモリの消費が増大します [3]_)。
+   直接SR (``NSRCG=0``) では ``NSplitSize > 1`` と併用できます。
 
 -  ``NSRCG``
 
@@ -707,7 +709,7 @@ ModParaファイル (modpara.def)
    **説明 :** SR法で連立一次方程式 :math:`Sx=g`
    を解くときに、 :math:`S`
    を陽に構築せずに解くことでメモリを削減する [4]_ オプション[NeuscammanUmrigarChan_ ](1で機能On,
-   ``NStore`` は1に固定されます)。
+   ``NStore`` は1に固定されます)。 ``NSRCG`` は ``NSplitSize > 1`` と併用できません。
 
 -  ``useDiagScale``
 

--- a/doc/ja/source/expert.rst
+++ b/doc/ja/source/expert.rst
@@ -710,6 +710,8 @@ ModParaファイル (modpara.def)
    を解くときに、 :math:`S`
    を陽に構築せずに解くことでメモリを削減する [4]_ オプション[NeuscammanUmrigarChan_ ](1で機能On,
    ``NStore`` は1に固定されます)。 ``NSRCG`` は ``NSplitSize > 1`` と併用できません。
+   この制限は内部MPI分割に固有のものです。 ``NSplitSize=1`` の場合、SR-CG は従来通り
+   stored :math:`O` 経路を内部で使用します。
 
 -  ``useDiagScale``
 

--- a/doc/ja/source/standard.rst
+++ b/doc/ja/source/standard.rst
@@ -718,6 +718,8 @@ Figs. :num:`latticepng` , :num:`honeycombpng` , :num:`kagomepng`
    を解くときに、 :math:`S`
    を陽に構築せずに解くことでメモリを削減する [2]_ オプション[NeuscammanUmrigarChan_ ](1で機能On,
    ``NStore`` は1に固定されます)。 ``NSRCG`` は ``NSplitSize > 1`` と併用できません。
+   この制限は内部MPI分割に固有のものです。 ``NSplitSize=1`` の場合、SR-CG は従来通り
+   stored :math:`O` 経路を内部で使用します。
 
 -  ``ComplexType``
 

--- a/doc/ja/source/standard.rst
+++ b/doc/ja/source/standard.rst
@@ -697,9 +697,10 @@ Figs. :num:`latticepng` , :num:`honeycombpng` , :num:`kagomepng`
 
    ``NSplitSize`` は1以上である必要があります。全MPIプロセス数が
    ``NSplitSize`` で割り切れない場合、最後のグループが小さくなり
-   load imbalance が起こり得ます。 ``NSplitSize > 1`` の場合、
-   stored :math:`O` を使うSR経路は内部MPI分割に対応していないため、
-   ``NStore=0`` かつ ``NSRCG=0`` を指定してください。
+   load imbalance が起こり得ます。直接SRでは ``NStore=0`` と
+   ``NStore=1`` のどちらも ``NSplitSize > 1`` に対応しています。
+   SR-CG の stored :math:`O` 行列ベクトル積は内部MPI分割に対応していないため、
+   ``NSplitSize > 1`` の場合は ``NSRCG=0`` を指定してください。
 
 -  ``NStore``
 
@@ -707,6 +708,7 @@ Figs. :num:`latticepng` , :num:`honeycombpng` , :num:`kagomepng`
 
    **説明 :**
    期待値 :math:`\langle O_k O_l \rangle` を計算するとき行列-行列積にして高速化するオプション(1で機能On、モンテカルロサンプリング数に応じてメモリの消費が増大します [1]_)。
+   直接SR (``NSRCG=0``) では ``NSplitSize > 1`` と併用できます。
 
 -  ``NSRCG``
 
@@ -715,7 +717,7 @@ Figs. :num:`latticepng` , :num:`honeycombpng` , :num:`kagomepng`
    **説明 :** SR法で連立一次方程式 :math:`Sx=g`
    を解くときに、 :math:`S`
    を陽に構築せずに解くことでメモリを削減する [2]_ オプション[NeuscammanUmrigarChan_ ](1で機能On,
-   ``NStore`` は1に固定されます)。
+   ``NStore`` は1に固定されます)。 ``NSRCG`` は ``NSplitSize > 1`` と併用できません。
 
 -  ``ComplexType``
 

--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -997,14 +997,14 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
     MPI_Abort(comm, EXIT_FAILURE);
   }
 
-  if (NSplitSize > 1 && (NStoreO != 0 || NSRCG != 0)) {
+  if (NSplitSize > 1 && NSRCG != 0) {
     if (rank == 0) {
       fprintf(stderr,
-              "error: NSplitSize > 1 cannot be combined with NStore != 0 "
-              "or NSRCG != 0 because the stored-O SR path is not supported "
-              "for inner MPI splitting (NSplitSize=%d, NStore=%d, NSRCG=%d).\n",
+              "error: NSplitSize > 1 cannot be combined with NSRCG != 0 "
+              "because the SR-CG stored-O matvec path is not supported for "
+              "inner MPI splitting (NSplitSize=%d, NStore=%d, NSRCG=%d).\n",
               NSplitSize, NStoreO, NSRCG);
-      fprintf(stderr, "       Use NSplitSize=1, or set NStore=0 and NSRCG=0.\n");
+      fprintf(stderr, "       Use NSplitSize=1, or set NSRCG=0.\n");
     }
     MPI_Abort(comm, EXIT_FAILURE);
   }

--- a/src/mVMC/vmccal.c
+++ b/src/mVMC/vmccal.c
@@ -92,7 +92,7 @@ static void clearStoredOSampleRange(const int sampleStart, const int sampleEnd) 
     size_t i;
     for(i=0; i<nStore; i++) SROptO_Store_real[offset+i] = 0.0;
   } else {
-    const size_t stride = (size_t)(2*SROptSize);
+    const size_t stride = 2 * (size_t)SROptSize;
     const size_t offset = (size_t)sampleStart * stride;
     const size_t nStore = (size_t)sampleSize * stride;
     size_t i;
@@ -356,7 +356,7 @@ void VMCMainCal(MPI_Comm comm) {
         }else{
           double complex *srOptO_Store_ptr = SROptO_Store;
           if(NSRCG==0) {
-            srOptO_Store_ptr += (size_t)sampleStart * (size_t)(2*SROptSize);
+            srOptO_Store_ptr += (size_t)sampleStart * (2 * (size_t)SROptSize);
           }
           StartTimer(45);
           calculateOO_Store(SROptOO,SROptHO,srOptO_Store_ptr,w,e,2*SROptSize,sampleSize);
@@ -610,7 +610,7 @@ for(i=0;i<nProj;i++) srOptO[i+1] = (double)(eleProjCnt[i]);
         }else{
           double complex *srOptO_Store_ptr = SROptO_Store;
           if(NSRCG==0) {
-            srOptO_Store_ptr += (size_t)sampleStart * (size_t)(2*SROptSize);
+            srOptO_Store_ptr += (size_t)sampleStart * (2 * (size_t)SROptSize);
           }
           StartTimer(45);
           calculateOO_Store(SROptOO,SROptHO,srOptO_Store_ptr,w,e,2*SROptSize,sampleSize);

--- a/src/mVMC/vmccal.c
+++ b/src/mVMC/vmccal.c
@@ -28,6 +28,8 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #ifndef _SRC_VMCCAL
 #define _SRC_VMCCAL
 
+#include <stddef.h>
+
 #include "vmccal.h"
 #include "matrix.h"
 #include "calham_real.h"
@@ -79,6 +81,25 @@ void calculateQCACAQDC(double complex *qcacaq, const double complex *lslq, const
                        int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt,
                        const double complex h1, const double complex ip,double complex *rbmCnt);
 
+static void clearStoredOSampleRange(const int sampleStart, const int sampleEnd) {
+  const int sampleSize = sampleEnd - sampleStart;
+
+  if(sampleSize <= 0) return;
+
+  if(AllComplexFlag == 0) {
+    const size_t offset = (size_t)sampleStart * (size_t)SROptSize;
+    const size_t nStore = (size_t)sampleSize * (size_t)SROptSize;
+    size_t i;
+    for(i=0; i<nStore; i++) SROptO_Store_real[offset+i] = 0.0;
+  } else {
+    const size_t stride = (size_t)(2*SROptSize);
+    const size_t offset = (size_t)sampleStart * stride;
+    const size_t nStore = (size_t)sampleSize * stride;
+    size_t i;
+    for(i=0; i<nStore; i++) SROptO_Store[offset+i] = 0.0 + 0.0*I;
+  }
+}
+
 void VMCMainCal(MPI_Comm comm) {
   int *eleIdx,*eleCfg,*eleNum,*eleProjCnt;
   double complex e,ip;
@@ -111,6 +132,11 @@ void VMCMainCal(MPI_Comm comm) {
   StartTimer(24);
   clearPhysQuantity();
   StopTimer(24);
+
+  if(NVMCCalMode==0 && NStoreO!=0 && NSRCG==0) {
+    clearStoredOSampleRange(sampleStart, sampleEnd);
+  }
+
   for(sample=sampleStart;sample<sampleEnd;sample++) {
 
     eleIdx = EleIdx + sample*Nsize;
@@ -318,14 +344,24 @@ void VMCMainCal(MPI_Comm comm) {
   if(NVMCCalMode==0){
     if(NSRCG!=0 || NStoreO!=0){
       sampleSize=sampleEnd-sampleStart;
-      if(AllComplexFlag==0){
-        StartTimer(45);
-        calculateOO_Store_real(SROptOO_real,SROptHO_real,SROptO_Store_real,creal(w),creal(e),SROptSize,sampleSize);
-        StopTimer(45);
-      }else{
-        StartTimer(45);
-        calculateOO_Store(SROptOO,SROptHO,SROptO_Store,w,e,2*SROptSize,sampleSize);
-        StopTimer(45);
+      if(NSRCG!=0 || sampleSize>0){
+        if(AllComplexFlag==0){
+          double *srOptO_Store_ptr = SROptO_Store_real;
+          if(NSRCG==0) {
+            srOptO_Store_ptr += (size_t)sampleStart * (size_t)SROptSize;
+          }
+          StartTimer(45);
+          calculateOO_Store_real(SROptOO_real,SROptHO_real,srOptO_Store_ptr,creal(w),creal(e),SROptSize,sampleSize);
+          StopTimer(45);
+        }else{
+          double complex *srOptO_Store_ptr = SROptO_Store;
+          if(NSRCG==0) {
+            srOptO_Store_ptr += (size_t)sampleStart * (size_t)(2*SROptSize);
+          }
+          StartTimer(45);
+          calculateOO_Store(SROptOO,SROptHO,srOptO_Store_ptr,w,e,2*SROptSize,sampleSize);
+          StopTimer(45);
+        }
       }
     }
   }
@@ -364,6 +400,10 @@ void VMC_BF_MainCal(MPI_Comm comm) {
   StartTimer(24);
   clearPhysQuantity();
   StopTimer(24);
+
+  if(NVMCCalMode==0 && NStoreO!=0 && NSRCG==0) {
+    clearStoredOSampleRange(sampleStart, sampleEnd);
+  }
 
   InvM_Moto = InvM;
   PfM_Moto = PfM;
@@ -558,14 +598,24 @@ for(i=0;i<nProj;i++) srOptO[i+1] = (double)(eleProjCnt[i]);
   if(NVMCCalMode==0){
     if(NStoreO!=0 || NSRCG!=0){
       sampleSize=sampleEnd-sampleStart;
-      if(AllComplexFlag==0){
-        StartTimer(45);
-        calculateOO_Store_real(SROptOO_real,SROptHO_real,SROptO_Store_real,creal(w),creal(e),SROptSize,sampleSize);
-        StopTimer(45);
-      }else{
-        StartTimer(45);
-        calculateOO_Store(SROptOO,SROptHO,SROptO_Store,w,e,2*SROptSize,sampleSize);
-        StopTimer(45);
+      if(NSRCG!=0 || sampleSize>0){
+        if(AllComplexFlag==0){
+          double *srOptO_Store_ptr = SROptO_Store_real;
+          if(NSRCG==0) {
+            srOptO_Store_ptr += (size_t)sampleStart * (size_t)SROptSize;
+          }
+          StartTimer(45);
+          calculateOO_Store_real(SROptOO_real,SROptHO_real,srOptO_Store_ptr,creal(w),creal(e),SROptSize,sampleSize);
+          StopTimer(45);
+        }else{
+          double complex *srOptO_Store_ptr = SROptO_Store;
+          if(NSRCG==0) {
+            srOptO_Store_ptr += (size_t)sampleStart * (size_t)(2*SROptSize);
+          }
+          StartTimer(45);
+          calculateOO_Store(SROptOO,SROptHO,srOptO_Store_ptr,w,e,2*SROptSize,sampleSize);
+          StopTimer(45);
+        }
       }
     }
   }

--- a/src/mVMC/vmccal_fsz.c
+++ b/src/mVMC/vmccal_fsz.c
@@ -27,11 +27,33 @@ along with this program. If not, see http://www.gnu.org/licenses/.
  *-------------------------------------------------------------*/
 #ifndef _SRC_VMCCAL_FSZ
 #define _SRC_VMCCAL_FSZ
+
+#include <stddef.h>
+
 #include "vmccal_fsz.h"
 #include "matrix.h"
 #include "calham_fsz_real.h"
 #include "calham_fsz.h"
 #include "calgrn_fsz.h"
+
+static void clearStoredOSampleRange_fsz(const int sampleStart, const int sampleEnd) {
+  const int sampleSize = sampleEnd - sampleStart;
+
+  if(sampleSize <= 0) return;
+
+  if(AllComplexFlag == 0) {
+    const size_t offset = (size_t)sampleStart * (size_t)SROptSize;
+    const size_t nStore = (size_t)sampleSize * (size_t)SROptSize;
+    size_t i;
+    for(i=0; i<nStore; i++) SROptO_Store_real[offset+i] = 0.0;
+  } else {
+    const size_t stride = (size_t)(2*SROptSize);
+    const size_t offset = (size_t)sampleStart * stride;
+    const size_t nStore = (size_t)sampleSize * stride;
+    size_t i;
+    for(i=0; i<nStore; i++) SROptO_Store[offset+i] = 0.0 + 0.0*I;
+  }
+}
 
 void VMCMainCal_fsz(MPI_Comm comm) {
   int *eleIdx,*eleCfg,*eleNum,*eleProjCnt,*eleSpn; //fsz
@@ -64,6 +86,11 @@ void VMCMainCal_fsz(MPI_Comm comm) {
   StartTimer(24);
   clearPhysQuantity();
   StopTimer(24);
+
+  if(NVMCCalMode==0 && NStoreO!=0 && NSRCG==0) {
+    clearStoredOSampleRange_fsz(sampleStart, sampleEnd);
+  }
+
   for(sample=sampleStart;sample<sampleEnd;sample++) {
     eleIdx = EleIdx + sample*Nsize;
     eleCfg = EleCfg + sample*Nsite2;
@@ -233,17 +260,27 @@ void VMCMainCal_fsz(MPI_Comm comm) {
   if(NVMCCalMode==0){
     if(NStoreO!=0 || NSRCG!=0){
       sampleSize=sampleEnd-sampleStart;
-      /*StartTimer(45);
-      calculateOO_Store(SROptOO,SROptHO,SROptO_Store,w,e,2*SROptSize,sampleSize);
-      StopTimer(45);*/
-      if(AllComplexFlag==0){
-        StartTimer(45);
-        calculateOO_Store_real(SROptOO_real,SROptHO_real,SROptO_Store_real,creal(w),creal(e),SROptSize,sampleSize);
-        StopTimer(45);
-      }else{
-        StartTimer(45);
+      if(NSRCG!=0 || sampleSize>0){
+        /*StartTimer(45);
         calculateOO_Store(SROptOO,SROptHO,SROptO_Store,w,e,2*SROptSize,sampleSize);
-        StopTimer(45);
+        StopTimer(45);*/
+        if(AllComplexFlag==0){
+          double *srOptO_Store_ptr = SROptO_Store_real;
+          if(NSRCG==0) {
+            srOptO_Store_ptr += (size_t)sampleStart * (size_t)SROptSize;
+          }
+          StartTimer(45);
+          calculateOO_Store_real(SROptOO_real,SROptHO_real,srOptO_Store_ptr,creal(w),creal(e),SROptSize,sampleSize);
+          StopTimer(45);
+        }else{
+          double complex *srOptO_Store_ptr = SROptO_Store;
+          if(NSRCG==0) {
+            srOptO_Store_ptr += (size_t)sampleStart * (size_t)(2*SROptSize);
+          }
+          StartTimer(45);
+          calculateOO_Store(SROptOO,SROptHO,srOptO_Store_ptr,w,e,2*SROptSize,sampleSize);
+          StopTimer(45);
+        }
       }
     }
   }

--- a/src/mVMC/vmccal_fsz.c
+++ b/src/mVMC/vmccal_fsz.c
@@ -47,7 +47,7 @@ static void clearStoredOSampleRange_fsz(const int sampleStart, const int sampleE
     size_t i;
     for(i=0; i<nStore; i++) SROptO_Store_real[offset+i] = 0.0;
   } else {
-    const size_t stride = (size_t)(2*SROptSize);
+    const size_t stride = 2 * (size_t)SROptSize;
     const size_t offset = (size_t)sampleStart * stride;
     const size_t nStore = (size_t)sampleSize * stride;
     size_t i;
@@ -275,7 +275,7 @@ void VMCMainCal_fsz(MPI_Comm comm) {
         }else{
           double complex *srOptO_Store_ptr = SROptO_Store;
           if(NSRCG==0) {
-            srOptO_Store_ptr += (size_t)sampleStart * (size_t)(2*SROptSize);
+            srOptO_Store_ptr += (size_t)sampleStart * (2 * (size_t)SROptSize);
           }
           StartTimer(45);
           calculateOO_Store(SROptOO,SROptHO,srOptO_Store_ptr,w,e,2*SROptSize,sampleSize);

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -4,6 +4,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_mpi.py DESTINATION ${CMAKE_BINARY_
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_expert.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_invalid_expert.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_sr.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nstore_nsplit.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_UHF.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/test_UHF_InterAll.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_expert_phys.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
@@ -270,10 +271,12 @@ add_test(NAME NSplitSize_Negative_Invalid
          COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
                  "NSplitSize (= -1) must be a positive integer" NSplitSize=-1 NStore=0)
 set_tests_properties(NSplitSize_Negative_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
-add_test(NAME NSplitSize_Store_Invalid
-         COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
-                 "NSplitSize > 1 cannot be combined" NSplitSize=2)
-set_tests_properties(NSplitSize_Store_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME NSplitSize_NStore_Compare
+         COMMAND ${PYTHON_EXECUTABLE} runtest_nstore_nsplit.py HubbardChain_SpinJastrow)
+set_tests_properties(NSplitSize_NStore_Compare PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;MVMC_MPI_PROCS_REF=2;MVMC_MPI_PROCS_SPLIT=4;OMP_NUM_THREADS=1")
+add_test(NAME NSplitSize_NStore_fsz_Compare
+         COMMAND ${PYTHON_EXECUTABLE} runtest_nstore_nsplit.py HubbardChain_fsz_SpinJastrow)
+set_tests_properties(NSplitSize_NStore_fsz_Compare PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;MVMC_MPI_PROCS_REF=2;MVMC_MPI_PROCS_SPLIT=4;OMP_NUM_THREADS=1")
 add_test(NAME NSplitSize_SRCG_Invalid
          COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
                  "NSplitSize > 1 cannot be combined" NSplitSize=2 NStore=0 NSRCG=1)

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -271,12 +271,12 @@ add_test(NAME NSplitSize_Negative_Invalid
          COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
                  "NSplitSize (= -1) must be a positive integer" NSplitSize=-1 NStore=0)
 set_tests_properties(NSplitSize_Negative_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
-add_test(NAME NSplitSize_NStore_Compare
+add_test(NAME NSplitSize_NStore_Compare_mpi
          COMMAND ${PYTHON_EXECUTABLE} runtest_nstore_nsplit.py HubbardChain_SpinJastrow)
-set_tests_properties(NSplitSize_NStore_Compare PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;MVMC_MPI_PROCS_REF=2;MVMC_MPI_PROCS_SPLIT=4;OMP_NUM_THREADS=1")
-add_test(NAME NSplitSize_NStore_fsz_Compare
+set_tests_properties(NSplitSize_NStore_Compare_mpi PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;MVMC_MPI_PROCS_REF=2;MVMC_MPI_PROCS_SPLIT=4;OMP_NUM_THREADS=1")
+add_test(NAME NSplitSize_NStore_fsz_Compare_mpi
          COMMAND ${PYTHON_EXECUTABLE} runtest_nstore_nsplit.py HubbardChain_fsz_SpinJastrow)
-set_tests_properties(NSplitSize_NStore_fsz_Compare PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;MVMC_MPI_PROCS_REF=2;MVMC_MPI_PROCS_SPLIT=4;OMP_NUM_THREADS=1")
+set_tests_properties(NSplitSize_NStore_fsz_Compare_mpi PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;MVMC_MPI_PROCS_REF=2;MVMC_MPI_PROCS_SPLIT=4;OMP_NUM_THREADS=1")
 add_test(NAME NSplitSize_SRCG_Invalid
          COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
                  "NSplitSize > 1 cannot be combined" NSplitSize=2 NStore=0 NSRCG=1)

--- a/test/python/runtest_nstore_nsplit.py
+++ b/test/python/runtest_nstore_nsplit.py
@@ -1,0 +1,146 @@
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+COMMON_MODPARA_UPDATES = {
+    "NSROptItrStep": 12,
+    "NSROptItrSmp": 4,
+    "NVMCWarmUp": 4,
+    "NVMCSample": 24,
+    "NSRCG": 0,
+}
+
+
+def copy_defs(src, dst):
+    for fn in os.listdir(src):
+        if fn.endswith(".def"):
+            shutil.copy(os.path.join(src, fn), os.path.join(dst, fn))
+
+
+def update_modpara(filename, updates):
+    found = set()
+    lines = []
+    with open(filename) as f:
+        for line in f:
+            words = line.split()
+            if words and words[0] in updates:
+                lines.append("{:<15} {}\n".format(words[0], updates[words[0]]))
+                found.add(words[0])
+            else:
+                lines.append(line)
+
+    for key, value in updates.items():
+        if key not in found:
+            lines.append("{:<15} {}\n".format(key, value))
+
+    with open(filename, "w") as f:
+        f.writelines(lines)
+
+
+def read_opt(path):
+    rows = []
+    with open(path) as f:
+        for line in f:
+            cols = line.split()
+            if cols:
+                rows.append([float(x) for x in cols[2:]])
+    if len(rows) > 4:
+        rows = rows[4:]
+    return rows
+
+
+def run_case(rootdir, refdir, workroot, model, name, nproc, updates):
+    workdir = os.path.join(workroot, name)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    copy_defs(refdir, workdir)
+    update_modpara(os.path.join(workdir, "modpara.def"), updates)
+
+    bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
+    cmd = ["mpirun", "-np", str(nproc), bin_to_test, "-e", "namelist.def"]
+    if os.path.exists(os.path.join(workdir, "initial.def")):
+        cmd.append("initial.def")
+
+    result = subprocess.call(cmd, cwd=workdir)
+    if result != 0:
+        raise RuntimeError("{} failed with exit code {}".format(name, result))
+
+    return read_opt(os.path.join(workdir, "output", "zqp_opt.dat"))
+
+
+def compare(label, left, right, tol):
+    left_shape = (len(left), len(left[0]) if left else 0)
+    right_shape = (len(right), len(right[0]) if right else 0)
+    if left_shape != right_shape:
+        print("{} shape mismatch: left={} right={}".format(label, left_shape, right_shape))
+        return 1
+
+    diffs = []
+    for left_row, right_row in zip(left, right):
+        diffs.extend(abs(a - b) for a, b in zip(left_row, right_row))
+    if not diffs:
+        print("{} has no comparable data".format(label))
+        return 1
+
+    mean_abs_diff = sum(diffs) / len(diffs)
+    max_abs_diff = max(diffs)
+    if mean_abs_diff >= tol:
+        print(
+            "{} mismatch: mean_abs_diff={:.3e}, max_abs_diff={:.3e}".format(
+                label, mean_abs_diff, max_abs_diff
+            )
+        )
+        return 1
+    return 0
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: {} <model name>".format(sys.argv[0]))
+        return -1
+
+    model = sys.argv[1]
+    rootdir = os.getcwd()
+    refdir = os.path.join(rootdir, "data", model)
+    workroot = os.path.join(rootdir, "work", "{}_nstore_nsplit".format(model))
+    if os.path.exists(workroot):
+        shutil.rmtree(workroot)
+    os.makedirs(workroot)
+
+    nproc_ref = int(os.environ.get("MVMC_MPI_PROCS_REF", "2"))
+    nproc_split = int(os.environ.get("MVMC_MPI_PROCS_SPLIT", "4"))
+
+    cases = {
+        "direct_ref": dict(COMMON_MODPARA_UPDATES, NSplitSize=1, NStore=0),
+        "store_ref": dict(COMMON_MODPARA_UPDATES, NSplitSize=1, NStore=1),
+        "direct_split": dict(COMMON_MODPARA_UPDATES, NSplitSize=2, NStore=0),
+        "store_split": dict(COMMON_MODPARA_UPDATES, NSplitSize=2, NStore=1),
+    }
+
+    results = {
+        "direct_ref": run_case(rootdir, refdir, workroot, model, "direct_ref", nproc_ref, cases["direct_ref"]),
+        "store_ref": run_case(rootdir, refdir, workroot, model, "store_ref", nproc_ref, cases["store_ref"]),
+        "direct_split": run_case(
+            rootdir, refdir, workroot, model, "direct_split", nproc_split, cases["direct_split"]
+        ),
+        "store_split": run_case(
+            rootdir, refdir, workroot, model, "store_split", nproc_split, cases["store_split"]
+        ),
+    }
+
+    tol = 1.0e-8
+    result = 0
+    result |= compare("direct_ref vs direct_split", results["direct_ref"], results["direct_split"], tol)
+    result |= compare("store_ref vs store_split", results["store_ref"], results["store_split"], tol)
+    result |= compare("direct_split vs store_split", results["direct_split"], results["store_split"], tol)
+    result |= compare("direct_ref vs store_ref", results["direct_ref"], results["store_ref"], tol)
+    return -1 if result else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/python/runtest_nstore_nsplit.py
+++ b/test/python/runtest_nstore_nsplit.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import math
 import os
 import shutil
 import subprocess
@@ -81,8 +82,16 @@ def compare(label, left, right, tol):
         return 1
 
     diffs = []
-    for left_row, right_row in zip(left, right):
-        diffs.extend(abs(a - b) for a, b in zip(left_row, right_row))
+    for row_idx, (left_row, right_row) in enumerate(zip(left, right)):
+        for col_idx, (a, b) in enumerate(zip(left_row, right_row)):
+            if math.isnan(a) or math.isinf(a) or math.isnan(b) or math.isinf(b):
+                print(
+                    "{} non-finite value at row {}, column {}: left={} right={}".format(
+                        label, row_idx, col_idx, a, b
+                    )
+                )
+                return 1
+            diffs.append(abs(a - b))
     if not diffs:
         print("{} has no comparable data".format(label))
         return 1


### PR DESCRIPTION
## Summary

Depends on #111.

This PR enables `NStore != 0` with `NSplitSize > 1` for the direct SR path (`NSRCG=0`).

Previously, `NSplitSize > 1` was rejected when either `NStore != 0` or `NSRCG != 0`. The direct stored-O SR path can support inner MPI splitting by using only the local sample range on each rank, so this PR relaxes the restriction for `NStore` while keeping `NSRCG` rejected with `NSplitSize > 1`.

## Changes

- Relax `NSplitSize > 1` validation to reject only `NSRCG != 0`.
- Clear only the local stored-O sample range before direct stored-O accumulation.
- Shift the stored-O pointer passed to `calculateOO_Store*()` for direct SR so each rank processes its local sample block.
- Preserve SR-CG behavior by not changing its stored-O clear or base-pointer assumptions.
- Add MPI comparison coverage for:
  - `NStore=0/1`
  - `NSplitSize=1/2`
  - normal and fsz paths
- Update English and Japanese documentation for `NSplitSize`, `NStore`, and `NSRCG`.

## Tests

- `git diff --check`
- `cmake -S mVMC -B mVMC/build-nstore-nsplit -DCONFIG=mac_gcc -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DTesting=ON -DPYTHON_EXECUTABLE=<python3-with-numpy>`
- `cmake --build mVMC/build-nstore-nsplit -j 4`
- `env OMP_NUM_THREADS=1 ctest --test-dir mVMC/build-nstore-nsplit --output-on-failure`
  - `93/93` passed
- `env OMP_NUM_THREADS=1 ctest --test-dir mVMC/build-nstore-nsplit --output-on-failure -R 'NSplitSize'`
  - `5/5` passed

## Notes

`NSRCG != 0` remains unsupported with `NSplitSize > 1` because the SR-CG stored-O matvec path still assumes the full stored sample layout.
