### PR TITLE
Classify BF-FSZ candidate Pfaffian failures

### DIFF
--- a/src/mVMC/include/matrix.h
+++ b/src/mVMC/include/matrix.h
@@ -1,12 +1,18 @@
 #ifndef _MATRIX
 #define _MATRIX
 
+#define BF_FSZ_PF_OK 0
+#define BF_FSZ_PF_LAPACK_FAILURE 1
+#define BF_FSZ_PF_NONFINITE 2
+
 int CalculateMAll_fcmp(const int *eleIdx, const int qpStart, const int qpEnd);
 int CalculateMAll_real(const int *eleIdx, const int qpStart, const int qpEnd);
 
 int CalculateMAll_BF_real(const int *eleIdx, const int qpStart, const int qpEnd);
 int CalculateMAll_BF_fcmp(const int *eleIdx, const int qpStart, const int qpEnd);
 int CalculateMAll_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd);
+int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
+    double complex *pfMOut, int *failureDetail);
 
 int CalculateMAll_fsz(const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd);
 int CalculateMAll_fsz_real(const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd);
@@ -23,6 +29,9 @@ int calculateMAll_BF_fcmp_child(const int *eleIdx, const int qpStart, const int 
 int calculateMAll_BF_fsz_child(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
     const int qpidx, double complex *bufM, int *iwork, double complex *work, int lwork,
     double *rwork, double complex *pfM, double complex *invM);
+int calculatePfM_BF_fsz_child(const int *eleIdx, const int *eleSpn, const int qpStart,
+    const int qpidx, double complex *bufM, int *iwork, double complex *work, int lwork,
+    double *rwork, double complex *pfMOut, int *failureDetail);
 
 int calculateMAll_child_fsz(const int *eleIdx,const int *elesSpn, const int qpStart, const int qpEnd, const int qpidx,
     double complex *bufM, int *iwork, double complex *work, int lwork,double *rwork);
@@ -32,4 +41,3 @@ int calculateMAll_child_fsz_real(const int *eleIdx, const int *elesSpn, const in
 
 
 #endif
-

--- a/src/mVMC/locgrn_fsz.c
+++ b/src/mVMC/locgrn_fsz.c
@@ -59,6 +59,43 @@ double complex GreenFuncN_fsz(const int n, int *rsi, int *rsj, const double comp
 double complex calculateNewPfMN_child_fsz(const int qpidx, const int n, const int *msa,
                               const int *eleIdx, const int *eleSpn,
                               double complex *buffer, double *rwork);
+
+static double complex BF_FSZ_NaNValue(void) {
+  const double nanValue = NAN;
+  return nanValue + I*nanValue;
+}
+
+static double complex CalculateBF_FSZ_CandidateIP(const char *caller, const int *eleIdx,
+    const int *eleSpn, double complex *pfMNew) {
+  int status;
+  int detail = 0;
+  double complex ipNew;
+
+  status = CalculatePfM_BF_fsz(eleIdx, eleSpn, 0, NQPFull, pfMNew, &detail);
+  if(status == BF_FSZ_PF_LAPACK_FAILURE) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian failed in M_ZSKPFA (info=%d); propagating NaN.\n",
+        caller, detail);
+    return BF_FSZ_NaNValue();
+  }
+  if(status == BF_FSZ_PF_NONFINITE) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian is non-finite (qpidx=%d); propagating NaN.\n",
+        caller, detail);
+    return BF_FSZ_NaNValue();
+  }
+  if(status != BF_FSZ_PF_OK) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian returned unknown status %d; propagating NaN.\n",
+        caller, status);
+    return BF_FSZ_NaNValue();
+  }
+
+  ipNew = CalculateIP_fcmp(pfMNew, 0, NQPFull, MPI_COMM_SELF);
+  if(!(isfinite(creal(ipNew)) && isfinite(cimag(ipNew)))) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate projected overlap is non-finite; propagating NaN.\n",
+        caller);
+    return BF_FSZ_NaNValue();
+  }
+  return ipNew;
+}
 /*
 double complex GreenFuncN(const int n, int *rsi, int *rsj, const double complex  ip,
                   int *eleIdx, const int *eleCfg, int *eleNum, const int *eleProjCnt,
@@ -408,7 +445,6 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
                   double complex *buffer) {
   double complex z;
   int mj,rsi,rsj;
-  int qpidx;
   double complex *pfMNew = buffer;
 
   (void)eleProjBFCnt;
@@ -434,12 +470,7 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
 
   MakeProjBFCnt(projBFCntNew, eleNum);
   MakeSlaterElmBF_fsz(eleNum, projBFCntNew);
-  if(CalculateMAll_BF_fsz(eleIdx,eleSpn,0,NQPFull) != 0) {
-    z = 0.0;
-  } else {
-    for(qpidx=0;qpidx<NQPFull;qpidx++) pfMNew[qpidx] = PfM[qpidx];
-    z *= CalculateIP_fcmp(pfMNew, 0, NQPFull, MPI_COMM_SELF);
-  }
+  z *= CalculateBF_FSZ_CandidateIP("GreenFunc1BF_fsz", eleIdx, eleSpn, pfMNew);
 
   eleCfg[rsj] = mj;
   eleCfg[rsi] = -1;
@@ -459,7 +490,6 @@ double complex GreenFunc2BF_fsz(const int ri, const int rj, const int rk, const 
   double complex z;
   int mj,ml;
   int rsi,rsj,rtk,rtl;
-  int qpidx;
   double complex *pfMNew = buffer;
 
   (void)eleProjBFCnt;
@@ -547,12 +577,7 @@ double complex GreenFunc2BF_fsz(const int ri, const int rj, const int rk, const 
 
   MakeProjBFCnt(projBFCntNew, eleNum);
   MakeSlaterElmBF_fsz(eleNum, projBFCntNew);
-  if(CalculateMAll_BF_fsz(eleIdx,eleSpn,0,NQPFull) != 0) {
-    z = 0.0;
-  } else {
-    for(qpidx=0;qpidx<NQPFull;qpidx++) pfMNew[qpidx] = PfM[qpidx];
-    z *= CalculateIP_fcmp(pfMNew, 0, NQPFull, MPI_COMM_SELF);
-  }
+  z *= CalculateBF_FSZ_CandidateIP("GreenFunc2BF_fsz", eleIdx, eleSpn, pfMNew);
 
   eleCfg[rtl] = ml;
   eleCfg[rtk] = -1;

--- a/src/mVMC/matrix.c
+++ b/src/mVMC/matrix.c
@@ -552,6 +552,113 @@ int CalculateMAll_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart
   return info;
 }
 
+int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
+    double complex *pfMOut, int *failureDetail) {
+  const int qpNum = qpEnd-qpStart;
+  int qpidx;
+
+  int status = BF_FSZ_PF_OK;
+  int detail = 0;
+
+  double complex *myBufM;
+  double complex *myWork;
+  int *myIWork;
+  int myStatus;
+  int myDetail;
+  double *myRWork;
+
+  RequestWorkSpaceThreadInt(Nsize);
+  RequestWorkSpaceThreadComplex(Nsize*Nsize+LapackLWork);
+  RequestWorkSpaceThreadDouble(LapackLWork);
+
+#pragma omp parallel default(shared)              \
+  private(myIWork,myWork,myRWork,myStatus,myDetail,myBufM)
+  {
+    myIWork = GetWorkSpaceThreadInt(Nsize);
+    myBufM  = GetWorkSpaceThreadComplex(Nsize*Nsize);
+    myWork  = GetWorkSpaceThreadComplex(LapackLWork);
+    myRWork = GetWorkSpaceThreadDouble(LapackLWork);
+
+#pragma omp for private(qpidx)
+    for(qpidx=0;qpidx<qpNum;qpidx++) {
+      myDetail = 0;
+      myStatus = calculatePfM_BF_fsz_child(eleIdx, eleSpn, qpStart, qpidx,
+          myBufM, myIWork, myWork, LapackLWork, myRWork, pfMOut, &myDetail);
+      if(myStatus!=BF_FSZ_PF_OK) {
+#pragma omp critical
+        {
+          if(status==BF_FSZ_PF_OK) {
+            status = myStatus;
+            detail = myDetail;
+          }
+        }
+      }
+    }
+  }
+
+  ReleaseWorkSpaceThreadInt();
+  ReleaseWorkSpaceThreadComplex();
+  ReleaseWorkSpaceThreadDouble();
+  if(failureDetail != NULL) *failureDetail = detail;
+  return status;
+}
+
+int calculatePfM_BF_fsz_child(
+       const int *eleIdx,
+       const int *eleSpn,
+       const int qpStart,
+       const int qpidx,
+       double complex *bufM,
+       int *iwork,
+       double complex *work,
+       int lwork,
+       double *rwork,
+       double complex *pfMOut,
+       int *failureDetail
+       )
+{
+#pragma procedure serial
+  int msi,msj;
+  int rsi,rsj;
+
+  char uplo='U', mthd='P';
+  int n,lda,info=0;
+  double complex pfaff;
+
+  const int nsize = Nsize;
+
+  const double complex *sltE = SlaterElmBF + (qpidx+qpStart)*Nsite2*Nsite2;
+  const double complex *sltE_i;
+
+  double complex *bufM_i;
+
+  n=lda=Nsize;
+
+#pragma loop noalias
+  for(msi=0;msi<nsize;msi++) {
+    rsi = eleIdx[msi] + eleSpn[msi]*Nsite;
+    bufM_i = bufM + msi*Nsize;
+    sltE_i = sltE + rsi*Nsite2;
+#pragma loop norecurrence
+    for(msj=0;msj<nsize;msj++) {
+      rsj = eleIdx[msj] + eleSpn[msj]*Nsite;
+      bufM_i[msj] = -sltE_i[rsj];
+    }
+  }
+
+  M_ZSKPFA(&uplo, &mthd, &n, bufM, &lda, &pfaff, iwork, work, &lwork, rwork, &info);
+  if(info!=0) {
+    if(failureDetail != NULL) *failureDetail = info;
+    return BF_FSZ_PF_LAPACK_FAILURE;
+  }
+  if(!(isfinite(creal(pfaff)) && isfinite(cimag(pfaff)))) {
+    if(failureDetail != NULL) *failureDetail = qpidx+qpStart;
+    return BF_FSZ_PF_NONFINITE;
+  }
+  pfMOut[qpidx] = pfaff;
+  return BF_FSZ_PF_OK;
+}
+
 int calculateMAll_BF_fsz_child(
        const int *eleIdx,
        const int *eleSpn,


### PR DESCRIPTION
## Summary

This PR hardens the BackFlow FSZ Green-function candidate path by separating physical zero overlaps from numerical Pfaffian failures.

The previous `GreenFunc1BF_fsz` / `GreenFunc2BF_fsz` candidate path called `CalculateMAll_BF_fsz()`, and any nonzero return value was treated as `z = 0.0`. That conflated a legitimate finite zero overlap with LAPACK/Pfaffian numerical failures.

This PR adds a Pfaffian-only helper for BF-FSZ candidate configurations and classifies failures explicitly.

## Changes

- Add BF-FSZ Pfaffian status codes:
  - `BF_FSZ_PF_OK`
  - `BF_FSZ_PF_LAPACK_FAILURE`
  - `BF_FSZ_PF_NONFINITE`
- Add `CalculatePfM_BF_fsz()` / `calculatePfM_BF_fsz_child()`
  - computes candidate Pfaffians into a caller-provided buffer
  - does not update global `PfM` / `InvM`
  - does not run `ZGETRF` / `ZGETRI` / `ZSCAL`
- Update `GreenFunc1BF_fsz()` and `GreenFunc2BF_fsz()`
  - finite Pfaffians, including exact zero, continue through the normal overlap path
  - `M_ZSKPFA` failure emits a warning and propagates `NaN`
  - non-finite Pfaffians emit a warning and propagate `NaN`
  - non-finite projected overlaps also emit a warning and propagate `NaN`

## Behavior

Physical exact-zero candidate overlaps remain zero.

Numerical failures are no longer silently converted to zero. In the Hamiltonian path, the propagated `NaN` is caught by the existing non-finite sample check. In Green-function measurement output, the `NaN` remains visible instead of being hidden as a zero contribution.

## Validation

- `git diff --check HEAD^..HEAD`
- Configure/build with `CONFIG=mac_gcc`, `Testing=ON`
- `OMP_NUM_THREADS=1 ctest --output-on-failure -R 'BackFlow_FSZ_(IdentityEnergy_Complex(_mpi)?|InvalidSpinChanging.*)$'`
  - 7/7 passed
- `OMP_NUM_THREADS=1 ctest --output-on-failure -R 'BackFlow'`
  - 49/49 passed
- `OMP_NUM_THREADS=1 ctest --output-on-failure -R 'fsz|FSZ'`
  - 24/24 passed
- Temporary local mutation check, reverted before commit:
  - forced the new Pfaffian helper to return `BF_FSZ_PF_NONFINITE`
  - confirmed the warning + `NaN` propagation path is exercised
