### PR TITLE
Split BF-FSZ Slater builder output buffer

### DIFF
--- a/src/mVMC/include/slater.h
+++ b/src/mVMC/include/slater.h
@@ -10,6 +10,7 @@ void BackFlowDiff_fcmp(complex double *srOptO, const double complex ip, int *ele
 
 void MakeSlaterElmBF_fcmp(const int *eleNum, const int *eleProjBFCnt);
 void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt);
+void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt);
 void UpdateSlaterElmBF_fcmp(const int ma, const int ra, const int rb, const int u,
                        const int *eleCfg, const int *eleNum, const int *eleProjBFCnt, int *msa, int *hopNum, double complex*sltElmTmp);
 void UpdateSlaterElmBF_real(const int ma, const int ra, const int rb, const int u,

--- a/src/mVMC/slater_fsz.c
+++ b/src/mVMC/slater_fsz.c
@@ -28,6 +28,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 
 void UpdateSlaterElm_fsz();
 void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt);
+void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt);
 void SlaterElmDiff_fsz(double complex *srOptO, const double complex ip, int *eleIdx,int *eleSpn);
 
 static inline int BFThetaCount_fsz(const int mu, const int centerSite,
@@ -252,7 +253,7 @@ void UpdateSlaterElm_fsz() {
   return;
 }
 
-void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt) {
+void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt) {
   int ri,ori,tri,sgni,rsi;
   int rj,orj,trj,sgnj,rsj;
   int si,sj;
@@ -301,7 +302,7 @@ void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt) {
     xqp       = QPTrans[mpidx];
     xqpSgn    = QPTransSgn[mpidx];
 
-    sltE      = SlaterElmBF + qpidx*Nsite2*Nsite2;
+    sltE      = sltElmBF + qpidx*Nsite2*Nsite2;
 
     for(rsi=0;rsi<Nsite2;rsi++) {
       ri = rsi % Nsite;
@@ -334,6 +335,11 @@ void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt) {
     }
   }
   free(sparseWork);
+  return;
+}
+
+void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt) {
+  MakeSlaterElmBF_fsz_to(SlaterElmBF, eleNum, eleProjBFCnt);
   return;
 }
 


### PR DESCRIPTION
## Summary

- Split `MakeSlaterElmBF_fsz` into a caller-provided output-buffer core, `MakeSlaterElmBF_fsz_to`.
- Keep the existing `MakeSlaterElmBF_fsz` API as a compatibility wrapper that writes to global `SlaterElmBF`.
- Leave all current call sites unchanged, making this a behavior-preserving refactor for the next Green-function scratch-buffer work.

## Validation

- `cmake --build <build-dir> -j2`
- `env OMP_NUM_THREADS=1 ctest --test-dir <build-dir> --output-on-failure -R 'BackFlow_FSZ'`
  - 7/7 passed
- `env OMP_NUM_THREADS=1 ctest --test-dir <build-dir> --output-on-failure -R 'BackFlow|fsz'`
  - 66/66 passed
- Re-ran nearest/dense BF-FSZ profile inputs and confirmed the main output files are bitwise identical to the PR #121 baseline:
  - `zvo_out_001.dat`
  - `zvo_var_001.dat`
  - `zvo_cisajs_001.dat`
  - `zvo_cisajscktalt_001.dat`

## Notes

This is the F1-0 preparatory step. Follow-up work can use `MakeSlaterElmBF_fsz_to` to build candidate BF-FSZ Slater matrices into scratch buffers without mutating global `SlaterElmBF`.