### PR TITLE
Fix complex BLAS return ABI for blocked Pfaffian updates

### DIFF
--- a/src/ltl2inv/CMakeLists.txt
+++ b/src/ltl2inv/CMakeLists.txt
@@ -3,9 +3,8 @@ if(${CMAKE_PROJECT_NAME} STREQUAL "Project")
   message(FATAL_ERROR "cmake should be executed not for 'src' subdirectory, but for the top directory of mVMC.")
 endif(${CMAKE_PROJECT_NAME} STREQUAL "Project")
 
-if("${ARCHITECTURE}" STREQUAL "x86_64")
-  add_definitions(-DF77_COMPLEX_RET_INTEL)
-endif()
+# F77_COMPLEX_RET_INTEL is a BLAS vendor ABI choice, not a CPU architecture
+# choice. The top-level CMakeLists.txt enables it for MKL/Intel BLAS only.
 include_directories(../common)
 
 # blalink_gemmt.c requires BLIS (bli_*gemmt); only needed when USE_GEMMT is ON.
@@ -15,4 +14,3 @@ if(USE_GEMMT)
 endif()
 add_library(ltl2inv STATIC ${SOURCES_ltl2inv})
 target_compile_definitions(ltl2inv PRIVATE -D_CC_IMPL)
-

--- a/src/pfupdates/CMakeLists.txt
+++ b/src/pfupdates/CMakeLists.txt
@@ -3,12 +3,10 @@ if(${CMAKE_PROJECT_NAME} STREQUAL "Project")
   message(FATAL_ERROR "cmake should be executed not for 'src' subdirectory, but for the top directory of mVMC.")
 endif(${CMAKE_PROJECT_NAME} STREQUAL "Project")
 
-if(${ARCHITECTURE} STREQUAL "x86_64")
-  add_definitions(-DF77_COMPLEX_RET_INTEL)
-endif()
+# F77_COMPLEX_RET_INTEL is a BLAS vendor ABI choice, not a CPU architecture
+# choice. The top-level CMakeLists.txt enables it for MKL/Intel BLAS only.
 include_directories(../common)
 include_directories(../ltl2inv)
 
 add_library(pfupdates STATIC pf_interface.cc)
 target_compile_definitions(pfupdates PRIVATE -D_CC_IMPL)
-


### PR DESCRIPTION
## Summary

- Do not define `F77_COMPLEX_RET_INTEL` based only on `x86_64` architecture in `pfupdates`/`ltl2inv`.
- Leave the Intel/MKL complex-return ABI selection to the existing top-level BLAS vendor check.
- Fix incorrect complex `zdotu_` calls with GCC/OpenBLAS when `PFAFFIAN_BLOCKED=ON`.

## Background

In a GCC/OpenBLAS build with `PFAFFIAN_BLOCKED=ON`, the blocked Pfaffian update path was compiled with `F77_COMPLEX_RET_INTEL` solely because `ARCHITECTURE` was `x86_64`.

That macro selects the Intel/MKL-style hidden-result-argument ABI for complex BLAS return values. With GCC/OpenBLAS, complex `zdotu_` returns use the normal function return ABI instead. As a result, the C++ BLAS wrapper read the dot product incorrectly, corrupted the Pfaffian ratio, and produced abnormally low hopping acceptance.

`F77_COMPLEX_RET_INTEL` is a BLAS/Fortran ABI choice, not a CPU architecture choice. The top-level `CMakeLists.txt` already enables it for MKL/Intel BLAS, so the architecture-based definitions in `pfupdates` and `ltl2inv` should not be present.

## Verification

- `git diff --check`
- Docker `linux/amd64` Ubuntu 20.04, GCC 10.5, OpenBLAS, BLIS artifact `amd64`, `PFAFFIAN_BLOCKED=ON`, `ARCHITECTURE=x86_64`
  - Hopping acceptance after this patch: `acc_hop = 0.50345 / 0.50238`
  - SRinfo after this patch: `Msize = 1002 / 1002`, `diagCut = 0 / 0`
  - Confirmed `pfupdates`/`ltl2inv` build flags no longer contain `F77_COMPLEX_RET_INTEL` under GCC/OpenBLAS

Full `ctest` was not run.