### PR TITLE
Validate SR optimization sample window

### DIFF
--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -912,6 +912,27 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
   NGutzwillerIdx = bufInt[IdxNGutz];
   NJastrowIdx = bufInt[IdxNJast];
   NSpinJastrowIdx = bufInt[IdxNSpinJast];
+  if (NVMCCalMode == 0) {
+    if (NSROptItrStep < 1) {
+      if (rank == 0) {
+        fprintf(stderr,
+                "error: NSROptItrStep (= %d) must be a positive integer "
+                "when NVMCCalMode=0.\n",
+                NSROptItrStep);
+      }
+      MPI_Abort(comm, EXIT_FAILURE);
+    }
+    if (NSROptItrSmp < 1 || NSROptItrSmp > NSROptItrStep) {
+      if (rank == 0) {
+        fprintf(stderr,
+                "error: NSROptItrSmp (= %d) must satisfy "
+                "1 <= NSROptItrSmp <= NSROptItrStep (= %d) "
+                "when NVMCCalMode=0.\n",
+                NSROptItrSmp, NSROptItrStep);
+      }
+      MPI_Abort(comm, EXIT_FAILURE);
+    }
+  }
   if (NSpinJastrowIdx < 0) {
     if (rank == 0) {
       fprintf(stderr,

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -303,6 +303,18 @@ add_test(NAME NSplitSize_SRCG_Invalid
          COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
                  "NSplitSize > 1 cannot be combined" NSplitSize=2 NStore=0 NSRCG=1)
 set_tests_properties(NSplitSize_SRCG_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME NSROptItrStep_Zero_Invalid
+         COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
+                 "NSROptItrStep (= 0) must be a positive integer" NSROptItrStep=0 NSROptItrSmp=1)
+set_tests_properties(NSROptItrStep_Zero_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME NSROptItrSmp_Zero_Invalid
+         COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
+                 "NSROptItrSmp (= 0) must satisfy" NSROptItrStep=2 NSROptItrSmp=0)
+set_tests_properties(NSROptItrSmp_Zero_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME NSROptItrSmp_TooLarge_Invalid
+         COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py HubbardChain_SpinJastrow
+                 "NSROptItrSmp (= 3) must satisfy" NSROptItrStep=2 NSROptItrSmp=3)
+set_tests_properties(NSROptItrSmp_TooLarge_Invalid PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
 add_python_vmc_test_nbodyg(NBodyG_Compare)
 add_python_vmc_test_nbodyg_mpi(NBodyG_Compare_mpi NBodyG_Compare)
 add_python_vmc_test_nbodyg(NBodyG_fsz_Compare)


### PR DESCRIPTION
## Summary

- Reject invalid SR optimization windows for `NVMCCalMode=0`.
- Require `NSROptItrStep >= 1`.
- Require `1 <= NSROptItrSmp <= NSROptItrStep`.
- Add invalid expert-input tests for zero step, zero sample count, and too-large sample count.

## Motivation

`StoreOptData()` stores data only for the final `NSROptItrSmp` optimization steps, while `OutputOptData()` averages over `NSROptItrSmp` samples.

When `NSROptItrSmp=0`, no optimization data is stored and the output path averages over zero samples, which can produce NaNs in optimized parameter output files. Also, when `NSROptItrSmp > NSROptItrStep`, only part of the expected sample window can be filled before averaging.

This patch turns these cases into explicit input errors before the VMC run starts.

## Tests

- `git diff --check origin/develop..HEAD`
- `cmake -S . -B <build-dir> -DCONFIG=mac_gcc -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DTesting=ON -DPYTHON_EXECUTABLE=<python-with-numpy>`
- `cmake --build <build-dir> -j2`
- `OMP_NUM_THREADS=1 ctest --test-dir <build-dir> -R '^(HubbardChain_SpinJastrow|NSplitSize_.*|SpinJastrow_NegativeNIdx|NSROptItr.*)$' --output-on-failure`