### PR TITLE
Scratch BF-FSZ GreenFunc1 candidate matrices

### DIFF
--- a/src/mVMC/calgrn_fsz.c
+++ b/src/mVMC/calgrn_fsz.c
@@ -212,6 +212,7 @@ void CalculateGreenFuncBF_fsz(const double w, const double complex ip, int *eleI
   int *myEleIdx, *myEleCfg, *myEleNum, *myEleSpn;
   int *myProjCntNew, *myProjBFCntNew;
   double complex *myBuffer;
+  const int bfSlaterSize = NQPFull*Nsite2*Nsite2;
 
   if(NTwist > 0 || NNBodyG > 0) {
     fprintf(stderr, "Error: CalculateGreenFuncBF_fsz does not support Twist or NBodyG yet.\n");
@@ -219,7 +220,7 @@ void CalculateGreenFuncBF_fsz(const double w, const double complex ip, int *eleI
   }
 
   RequestWorkSpaceInt(Nsize+Nsite2+Nsite2+Nsize+NProj+16*Nsite*Nrange);
-  RequestWorkSpaceComplex(NQPFull);
+  RequestWorkSpaceComplex(NQPFull + bfSlaterSize);
 
   myEleIdx = GetWorkSpaceInt(Nsize);
   myEleCfg = GetWorkSpaceInt(Nsite2);
@@ -227,7 +228,7 @@ void CalculateGreenFuncBF_fsz(const double w, const double complex ip, int *eleI
   myEleSpn = GetWorkSpaceInt(Nsize);
   myProjCntNew = GetWorkSpaceInt(NProj);
   myProjBFCntNew = GetWorkSpaceInt(16*Nsite*Nrange);
-  myBuffer = GetWorkSpaceComplex(NQPFull);
+  myBuffer = GetWorkSpaceComplex(NQPFull + bfSlaterSize);
 
   for(idx=0;idx<Nsize;idx++) myEleIdx[idx] = eleIdx[idx];
   for(idx=0;idx<Nsite2;idx++) myEleCfg[idx] = eleCfg[idx];

--- a/src/mVMC/calham_fsz.c
+++ b/src/mVMC/calham_fsz.c
@@ -246,6 +246,7 @@ double complex CalculateHamiltonianBF_fsz(const double complex ip, int *eleIdx, 
   int *myEleIdx, *myEleCfg, *myEleNum, *myEleSpn;
   int *myProjCntNew, *myProjBFCntNew;
   double complex *myBuffer;
+  const int bfSlaterSize = NQPFull*Nsite2*Nsite2;
 
   if(NPairHopping > 0 || NExchangeCoupling > 0 || NInterAll > 0 || NNBodyInterAll > 0) {
     fprintf(stderr, "Error: CalculateHamiltonianBF_fsz supports only density and one-body transfer terms.\n");
@@ -253,7 +254,7 @@ double complex CalculateHamiltonianBF_fsz(const double complex ip, int *eleIdx, 
   }
 
   RequestWorkSpaceInt(Nsize+Nsite2+Nsite2+Nsize+NProj+16*Nsite*Nrange);
-  RequestWorkSpaceComplex(NQPFull);
+  RequestWorkSpaceComplex(NQPFull + bfSlaterSize);
 
   myEleIdx = GetWorkSpaceInt(Nsize);
   myEleCfg = GetWorkSpaceInt(Nsite2);
@@ -261,7 +262,7 @@ double complex CalculateHamiltonianBF_fsz(const double complex ip, int *eleIdx, 
   myEleSpn = GetWorkSpaceInt(Nsize);
   myProjCntNew = GetWorkSpaceInt(NProj);
   myProjBFCntNew = GetWorkSpaceInt(16*Nsite*Nrange);
-  myBuffer = GetWorkSpaceComplex(NQPFull);
+  myBuffer = GetWorkSpaceComplex(NQPFull + bfSlaterSize);
 
   for(idx=0;idx<Nsize;idx++) myEleIdx[idx] = eleIdx[idx];
   for(idx=0;idx<Nsite2;idx++) myEleCfg[idx] = eleCfg[idx];

--- a/src/mVMC/include/matrix.h
+++ b/src/mVMC/include/matrix.h
@@ -13,6 +13,9 @@ int CalculateMAll_BF_fcmp(const int *eleIdx, const int qpStart, const int qpEnd)
 int CalculateMAll_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd);
 int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
     double complex *pfMOut, int *failureDetail);
+int CalculatePfM_BF_fsz_from(const double complex *sltElmBF, const int *eleIdx,
+    const int *eleSpn, const int qpStart, const int qpEnd,
+    double complex *pfMOut, int *failureDetail);
 
 int CalculateMAll_fsz(const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd);
 int CalculateMAll_fsz_real(const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd);
@@ -29,9 +32,10 @@ int calculateMAll_BF_fcmp_child(const int *eleIdx, const int qpStart, const int 
 int calculateMAll_BF_fsz_child(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
     const int qpidx, double complex *bufM, int *iwork, double complex *work, int lwork,
     double *rwork, double complex *pfM, double complex *invM);
-int calculatePfM_BF_fsz_child(const int *eleIdx, const int *eleSpn, const int qpStart,
-    const int qpidx, double complex *bufM, int *iwork, double complex *work, int lwork,
-    double *rwork, double complex *pfMOut, int *failureDetail);
+int calculatePfM_BF_fsz_child_from(const double complex *sltElmBF, const int *eleIdx,
+    const int *eleSpn, const int qpStart, const int qpidx, double complex *bufM,
+    int *iwork, double complex *work, int lwork, double *rwork,
+    double complex *pfMOut, int *failureDetail);
 
 int calculateMAll_child_fsz(const int *eleIdx,const int *elesSpn, const int qpStart, const int qpEnd, const int qpidx,
     double complex *bufM, int *iwork, double complex *work, int lwork,double *rwork);

--- a/src/mVMC/locgrn_fsz.c
+++ b/src/mVMC/locgrn_fsz.c
@@ -65,13 +65,15 @@ static double complex BF_FSZ_NaNValue(void) {
   return nanValue + I*nanValue;
 }
 
-static double complex CalculateBF_FSZ_CandidateIP(const char *caller, const int *eleIdx,
-    const int *eleSpn, double complex *pfMNew) {
+static double complex CalculateBF_FSZ_CandidateIP(const char *caller,
+    const double complex *sltElmBF, const int *eleIdx, const int *eleSpn,
+    double complex *pfMNew) {
   int status;
   int detail = 0;
   double complex ipNew;
 
-  status = CalculatePfM_BF_fsz(eleIdx, eleSpn, 0, NQPFull, pfMNew, &detail);
+  status = CalculatePfM_BF_fsz_from(sltElmBF, eleIdx, eleSpn, 0, NQPFull,
+      pfMNew, &detail);
   if(status == BF_FSZ_PF_LAPACK_FAILURE) {
     fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian failed in M_ZSKPFA (info=%d); propagating NaN.\n",
         caller, detail);
@@ -445,7 +447,9 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
                   double complex *buffer) {
   double complex z;
   int mj,rsi,rsj;
+  /* buffer: NQPFull Pfaffians followed by a candidate BF-FSZ Slater matrix. */
   double complex *pfMNew = buffer;
+  double complex *sltElmBFNew = buffer + NQPFull;
 
   (void)eleProjBFCnt;
 
@@ -469,8 +473,9 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
   z = ProjRatio(projCntNew,eleProjCnt);
 
   MakeProjBFCnt(projBFCntNew, eleNum);
-  MakeSlaterElmBF_fsz(eleNum, projBFCntNew);
-  z *= CalculateBF_FSZ_CandidateIP("GreenFunc1BF_fsz", eleIdx, eleSpn, pfMNew);
+  MakeSlaterElmBF_fsz_to(sltElmBFNew, eleNum, projBFCntNew);
+  z *= CalculateBF_FSZ_CandidateIP("GreenFunc1BF_fsz", sltElmBFNew, eleIdx,
+      eleSpn, pfMNew);
 
   eleCfg[rsj] = mj;
   eleCfg[rsi] = -1;
@@ -577,7 +582,8 @@ double complex GreenFunc2BF_fsz(const int ri, const int rj, const int rk, const 
 
   MakeProjBFCnt(projBFCntNew, eleNum);
   MakeSlaterElmBF_fsz(eleNum, projBFCntNew);
-  z *= CalculateBF_FSZ_CandidateIP("GreenFunc2BF_fsz", eleIdx, eleSpn, pfMNew);
+  z *= CalculateBF_FSZ_CandidateIP("GreenFunc2BF_fsz", SlaterElmBF, eleIdx,
+      eleSpn, pfMNew);
 
   eleCfg[rtl] = ml;
   eleCfg[rtk] = -1;

--- a/src/mVMC/matrix.c
+++ b/src/mVMC/matrix.c
@@ -554,6 +554,13 @@ int CalculateMAll_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart
 
 int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
     double complex *pfMOut, int *failureDetail) {
+  return CalculatePfM_BF_fsz_from(SlaterElmBF, eleIdx, eleSpn, qpStart, qpEnd,
+      pfMOut, failureDetail);
+}
+
+int CalculatePfM_BF_fsz_from(const double complex *sltElmBF, const int *eleIdx,
+    const int *eleSpn, const int qpStart, const int qpEnd,
+    double complex *pfMOut, int *failureDetail) {
   const int qpNum = qpEnd-qpStart;
   int qpidx;
 
@@ -582,8 +589,9 @@ int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart,
 #pragma omp for private(qpidx)
     for(qpidx=0;qpidx<qpNum;qpidx++) {
       myDetail = 0;
-      myStatus = calculatePfM_BF_fsz_child(eleIdx, eleSpn, qpStart, qpidx,
-          myBufM, myIWork, myWork, LapackLWork, myRWork, pfMOut, &myDetail);
+      myStatus = calculatePfM_BF_fsz_child_from(sltElmBF, eleIdx, eleSpn,
+          qpStart, qpidx, myBufM, myIWork, myWork, LapackLWork, myRWork,
+          pfMOut, &myDetail);
       if(myStatus!=BF_FSZ_PF_OK) {
 #pragma omp critical
         {
@@ -603,7 +611,8 @@ int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart,
   return status;
 }
 
-int calculatePfM_BF_fsz_child(
+int calculatePfM_BF_fsz_child_from(
+       const double complex *sltElmBF,
        const int *eleIdx,
        const int *eleSpn,
        const int qpStart,
@@ -627,7 +636,7 @@ int calculatePfM_BF_fsz_child(
 
   const int nsize = Nsize;
 
-  const double complex *sltE = SlaterElmBF + (qpidx+qpStart)*Nsite2*Nsite2;
+  const double complex *sltE = sltElmBF + (qpidx+qpStart)*Nsite2*Nsite2;
   const double complex *sltE_i;
 
   double complex *bufM_i;


### PR DESCRIPTION
## Summary

This PR makes `GreenFunc1BF_fsz` evaluate candidate BF-FSZ Slater matrices from a caller-provided scratch buffer instead of rebuilding them through the global `SlaterElmBF`.

Changes:
- add `CalculatePfM_BF_fsz_from()` for evaluating Pfaffians from an explicit BF Slater matrix buffer
- make `GreenFunc1BF_fsz` build candidate matrices with `MakeSlaterElmBF_fsz_to()`
- reserve and claim the full complex workspace region needed for both candidate Pfaffians and candidate BF Slater matrices
- keep the existing `CalculatePfM_BF_fsz()` wrapper for current global-buffer callers

This is a preparatory cleanup for parallelizing / batching Green function measurements: `GreenFunc1BF_fsz` no longer clobbers the global BF-FSZ Slater matrix while testing one-body candidates.

## Scope notes

`GreenFunc2BF_fsz` still uses the global `SlaterElmBF` path. That is intentionally left for a follow-up change, since this PR only covers the one-body Green function path.

## Validation

- `git diff --check`
- `cmake --build <mVMC-build> -j 8`
- `env OMP_NUM_THREADS=1 ctest --test-dir <mVMC-build> -R 'BackFlow_FSZ|BackFlow_Identity_TwoBodyG|BackFlow_Identity_TwoBodyGEx|BackFlow_NonIdentity_TwoBodyG' --output-on-failure`
  - 16/16 passed
- `env OMP_NUM_THREADS=1 ctest --test-dir <mVMC-build> -R 'BackFlow|fsz' --output-on-failure`
  - 57/57 passed
