### PR TITLE
Parallelize BF-FSZ GreenFunc1 measurement

### DIFF
--- a/src/mVMC/calgrn_fsz.c
+++ b/src/mVMC/calgrn_fsz.c
@@ -34,6 +34,13 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
                   int *projCntNew, const int *eleProjBFCnt, int *projBFCntNew,
                   double complex *buffer);
 
+double complex GreenFunc1BF_fsz_workspace(const int ri, const int rj, const int s,
+                  const double complex ip, int *eleIdx, int *eleCfg, int *eleNum,
+                  const int *eleProjCnt, int *eleSpn, int *projCntNew,
+                  const int *eleProjBFCnt, int *projBFCntNew,
+                  double complex *buffer, double complex *pfBufM, int *pfIWork,
+                  double complex *pfWork, double *pfRWork);
+
 double complex GreenFunc2BF_fsz(const int ri, const int rj, const int rk, const int rl,
                   const int s, const int t, const double complex ip,
                   int *eleIdx, int *eleCfg, int *eleNum, const int *eleProjCnt,int *eleSpn,
@@ -213,6 +220,14 @@ void CalculateGreenFuncBF_fsz(const double w, const double complex ip, int *eleI
   int *myProjCntNew, *myProjBFCntNew;
   double complex *myBuffer;
   const int bfSlaterSize = NQPFull*Nsite2*Nsite2;
+  const int bfGreen1BufferSize = NQPFull + bfSlaterSize;
+  const int bfGreen1ComplexSize = bfGreen1BufferSize + Nsize*Nsize + LapackLWork;
+  const int bfGreen1IntSize = Nsize + Nsite2 + Nsite2 + Nsize
+      + NProj + 16*Nsite*Nrange + Nsize;
+  int *thEleIdx, *thEleCfg, *thEleNum, *thEleSpn;
+  int *thProjCntNew, *thProjBFCntNew, *thPfIWork;
+  double complex *thBuffer, *thPfBufM, *thPfWork;
+  double *thPfRWork;
 
   if(NTwist > 0 || NNBodyG > 0) {
     fprintf(stderr, "Error: CalculateGreenFuncBF_fsz does not support Twist or NBodyG yet.\n");
@@ -221,6 +236,9 @@ void CalculateGreenFuncBF_fsz(const double w, const double complex ip, int *eleI
 
   RequestWorkSpaceInt(Nsize+Nsite2+Nsite2+Nsize+NProj+16*Nsite*Nrange);
   RequestWorkSpaceComplex(NQPFull + bfSlaterSize);
+  RequestWorkSpaceThreadInt(bfGreen1IntSize);
+  RequestWorkSpaceThreadComplex(bfGreen1ComplexSize);
+  RequestWorkSpaceThreadDouble(LapackLWork);
 
   myEleIdx = GetWorkSpaceInt(Nsize);
   myEleCfg = GetWorkSpaceInt(Nsite2);
@@ -235,21 +253,61 @@ void CalculateGreenFuncBF_fsz(const double w, const double complex ip, int *eleI
   for(idx=0;idx<Nsite2;idx++) myEleNum[idx] = eleNum[idx];
   for(idx=0;idx<Nsize;idx++) myEleSpn[idx] = eleSpn[idx];
 
-  StartTimer(50);
-  for(idx=0;idx<NCisAjs;idx++) {
-    ri = CisAjsIdx[idx][0];
-    s  = CisAjsIdx[idx][1];
-    rj = CisAjsIdx[idx][2];
-    t  = CisAjsIdx[idx][3];
-    if(s != t) {
-      fprintf(stderr, "Error: BackFlow FSZ does not support spin-changing OneBodyG yet.\n");
-      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  #pragma omp parallel default(shared)                                      \
+    private(thEleIdx,thEleCfg,thEleNum,thEleSpn,thProjCntNew,thProjBFCntNew, \
+            thPfIWork,thBuffer,thPfBufM,thPfWork,thPfRWork,idx,ri,rj,s,t,tmp)
+  {
+    thEleIdx = GetWorkSpaceThreadInt(Nsize);
+    thEleCfg = GetWorkSpaceThreadInt(Nsite2);
+    thEleNum = GetWorkSpaceThreadInt(Nsite2);
+    thEleSpn = GetWorkSpaceThreadInt(Nsize);
+    thProjCntNew = GetWorkSpaceThreadInt(NProj);
+    thProjBFCntNew = GetWorkSpaceThreadInt(16*Nsite*Nrange);
+    thPfIWork = GetWorkSpaceThreadInt(Nsize);
+    thBuffer = GetWorkSpaceThreadComplex(bfGreen1BufferSize);
+    thPfBufM = GetWorkSpaceThreadComplex(Nsize*Nsize);
+    thPfWork = GetWorkSpaceThreadComplex(LapackLWork);
+    thPfRWork = GetWorkSpaceThreadDouble(LapackLWork);
+
+    #pragma loop noalias
+    for(idx=0;idx<Nsize;idx++) thEleIdx[idx] = eleIdx[idx];
+    #pragma loop noalias
+    for(idx=0;idx<Nsite2;idx++) thEleCfg[idx] = eleCfg[idx];
+    #pragma loop noalias
+    for(idx=0;idx<Nsite2;idx++) thEleNum[idx] = eleNum[idx];
+    #pragma loop noalias
+    for(idx=0;idx<Nsize;idx++) thEleSpn[idx] = eleSpn[idx];
+
+    #pragma omp barrier
+    #pragma omp master
+    { StartTimer(50); }
+    #pragma omp barrier
+
+    #pragma omp for schedule(dynamic)
+    for(idx=0;idx<NCisAjs;idx++) {
+      ri = CisAjsIdx[idx][0];
+      s  = CisAjsIdx[idx][1];
+      rj = CisAjsIdx[idx][2];
+      t  = CisAjsIdx[idx][3];
+      if(s != t) {
+        fprintf(stderr, "Error: BackFlow FSZ does not support spin-changing OneBodyG yet.\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+      }
+      tmp = GreenFunc1BF_fsz_workspace(ri,rj,s,ip,thEleIdx,thEleCfg,thEleNum,
+                              eleProjCnt,thEleSpn,thProjCntNew,eleProjBFCnt,
+                              thProjBFCntNew,thBuffer,thPfBufM,thPfIWork,
+                              thPfWork,thPfRWork);
+      LocalCisAjs[idx] = tmp;
     }
-    tmp = GreenFunc1BF_fsz(ri,rj,s,ip,myEleIdx,myEleCfg,myEleNum,eleProjCnt,myEleSpn,
-                           myProjCntNew,eleProjBFCnt,myProjBFCntNew,myBuffer);
-    LocalCisAjs[idx] = tmp;
+
+    #pragma omp barrier
+    #pragma omp master
+    { StopTimer(50); }
   }
-  StopTimer(50);
+
+  ReleaseWorkSpaceThreadInt();
+  ReleaseWorkSpaceThreadComplex();
+  ReleaseWorkSpaceThreadDouble();
 
   StartTimer(51);
   for(idx=0;idx<NCisAjsCktAltDC;idx++) {

--- a/src/mVMC/calham_real.c
+++ b/src/mVMC/calham_real.c
@@ -243,7 +243,8 @@ double CalculateHamiltonianBF_real(const double ip, int *eleIdx, const int *eleC
 #pragma omp parallel default(shared)\
   private(myEleIdx,myEleNum,myEleCfg,myProjCntNew,myProjBFCntNew,myBuffer,\
           myBatchIdx,myBatchMsa,myBatchIcount,myBatchVec,myBatchPfM,myBatchProj,myBatchGreen,\
-          myBatchVecStack,myBatchWStack,myEnergy,batchNo,batchStart,batchEnd,batchIdx,batchCount)\
+          myBatchVecStack,myBatchWStack,myEnergy,idx,ri,rj,s,rk,rl,t,tmp,\
+          batchNo,batchStart,batchEnd,batchIdx,batchCount)\
   reduction(+:e)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);

--- a/src/mVMC/include/matrix.h
+++ b/src/mVMC/include/matrix.h
@@ -16,6 +16,10 @@ int CalculatePfM_BF_fsz(const int *eleIdx, const int *eleSpn, const int qpStart,
 int CalculatePfM_BF_fsz_from(const double complex *sltElmBF, const int *eleIdx,
     const int *eleSpn, const int qpStart, const int qpEnd,
     double complex *pfMOut, int *failureDetail);
+int CalculatePfM_BF_fsz_from_workspace(const double complex *sltElmBF,
+    const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
+    double complex *pfMOut, int *failureDetail, double complex *bufM,
+    int *iwork, double complex *work, int lwork, double *rwork);
 
 int CalculateMAll_fsz(const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd);
 int CalculateMAll_fsz_real(const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd);

--- a/src/mVMC/include/slater.h
+++ b/src/mVMC/include/slater.h
@@ -11,6 +11,8 @@ void BackFlowDiff_fcmp(complex double *srOptO, const double complex ip, int *ele
 void MakeSlaterElmBF_fcmp(const int *eleNum, const int *eleProjBFCnt);
 void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt);
 void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt);
+void MakeSlaterElmBF_fsz_to_serial(double complex *sltElmBF, const int *eleNum,
+                       const int *eleProjBFCnt);
 void UpdateSlaterElmBF_fcmp(const int ma, const int ra, const int rb, const int u,
                        const int *eleCfg, const int *eleNum, const int *eleProjBFCnt, int *msa, int *hopNum, double complex*sltElmTmp);
 void UpdateSlaterElmBF_real(const int ma, const int ra, const int rb, const int u,

--- a/src/mVMC/locgrn_fsz.c
+++ b/src/mVMC/locgrn_fsz.c
@@ -46,6 +46,13 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
                   int *projCntNew, const int *eleProjBFCnt, int *projBFCntNew,
                   double complex *buffer);
 
+double complex GreenFunc1BF_fsz_workspace(const int ri, const int rj, const int s,
+                  const double complex ip, int *eleIdx, int *eleCfg, int *eleNum,
+                  const int *eleProjCnt, int *eleSpn, int *projCntNew,
+                  const int *eleProjBFCnt, int *projBFCntNew,
+                  double complex *buffer, double complex *pfBufM, int *pfIWork,
+                  double complex *pfWork, double *pfRWork);
+
 double complex GreenFunc2BF_fsz(const int ri, const int rj, const int rk, const int rl,
                   const int s, const int t, const double complex ip,
                   int *eleIdx, int *eleCfg, int *eleNum, const int *eleProjCnt,int *eleSpn,
@@ -74,6 +81,41 @@ static double complex CalculateBF_FSZ_CandidateIP(const char *caller,
 
   status = CalculatePfM_BF_fsz_from(sltElmBF, eleIdx, eleSpn, 0, NQPFull,
       pfMNew, &detail);
+  if(status == BF_FSZ_PF_LAPACK_FAILURE) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian failed in M_ZSKPFA (info=%d); propagating NaN.\n",
+        caller, detail);
+    return BF_FSZ_NaNValue();
+  }
+  if(status == BF_FSZ_PF_NONFINITE) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian is non-finite (qpidx=%d); propagating NaN.\n",
+        caller, detail);
+    return BF_FSZ_NaNValue();
+  }
+  if(status != BF_FSZ_PF_OK) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian returned unknown status %d; propagating NaN.\n",
+        caller, status);
+    return BF_FSZ_NaNValue();
+  }
+
+  ipNew = CalculateIP_fcmp(pfMNew, 0, NQPFull, MPI_COMM_SELF);
+  if(!(isfinite(creal(ipNew)) && isfinite(cimag(ipNew)))) {
+    fprintf(stderr, "warning: %s: BF-FSZ candidate projected overlap is non-finite; propagating NaN.\n",
+        caller);
+    return BF_FSZ_NaNValue();
+  }
+  return ipNew;
+}
+
+static double complex CalculateBF_FSZ_CandidateIP_workspace(const char *caller,
+    const double complex *sltElmBF, const int *eleIdx, const int *eleSpn,
+    double complex *pfMNew, double complex *pfBufM, int *pfIWork,
+    double complex *pfWork, double *pfRWork) {
+  int status;
+  int detail = 0;
+  double complex ipNew;
+
+  status = CalculatePfM_BF_fsz_from_workspace(sltElmBF, eleIdx, eleSpn, 0,
+      NQPFull, pfMNew, &detail, pfBufM, pfIWork, pfWork, LapackLWork, pfRWork);
   if(status == BF_FSZ_PF_LAPACK_FAILURE) {
     fprintf(stderr, "warning: %s: BF-FSZ candidate Pfaffian failed in M_ZSKPFA (info=%d); propagating NaN.\n",
         caller, detail);
@@ -476,6 +518,54 @@ double complex GreenFunc1BF_fsz(const int ri, const int rj, const int s, const d
   MakeSlaterElmBF_fsz_to(sltElmBFNew, eleNum, projBFCntNew);
   z *= CalculateBF_FSZ_CandidateIP("GreenFunc1BF_fsz", sltElmBFNew, eleIdx,
       eleSpn, pfMNew);
+
+  eleCfg[rsj] = mj;
+  eleCfg[rsi] = -1;
+  eleIdx[mj] = rj;
+  eleSpn[mj] = s;
+  eleNum[rsj] = 1;
+  eleNum[rsi] = 0;
+
+  return conj(z/ip);
+}
+
+double complex GreenFunc1BF_fsz_workspace(const int ri, const int rj, const int s,
+                  const double complex ip, int *eleIdx, int *eleCfg, int *eleNum,
+                  const int *eleProjCnt, int *eleSpn, int *projCntNew,
+                  const int *eleProjBFCnt, int *projBFCntNew,
+                  double complex *buffer, double complex *pfBufM, int *pfIWork,
+                  double complex *pfWork, double *pfRWork) {
+  double complex z;
+  int mj,rsi,rsj;
+  /* buffer: NQPFull Pfaffians followed by a candidate BF-FSZ Slater matrix. */
+  double complex *pfMNew = buffer;
+  double complex *sltElmBFNew = buffer + NQPFull;
+
+  (void)eleProjBFCnt;
+
+  if(ri==rj) return eleNum[ri+s*Nsite];
+  if(eleNum[ri+s*Nsite]==1 || eleNum[rj+s*Nsite]==0) return 0.0;
+  if(NExUpdatePath==4 || NExUpdatePath==5){
+    if(eleNum[ri+(1-s)*Nsite]==1) return 0.0;
+  }
+
+  mj  = eleCfg[rj+s*Nsite];
+  rsi = ri + s*Nsite;
+  rsj = rj + s*Nsite;
+
+  eleCfg[rsj] = -1;
+  eleCfg[rsi] = mj;
+  eleIdx[mj] = ri;
+  eleSpn[mj] = s;
+  eleNum[rsj] = 0;
+  eleNum[rsi] = 1;
+  UpdateProjCnt(rj, ri, s, projCntNew, eleProjCnt, eleNum);
+  z = ProjRatio(projCntNew,eleProjCnt);
+
+  MakeProjBFCnt(projBFCntNew, eleNum);
+  MakeSlaterElmBF_fsz_to_serial(sltElmBFNew, eleNum, projBFCntNew);
+  z *= CalculateBF_FSZ_CandidateIP_workspace("GreenFunc1BF_fsz", sltElmBFNew,
+      eleIdx, eleSpn, pfMNew, pfBufM, pfIWork, pfWork, pfRWork);
 
   eleCfg[rsj] = mj;
   eleCfg[rsi] = -1;

--- a/src/mVMC/matrix.c
+++ b/src/mVMC/matrix.c
@@ -611,6 +611,29 @@ int CalculatePfM_BF_fsz_from(const double complex *sltElmBF, const int *eleIdx,
   return status;
 }
 
+int CalculatePfM_BF_fsz_from_workspace(const double complex *sltElmBF,
+    const int *eleIdx, const int *eleSpn, const int qpStart, const int qpEnd,
+    double complex *pfMOut, int *failureDetail, double complex *bufM,
+    int *iwork, double complex *work, int lwork, double *rwork) {
+  const int qpNum = qpEnd-qpStart;
+  int qpidx;
+  int status = BF_FSZ_PF_OK;
+  int detail = 0;
+
+  for(qpidx=0;qpidx<qpNum;qpidx++) {
+    int myDetail = 0;
+    int myStatus = calculatePfM_BF_fsz_child_from(sltElmBF, eleIdx, eleSpn,
+        qpStart, qpidx, bufM, iwork, work, lwork, rwork, pfMOut, &myDetail);
+    if(status==BF_FSZ_PF_OK && myStatus!=BF_FSZ_PF_OK) {
+      status = myStatus;
+      detail = myDetail;
+    }
+  }
+
+  if(failureDetail != NULL) *failureDetail = detail;
+  return status;
+}
+
 int calculatePfM_BF_fsz_child_from(
        const double complex *sltElmBF,
        const int *eleIdx,

--- a/src/mVMC/slater_fsz.c
+++ b/src/mVMC/slater_fsz.c
@@ -29,6 +29,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 void UpdateSlaterElm_fsz();
 void MakeSlaterElmBF_fsz(const int *eleNum, const int *eleProjBFCnt);
 void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt);
+void MakeSlaterElmBF_fsz_to_serial(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt);
 void SlaterElmDiff_fsz(double complex *srOptO, const double complex ip, int *eleIdx,int *eleSpn);
 
 static inline int BFThetaCount_fsz(const int mu, const int centerSite,
@@ -258,18 +259,66 @@ void UpdateSlaterElm_fsz() {
   return;
 }
 
-void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt) {
+static void MakeSlaterElmBF_fsz_qp(double complex *sltElmBF, const int qpidx,
+                                   const int *etaFlag, const int *sparseOffset,
+                                   const int *sparseCount, const int *sparseSite,
+                                   const int *sparseSubIdx, const int *sparseThetaCnt) {
   int ri,ori,sgni,rsi;
   int rj,orj,sgnj,rsj;
   int si,sj;
-  int qpidx,mpidx,optidx;
+  int mpidx,optidx;
+  int *xqp, *xqpSgn, *xqpOpt, *xqpOptSgn;
+  double complex slt;
+  double complex *sltE, *sltE_i;
+
+  optidx    = qpidx / NQPFix;
+  mpidx     = (qpidx%NQPFix) / NSPGaussLeg;
+
+  xqpOpt    = QPOptTrans[optidx];
+  xqpOptSgn = QPOptTransSgn[optidx];
+  xqp       = QPTrans[mpidx];
+  xqpSgn    = QPTransSgn[mpidx];
+
+  sltE      = sltElmBF + qpidx*Nsite2*Nsite2;
+
+#pragma loop noalias
+  for(rsi=0;rsi<Nsite2;rsi++) {
+    ri = rsi % Nsite;
+    si = rsi / Nsite;
+    ori  = xqpOpt[ri];
+    sgni = xqpSgn[ori]*xqpOptSgn[ri];
+    sltE_i = sltE + rsi*Nsite2;
+    sltE_i[rsi] = 0.0 + 0.0*I;
+
+    for(rsj=rsi+1;rsj<Nsite2;rsj++) {
+      rj = rsj % Nsite;
+      sj = rsj / Nsite;
+      orj  = xqpOpt[rj];
+      sgnj = xqpSgn[orj]*xqpOptSgn[rj];
+
+      slt = (SubSlaterElmBF_fsz_sparse(ri, si, rj, sj, xqp, xqpOpt, etaFlag,
+                                       sparseOffset, sparseCount,
+                                       sparseSite, sparseSubIdx,
+                                       sparseThetaCnt)
+             - SubSlaterElmBF_fsz_sparse(rj, sj, ri, si, xqp, xqpOpt, etaFlag,
+                                         sparseOffset, sparseCount,
+                                         sparseSite, sparseSubIdx,
+                                         sparseThetaCnt))
+            * (double)(sgni*sgnj);
+      sltE_i[rsj] = slt;
+      sltE[rsj*Nsite2 + rsi] = -slt;
+    }
+  }
+  return;
+}
+
+static void MakeSlaterElmBF_fsz_to_core(double complex *sltElmBF, const int *eleNum,
+                                        const int *eleProjBFCnt, const int useOMP) {
+  int qpidx;
   int sparseKeyCount, sparseEntryCapacity, sparseWorkSize;
   int *sparseWork;
   int *etaFlag, *sparseOffset, *sparseCount;
   int *sparseSite, *sparseSubIdx, *sparseThetaCnt;
-  int *xqp, *xqpSgn, *xqpOpt, *xqpOptSgn;
-  double complex slt;
-  double complex *sltE, *sltE_i;
 
   (void)eleNum;
 
@@ -292,52 +341,31 @@ void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const i
   MakeBFSparseThetaList_fsz(sparseOffset, sparseCount, sparseSite,
                             sparseSubIdx, sparseThetaCnt, eleProjBFCnt);
 
-  #pragma omp parallel for default(shared)        \
-    private(qpidx,optidx,mpidx,                   \
-            xqpOpt,xqpOptSgn,xqp,xqpSgn,sltE,     \
-            ri,ori,sgni,rsi,sltE_i,               \
-            rj,orj,sgnj,rsj,si,sj,slt)
-  #pragma loop noalias
-  for(qpidx=0;qpidx<NQPFull;qpidx++) {
-    optidx    = qpidx / NQPFix;
-    mpidx     = (qpidx%NQPFix) / NSPGaussLeg;
-
-    xqpOpt    = QPOptTrans[optidx];
-    xqpOptSgn = QPOptTransSgn[optidx];
-    xqp       = QPTrans[mpidx];
-    xqpSgn    = QPTransSgn[mpidx];
-
-    sltE      = sltElmBF + qpidx*Nsite2*Nsite2;
-
-    for(rsi=0;rsi<Nsite2;rsi++) {
-      ri = rsi % Nsite;
-      si = rsi / Nsite;
-      ori  = xqpOpt[ri];
-      sgni = xqpSgn[ori]*xqpOptSgn[ri];
-      sltE_i = sltE + rsi*Nsite2;
-      sltE_i[rsi] = 0.0 + 0.0*I;
-
-      for(rsj=rsi+1;rsj<Nsite2;rsj++) {
-        rj = rsj % Nsite;
-        sj = rsj / Nsite;
-        orj  = xqpOpt[rj];
-        sgnj = xqpSgn[orj]*xqpOptSgn[rj];
-
-        slt = (SubSlaterElmBF_fsz_sparse(ri, si, rj, sj, xqp, xqpOpt, etaFlag,
-                                         sparseOffset, sparseCount,
-                                         sparseSite, sparseSubIdx,
-                                         sparseThetaCnt)
-               - SubSlaterElmBF_fsz_sparse(rj, sj, ri, si, xqp, xqpOpt, etaFlag,
-                                           sparseOffset, sparseCount,
-                                           sparseSite, sparseSubIdx,
-                                           sparseThetaCnt))
-              * (double)(sgni*sgnj);
-        sltE_i[rsj] = slt;
-        sltE[rsj*Nsite2 + rsi] = -slt;
-      }
+  if(useOMP) {
+    #pragma omp parallel for default(shared) private(qpidx)
+    for(qpidx=0;qpidx<NQPFull;qpidx++) {
+      MakeSlaterElmBF_fsz_qp(sltElmBF, qpidx, etaFlag, sparseOffset,
+                             sparseCount, sparseSite, sparseSubIdx,
+                             sparseThetaCnt);
+    }
+  } else {
+    for(qpidx=0;qpidx<NQPFull;qpidx++) {
+      MakeSlaterElmBF_fsz_qp(sltElmBF, qpidx, etaFlag, sparseOffset,
+                             sparseCount, sparseSite, sparseSubIdx,
+                             sparseThetaCnt);
     }
   }
   free(sparseWork);
+  return;
+}
+
+void MakeSlaterElmBF_fsz_to(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt) {
+  MakeSlaterElmBF_fsz_to_core(sltElmBF, eleNum, eleProjBFCnt, 1);
+  return;
+}
+
+void MakeSlaterElmBF_fsz_to_serial(double complex *sltElmBF, const int *eleNum, const int *eleProjBFCnt) {
+  MakeSlaterElmBF_fsz_to_core(sltElmBF, eleNum, eleProjBFCnt, 0);
   return;
 }
 


### PR DESCRIPTION
## Summary

This stacked PR parallelizes the BF-FSZ `GreenFunc1` measurement loop.

Base PR: #124 (`feature/backflow-fsz-f1-1-scratch`)

Changes:

- Add outer-OpenMP-safe BF-FSZ candidate evaluation helpers:
  - `CalculatePfM_BF_fsz_from_workspace`
  - `MakeSlaterElmBF_fsz_to_serial`
  - `CalculateBF_FSZ_CandidateIP_workspace`
  - `GreenFunc1BF_fsz_workspace`
- Parallelize only the `OneBodyG` loop in `CalculateGreenFuncBF_fsz` with thread-private electron/projection/Pfaffian workspaces.
- Keep `GreenFunc2BF_fsz`, TwoBodyG measurement, and physical accumulation serial.
- Preserve existing energy/sampler paths; the original non-workspace APIs remain in use there.

## Correctness / Determinism

- `git diff --check`: PASS
- BF-FSZ focused tests, OMP=1: PASS
- `BackFlow|fsz` focused tests, OMP=1: 57/57 PASS
- BF-FSZ + TwoBodyG focused tests, OMP=4: PASS
- Non-identity `ProjBF` + `NMPTrans=2` fixture:
  - OMP=1 vs OMP=4: 4 output files bitwise identical
  - OMP=4 repeat: stable
- MPI smoke, 2 ranks: PASS
- `OMP_NESTED=true` representative check: bitwise identical

## Performance

Primary OpenMP performance check was done on genkai with Intel/MKL, not macOS local OpenMP.

Configuration:

- 1 MPI rank
- `OMP_NUM_THREADS=1/4`
- `MKL_NUM_THREADS=1`
- `MKL_DYNAMIC=FALSE`
- nearest and dense P1-size BF-FSZ Green measurement sets

genkai run IDs:

- build: `20260709-210018-89se`, job `6174662`
- profile: `20260709-210509-j5bj`, job `6174665`

Result summary (`OMP4/OMP1`, lower is better):

| set | case | `[50] GreenFunc1` | `[42] CalculateGreenFunc` | All |
|---|---:|---:|---:|---:|
| nearest | L08 | 0.316x | 0.440x | 0.182x |
| nearest | L12 | 0.296x | 0.413x | 0.905x |
| nearest | L16 | 0.279x | 0.375x | 0.878x |
| dense | L08 | 0.276x | 0.327x | 1.047x |
| dense | L12 | 0.262x | 0.288x | 0.651x |
| dense | L16 | 0.258x | 0.273x | 0.544x |

OMP=1 and OMP=4 produced bitwise-identical output files for all six profile cases.

## Notes

- This PR intentionally does not parallelize `GreenFunc2BF_fsz`; that path still uses global `SlaterElmBF` and is kept serial for now.
- The only remaining nested-OpenMP site is `UpdateProjCnt` in the doublon-holon branch. It writes to thread-private output in this path and is correctness-safe; current BF-FSZ profile/test fixtures do not enter that branch.
