### PR TITLE
Support the second power-Lanczos step

### DIFF
--- a/doc/en/source/algorithm.rst
+++ b/doc/en/source/algorithm.rst
@@ -328,6 +328,67 @@ From the condition
 solving the quadratic equations, we can determine the :math:`\alpha`.
 The variance is calculate in the similar way.
 
+Second power-Lanczos step
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For ``NLanczosStep=2``, mVMC first samples and retains the four local powers
+
+.. math::
+
+   F_a(x)=\frac{\langle x|\hat{H}^a|\psi\rangle}
+                 {\langle x|\psi\rangle},\qquad a=0,1,2,3,
+
+After the sample loop, the globally weighted variational energy
+:math:`\sigma=\langle H\rangle` is computed.  Before any moment products
+are accumulated, each sample is transformed to
+
+.. math::
+
+   F'_a(x)=\sum_{j=0}^{a}{a\choose j}(-\sigma)^{a-j}F_j(x).
+
+Thus :math:`F'_a` is the local estimator of
+:math:`(\hat H-\sigma)^a`, and mVMC forms the centered moment matrix
+
+.. math::
+
+   M'_{ab}=\sum_x \rho(x)F'_a(x)^\dagger F'_b(x).
+
+Centering before accumulation avoids the precision loss that would occur
+when raw moments such as :math:`\langle H^6\rangle` are formed for a
+large extensive energy.  It requires storage proportional to four local
+powers per Monte Carlo sample.
+Centering primarily removes the offset from the mean energy.  When
+:math:`|\langle H\rangle|` is small compared with the width of the energy
+distribution, the dynamic range of the high-order local powers may remain
+large; centering alone therefore does not guarantee numerical accuracy for
+every system.
+
+The :math:`H^3` local power uses nested outer and inner loops over
+``Transfer`` terms, so its dominant operator count grows as
+:math:`O(N_{\mathrm{Transfer}}^2)`. Wall-clock cost also depends on the
+wave function, projection, and execution environment.
+
+With :math:`X=\hat H-\sigma`, the overlap, centered-Hamiltonian, and
+centered squared-Hamiltonian matrices in the basis
+:math:`\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\}` are
+
+.. math::
+
+   S_{ab}=M'_{ab},\qquad
+   H'_{ab}=\frac{M'_{a,b+1}+M'_{a+1,b}}{2},\qquad
+   G'_{ab}=M'_{a+1,b+1},
+
+where :math:`a,b=0,1,2`. The lowest solution of
+:math:`H'd=E'Sd` gives :math:`E=E'+\sigma`.  The polynomial
+coefficients are transformed back to the unshifted basis so that the
+reported state is
+:math:`|\phi\rangle=(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle`.
+The reported variance is evaluated in the centered basis as
+:math:`d^\dagger G'd-(d^\dagger H'd)^2`, with
+:math:`d^\dagger Sd=1`. The ratios
+:math:`\alpha_1=c_1/c_0` and :math:`\alpha_2=c_2/c_0` are also
+reported when :math:`c_0` is numerically defined.
+
 Calculation of physical quantities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -351,5 +412,3 @@ where we define :math:`A_0`, :math:`A_{1(10)},~A_{1(01)},` and
    &A_{1(01)}=\sum_{x} \rho(x) F(x, \hat{A}\hat{H}),\\
    &A_{2(11)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{A}\hat{H}).
    \end{aligned}
-
-

--- a/doc/en/source/algorithm.rst
+++ b/doc/en/source/algorithm.rst
@@ -363,10 +363,18 @@ distribution, the dynamic range of the high-order local powers may remain
 large; centering alone therefore does not guarantee numerical accuracy for
 every system.
 
-The :math:`H^3` local power uses nested outer and inner loops over
-``Transfer`` terms, so its dominant operator count grows as
-:math:`O(N_{\mathrm{Transfer}}^2)`. Wall-clock cost also depends on the
-wave function, projection, and execution environment.
+With the identity quantum projection (``NQPFull=1``), the :math:`H^3`
+local power uses nested outer and inner loops over ``Transfer`` terms, so
+its dominant operator count grows as
+:math:`O(N_{\mathrm{Transfer}}^2)`.  For a nontrivial quantum projection
+(``NQPFull>1``), second power-Lanczos evaluates the projected
+:math:`H\,CACA` matrix elements by direct contraction from the original
+configuration.  Each such contraction adds an internal loop over
+``Transfer`` terms, giving a dominant
+:math:`O(N_{\mathrm{Transfer}}^3)` operator count on this path; the
+``GreenFuncN`` contraction work is also proportional to ``NQPFull``.
+Wall-clock cost therefore depends strongly on the projection as well as
+the wave function and execution environment.
 
 With :math:`X=\hat H-\sigma`, the overlap, centered-Hamiltonian, and
 centered squared-Hamiltonian matrices in the basis

--- a/doc/en/source/algorithm.rst
+++ b/doc/en/source/algorithm.rst
@@ -255,39 +255,86 @@ determinant.
 Power Lanczos method
 --------------------
 
-In this section, we show how to determine :math:`\alpha` in the
-power-Lanczos method. We also explain the calculation of physical
-quantities after the single-step Lanczos method.
+The power-Lanczos method improves an optimized VMC wave function
+:math:`|\psi\rangle` by using the trial wave function
 
-Determination of :math:`\alpha`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. math::
+
+   |\phi_p\rangle
+   =P_p(\hat H)|\psi\rangle
+   =\sum_{k=0}^{p}c_k\hat H^k|\psi\rangle.
+
+The coefficients :math:`c_k` minimize the energy in the Krylov subspace
+spanned by
+:math:`\{|\psi\rangle,\hat H|\psi\rangle,\ldots,\hat H^p|\psi\rangle\}`.
+The first- and second-step trial wave functions used by mVMC are
+
+.. math::
+
+   \begin{aligned}
+   |\phi_1\rangle &= (1+\alpha\hat H)|\psi\rangle,\\
+   |\phi_2\rangle &= (1+\alpha\hat H+\beta\hat H^2)|\psi\rangle.
+   \end{aligned}
+
+The first step requires ``NVMCCalMode=1``, ``NLanczosMode>=1``, and
+``NLanczosStep=1``. The second step requires ``NVMCCalMode=1``,
+``NLanczosMode=1``, and ``NLanczosStep=2``.
+
+The following subsections first explain the first-step optimization of
+:math:`\alpha`. They then separate the variational principle that
+determines :math:`\alpha,\beta` in the second step from the numerical
+stabilization used by the implementation. The final subsection describes
+the calculation of observables after the first power-Lanczos step.
+
+First power-Lanczos step and determination of :math:`\alpha`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First, we briefly explain the sampling procedure of the variational
-Monte Carlo (VMC) method. Physical properties :math:`\hat{A}` are
-calculated as follows:
+Monte Carlo (VMC) method. Here, :math:`x` denotes a configuration sampled
+from the base VMC wave function :math:`|\psi\rangle`. The expectation
+value of an observable :math:`\hat A` is
 
 .. math::
 
    \begin{aligned}
-   &\langle \hat{A}\rangle = \frac{\langle \phi| \hat{A}|\phi \rangle}{\langle \phi| \phi \rangle} = \sum_{x} \rho(x) F(x, {\hat{A}}),\\
-   & \rho(x)=\frac{|\langle \phi|x\rangle|^2}{\langle \phi | \phi \rangle}, ~~~~F(x,  {\hat{A}}) =  \frac{\langle x| \hat{A}|\phi \rangle}{\langle x| \phi \rangle}.
+   &\langle \hat{A}\rangle_\psi
+   = \frac{\langle \psi|\hat A|\psi\rangle}{\langle \psi|\psi\rangle}
+   = \sum_x \rho_\psi(x)F(x,\hat A),\\
+   &\rho_\psi(x)=\frac{|\langle x|\psi\rangle|^2}{\langle\psi|\psi\rangle},
+   \qquad
+   F(x,\hat A)=\frac{\langle x|\hat A|\psi\rangle}
+                     {\langle x|\psi\rangle}.
    \end{aligned}
 
-There are two ways to calculate the product of the operators
-:math:`\hat{A}\hat{B}`.
+The quantity :math:`F(x,\hat A)` is the local estimator of :math:`\hat A`
+at configuration :math:`x`. The expectation value of a product
+:math:`\hat A\hat B` has the following two representations:
 
 .. math::
 
    \begin{aligned}
-   &\langle \hat{A} \hat{B}\rangle = \sum_{x} \rho(x) F(x, {\hat{A}\hat{B}}),\\
-   &\langle \hat{A} \hat{B}\rangle = \sum_{x} \rho(x) F^{\dagger}(x, {\hat{A})F(x, \hat{B}}).
+   &\langle \hat A\hat B\rangle_\psi
+   = \sum_x\rho_\psi(x)F(x,\hat A\hat B),\\
+   &\langle \hat A\hat B\rangle_\psi
+   = \sum_x\rho_\psi(x)F^\dagger(x,\hat A)F(x,\hat B).
    \end{aligned}
 
-As we explain later, in general, the latter way is numerical stable
-one. For example, we consider the expectation value of the variance,
-which is defined as
-:math:`\sigma^2=\langle (\hat{H}-\langle \hat{H}\rangle)^2\rangle`.
-There are two ways to calculate the variance.
+In the former representation, the product :math:`\hat A\hat B` is
+evaluated as a single local estimator. In the latter, the complete set
+:math:`\sum_{x} |x\rangle \langle x|` is inserted between
+:math:`\hat A` and :math:`\hat B`, i.e., the product is split into the
+bra part :math:`\hat A` and the ket part :math:`\hat B`.
+The latter expression assumes that :math:`\hat A` is Hermitian. For a
+general :math:`\hat A`, :math:`F^\dagger(x,\hat A)` must be replaced by
+:math:`F^\dagger(x,\hat A^\dagger)`.
+Both representations then give the same expectation value in the limit of an
+infinite number of samples. They differ for a finite number of samples,
+and the latter is numerically more stable in general. For compact
+notation, :math:`\rho_\psi(x)` is abbreviated as :math:`\rho(x)` below.
+
+For example, the variance of the energy,
+:math:`\sigma^2=\langle (\hat{H}-\langle \hat{H}\rangle)^2\rangle`, can
+be calculated in the two ways:
 
 .. math::
 
@@ -297,22 +344,37 @@ There are two ways to calculate the variance.
    &= \sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}) F(x, \hat{H})- \left[ \sum_{x} \rho(x) F(x,  \hat{H})\right]^2
    \end{aligned}
 
-From its definition, the latter way gives the positive definitive
-variance even for the finite sampling while the former way does not
-guarantee the positive definitiveness of the variance. Here, we consider
-the expectation values of energy and variance for the (single-step)
-power Lanczos wave function
-:math:`|\phi\rangle =(1+\alpha \hat{H}) |\psi \rangle`. The energy is
-calculated as
+The latter way guarantees that the variance is non-negative even for a
+finite number of samples, while the former way does not.
+
+Next, we consider the energy expectation value of the first-step wave
+function :math:`|\phi_1\rangle =(1+\alpha \hat{H}) |\psi \rangle`.
+Expanding it with respect to :math:`\alpha` (the numerator and the
+denominator are divided by :math:`\langle \psi | \psi \rangle`) gives
 
 .. math::
 
    \begin{aligned}
-   E_{LS}(\alpha) =\frac{\langle \phi| \hat{H} |\phi\rangle}{\langle \phi|\phi\rangle}=\frac{h_1 + \alpha(h_{2(20)} + h_{2(11)}) + \alpha^2 h_{3(12)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}},
+   E_{LS}(\alpha) =\frac{\langle \phi_1| \hat{H} |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle}
+   =\frac{\langle \hat{H} \rangle_\psi + 2\alpha \langle \hat{H}^2 \rangle_\psi + \alpha^2 \langle \hat{H}^3 \rangle_\psi}
+   {1 + 2\alpha \langle \hat{H} \rangle_\psi + \alpha^2 \langle \hat{H}^2 \rangle_\psi},
    \end{aligned}
 
-where we define :math:`h_1`, :math:`h_{2(11)},~h_{2(20)},` and
-:math:`h_{3(12)}` as
+which requires the moments of :math:`\hat{H}` up to the third order. To
+estimate these moments with the splitting described above, we introduce
+the following notation:
+
+.. math::
+
+   \begin{aligned}
+   h_{n(ij)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}^i) F(x, \hat{H}^j), ~~~~ i+j=n.
+   \end{aligned}
+
+Namely, :math:`h_{n(ij)}` is an estimator of the :math:`n`-th moment
+:math:`\langle \hat{H}^n \rangle_\psi`, in which :math:`\hat{H}^i` is
+assigned to the bra side and :math:`\hat{H}^j` to the ket side (we set
+:math:`F(x, \hat{H}^0)=1` and abbreviate :math:`h_{1(10)}` as
+:math:`h_1`). The quantities used in the calculation are
 
 .. math::
 
@@ -320,39 +382,194 @@ where we define :math:`h_1`, :math:`h_{2(11)},~h_{2(20)},` and
    &h_1 =\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}),\\
    &h_{2(11)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}) F(x, \hat{H}),\\
    &h_{2(20)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}^2),\\
-   &h_{3(12)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{H}^2).
+   &h_{3(12)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{H}^2),\\
+   &h_{4(22)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}^2)F(x,  \hat{H}^2).
    \end{aligned}
 
-From the condition
-:math:`\frac{\partial E_{LS}(\alpha)}{\partial \alpha}=0`, i.e., by
-solving the quadratic equations, we can determine the :math:`\alpha`.
-The variance is calculate in the similar way.
+Note that both :math:`h_{2(11)}` and :math:`h_{2(20)}` are estimators
+of :math:`\langle \hat{H}^2 \rangle_\psi`, but they differ for a finite
+number of samples because of the different splittings. By assigning the
+powers of :math:`\hat{H}` to the bra and ket sides as evenly as
+possible, only :math:`F(x, \hat{H}^2)` appears as the local estimator,
+i.e., it is not necessary to evaluate the local estimators of
+:math:`\hat{H}^3` and :math:`\hat{H}^4` directly.
+
+With these estimators, the energy expectation value is evaluated as
+
+.. math::
+
+   \begin{aligned}
+   E_{LS}(\alpha) =\frac{h_1 + \alpha(h_{2(20)} + h_{2(11)}) + \alpha^2 h_{3(12)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}}.
+   \end{aligned}
+
+The two :math:`\langle \hat{H}^2 \rangle_\psi` terms in the first order
+of :math:`\alpha` in the numerator originate from the different factors
+:math:`(1+\alpha \hat{H})` on the bra and ket sides, and thus one of
+them is estimated by :math:`h_{2(11)}` and the other by
+:math:`h_{2(20)}`.
+
+The stationary condition
+:math:`\partial E_{LS}(\alpha)/\partial \alpha=0` reduces to the
+following quadratic equation for :math:`\alpha`:
+
+.. math::
+
+   \begin{aligned}
+   \left[2 h_1 h_{3(12)} - h_{2(11)}\left(h_{2(11)}+h_{2(20)}\right)\right] \alpha^2
+   + 2\left[h_{3(12)} - h_1 h_{2(11)}\right] \alpha
+   + \left(h_{2(11)}+h_{2(20)}\right) - 2h_1^2 = 0.
+   \end{aligned}
+
+We evaluate :math:`E_{LS}(\alpha_{\pm})` for the two real roots
+:math:`\alpha_{\pm}` of this quadratic equation and adopt the one that
+gives the lower energy as the optimized :math:`\alpha` (if the
+discriminant is negative and no real root exists, the Lanczos
+calculation stops with an error). The variance of the energy for the
+optimized :math:`|\phi_1\rangle` is also calculated as
+
+.. math::
+
+   \begin{aligned}
+   \sigma^2_{LS}(\alpha) = \frac{\langle \phi_1| \hat{H}^2 |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle} - E_{LS}(\alpha)^2,~~~~
+   \frac{\langle \phi_1| \hat{H}^2 |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle}
+   = \frac{h_{2(11)} + 2\alpha h_{3(12)} + \alpha^2 h_{4(22)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}}.
+   \end{aligned}
 
 Second power-Lanczos step
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For ``NLanczosStep=2``, mVMC first samples and retains the four local powers
+Variational determination of :math:`\alpha` and :math:`\beta`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For ``NLanczosStep=2``, mVMC minimizes the variational energy
 
 .. math::
 
-   F_a(x)=\frac{\langle x|\hat{H}^a|\psi\rangle}
-                 {\langle x|\psi\rangle},\qquad a=0,1,2,3,
+   E_2(\alpha,\beta)
+   =\frac{\langle\phi_2|\hat H|\phi_2\rangle}
+          {\langle\phi_2|\phi_2\rangle}
 
-After the sample loop, the globally weighted variational energy
-:math:`\sigma=\langle H\rangle` is computed.  Before any moment products
-are accumulated, each sample is transformed to
+of the trial wave function
+:math:`|\phi_2\rangle=(1+\alpha\hat H+\beta\hat H^2)|\psi\rangle`
+with respect to :math:`\alpha,\beta`. This is the direct extension of
+determining :math:`\alpha` from the stationary condition of
+:math:`E_{LS}(\alpha)` in the first step.
+
+The minimization can be written as a generalized eigenvalue problem in the
+Krylov basis
 
 .. math::
 
-   F'_a(x)=\sum_{j=0}^{a}{a\choose j}(-\sigma)^{a-j}F_j(x).
+   |v_a\rangle=\hat H^a|\psi\rangle,\qquad a=0,1,2.
 
-Thus :math:`F'_a` is the local estimator of
-:math:`(\hat H-\sigma)^a`, and mVMC forms the centered moment matrix
+Define the overlap and Hamiltonian matrices by
 
 .. math::
 
-   M'_{ab}=\sum_x \rho(x)F'_a(x)^\dagger F'_b(x).
+   S_{ab}=\frac{\langle v_a|v_b\rangle}{\langle\psi|\psi\rangle},
+   \qquad
+   {\cal H}_{ab}
+   =\frac{\langle v_a|\hat H|v_b\rangle}{\langle\psi|\psi\rangle}.
 
+From the definition of :math:`|v_a\rangle`, these matrix elements are
+nothing but the moments of the Hamiltonian with respect to the base wave
+function:
+
+.. math::
+
+   S_{ab}=\langle \hat H^{a+b}\rangle_\psi,
+   \qquad
+   {\cal H}_{ab}=\langle \hat H^{a+b+1}\rangle_\psi.
+
+The second step therefore requires the moments up to
+:math:`\langle \hat H^5\rangle_\psi` (up to
+:math:`\langle \hat H^6\rangle_\psi` when the variance described below
+is also evaluated). For :math:`\boldsymbol{c}=(c_0,c_1,c_2)^{\mathsf T}`,
+
+.. math::
+
+   |\phi_2\rangle=\sum_{a=0}^{2}c_a|v_a\rangle,\qquad
+   E_2(\boldsymbol{c})
+   =\frac{\boldsymbol{c}^\dagger{\cal H}\boldsymbol{c}}
+          {\boldsymbol{c}^\dagger S\boldsymbol{c}}.
+
+The stationary condition is therefore
+
+.. math::
+
+   {\cal H}\boldsymbol{c}=E_2 S\boldsymbol{c}.
+
+The eigenvector associated with the lowest eigenvalue gives the optimal
+coefficients. Its overall scale is arbitrary; setting
+:math:`\alpha=c_1/c_0` and :math:`\beta=c_2/c_0` recovers the
+:math:`(1+\alpha\hat H+\beta\hat H^2)|\psi\rangle` notation above.
+This generalized eigenvalue problem is the principle of the second
+power-Lanczos step. Note that fixing :math:`c_2=0` and optimizing only
+:math:`c_1/c_0` reduces this generalized eigenvalue problem to the
+quadratic equation of the first step. In other words, the second step
+applies the same variational principle with the dimension of the Krylov
+subspace extended from two to three.
+
+Numerically stable implementation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following operations do not change the variational principle. They
+evaluate the same matrix elements from Monte Carlo samples and solve the
+generalized eigenvalue problem more stably.
+
+First, mVMC applies the local-estimator definition above to
+:math:`\hat A=\hat H^a` and samples the four local powers
+
+.. math::
+
+   F_a(x)\equiv F(x,\hat H^a)
+   =\frac{\langle x|\hat H^a|\psi\rangle}
+          {\langle x|\psi\rangle},
+   \qquad a=0,1,2,3.
+
+For every sampled configuration :math:`x`, mVMC retains these four
+quantities. Here, :math:`F_0(x)=1`, :math:`F_1(x)` is the usual local
+energy, and :math:`F_2(x)` and :math:`F_3(x)` are the local estimators of
+:math:`\hat H^2` and :math:`\hat H^3`, respectively. They are not trial
+wave functions; they are sample-local quantities used to construct the
+overlap matrix :math:`S`, Hamiltonian matrix :math:`{\cal H}`, and the
+squared-Hamiltonian matrix used to calculate the variance.
+
+After the sample loop, the globally weighted energy of the base VMC wave
+function, :math:`E_{\rm shift}=\langle\hat H\rangle_\psi`, is computed,
+and :math:`X=\hat H-E_{\rm shift}` is introduced. Because
+
+.. math::
+
+   {\rm span}\{|\psi\rangle,\hat H|\psi\rangle,\hat H^2|\psi\rangle\}
+   =
+   {\rm span}\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\},
+
+this basis transformation changes neither the variational space nor its
+optimum. It is introduced only for numerical stability. Before any
+moment products are accumulated, each sample is transformed to
+
+.. math::
+
+   \widetilde F_a(x)
+   =\sum_{j=0}^{a}{a\choose j}(-E_{\rm shift})^{a-j}F_j(x).
+
+Thus :math:`\widetilde F_a` is the local estimator of :math:`X^a`, and
+mVMC forms the centered moment matrix
+
+.. math::
+
+   \widetilde M_{ab}
+   =\sum_x \rho(x)\widetilde F_a(x)^\dagger\widetilde F_b(x).
+
+The implementation retains all combinations with
+:math:`a,b=0,\ldots,3`. As in :math:`h_{n(ij)}` for the first step,
+each :math:`\widetilde M_{ab}` estimates the :math:`(a+b)`-th moment
+:math:`\langle X^{a+b}\rangle_\psi` by splitting the powers between the
+bra :math:`\widetilde F_a^\dagger` and the ket
+:math:`\widetilde F_b`. Because neither side has an exponent larger
+than three, :math:`\widetilde M_{33}` represents the moment through
+:math:`X^6` while requiring local powers only through :math:`F_3`.
 Centering before accumulation avoids the precision loss that would occur
 when raw moments such as :math:`\langle H^6\rangle` are formed for a
 large extensive energy.  It requires storage proportional to four local
@@ -363,54 +580,152 @@ distribution, the dynamic range of the high-order local powers may remain
 large; centering alone therefore does not guarantee numerical accuracy for
 every system.
 
-With the identity quantum projection (``NQPFull=1``), the :math:`H^3`
-local power uses nested outer and inner loops over ``Transfer`` terms, so
-its dominant operator count grows as
-:math:`O(N_{\mathrm{Transfer}}^2)`.  For a nontrivial quantum projection
-(``NQPFull>1``), second power-Lanczos evaluates the projected
-:math:`H\,CACA` matrix elements by direct contraction from the original
-configuration.  Each such contraction adds an internal loop over
-``Transfer`` terms, giving a dominant
-:math:`O(N_{\mathrm{Transfer}}^3)` operator count on this path; the
-``GreenFuncN`` contraction work is also proportional to ``NQPFull``.
-Wall-clock cost therefore depends strongly on the projection as well as
-the wave function and execution environment.
-
-With :math:`X=\hat H-\sigma`, the overlap, centered-Hamiltonian, and
-centered squared-Hamiltonian matrices in the basis
-:math:`\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\}` are
+Because :math:`\widetilde M_{ab}` and
+:math:`\widetilde M_{ba}^\dagger` are accumulated from the same
+samples, their contributions are equal sample by sample; finite sampling
+itself does not create a difference between them. Small anti-Hermitian
+components can nevertheless arise from floating-point arithmetic and
+parallel reductions, so mVMC projects the moment matrix onto its
+Hermitian part. In contrast, finite-sample statistical error affects
+different splittings :math:`\widetilde M_{ab}` and
+:math:`\widetilde M_{cd}` with :math:`a+b=c+d`; this difference is
+reported as ``hankel_residual``. mVMC then constructs the overlap,
+Hamiltonian, and squared-Hamiltonian matrices in the centered Krylov basis:
 
 .. math::
 
-   S_{ab}=M'_{ab},\qquad
-   H'_{ab}=\frac{M'_{a,b+1}+M'_{a+1,b}}{2},\qquad
-   G'_{ab}=M'_{a+1,b+1},
+   \widetilde S_{ab}=\widetilde M_{ab},\qquad
+   \widetilde{\cal H}_{ab}
+   =\frac{\widetilde M_{a,b+1}+\widetilde M_{a+1,b}}{2},\qquad
+   \widetilde G_{ab}=\widetilde M_{a+1,b+1},
 
-where :math:`a,b=0,1,2`. The lowest solution of
-:math:`H'd=E'Sd` gives :math:`E=E'+\sigma`.  The polynomial
-coefficients are transformed back to the unshifted basis so that the
-reported state is
-:math:`|\phi\rangle=(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle`.
-The reported variance is evaluated in the centered basis as
-:math:`d^\dagger G'd-(d^\dagger H'd)^2`, with
-:math:`d^\dagger Sd=1`. The ratios
-:math:`\alpha_1=c_1/c_0` and :math:`\alpha_2=c_2/c_0` are also
-reported when :math:`c_0` is numerically defined.
+where :math:`a,b=0,1,2`. Averaging the two moment estimates in
+:math:`\widetilde{\cal H}` also preserves Hermiticity at finite sample
+size.
 
-Calculation of physical quantities
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To reduce differences among the norms of the basis vectors, mVMC applies
+the diagonal scaling
 
-By using the optimized parameter :math:`\alpha`, we can calculate the
-expected value of the operator :math:`\hat{A}` as
+.. math::
+
+   D_{aa}=\frac{1}{\sqrt{\widetilde S_{aa}}}
+
+and solves
+
+.. math::
+
+   (D\widetilde{\cal H}D)\boldsymbol{u}
+   =E_X(D\widetilde S D)\boldsymbol{u}.
+
+Only if the overlap factorization fails, a small regularization is added
+to the diagonal of :math:`D\widetilde S D` before retrying. Centering,
+Hermitian projection, diagonal scaling, and this fallback regularization
+are numerical stabilization steps separate from the variational
+principle.
+
+The lowest eigenvalue gives the energy of the original Hamiltonian as
+:math:`E=E_X+E_{\rm shift}`. If
+:math:`\boldsymbol{d}=(d_0,d_1,d_2)^{\mathsf T}` denotes the coefficients
+in the centered basis, the unshifted coefficients are
 
 .. math::
 
    \begin{aligned}
-   A_{LS}(\alpha) =\frac{\langle \phi| \hat{A} |\phi\rangle}{\langle \phi|\phi\rangle}=\frac{A_0 + \alpha(A_{1(10)} + A_{1(01)}) + \alpha^2 A_{2(11)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}},
+   c_0 &= d_0-E_{\rm shift}d_1+E_{\rm shift}^2d_2,\\
+   c_1 &= d_1-2E_{\rm shift}d_2,\\
+   c_2 &= d_2.
    \end{aligned}
 
-where we define :math:`A_0`, :math:`A_{1(10)},~A_{1(01)},` and
-:math:`A_{2(11)}` as
+mVMC reports :math:`c_0,c_1,c_2` and reports the
+:math:`\alpha,\beta` defined above as :math:`\alpha_1,\alpha_2`,
+respectively.
+With :math:`\boldsymbol{d}^\dagger\widetilde S\boldsymbol{d}=1`, the
+variance is evaluated in the centered basis as
+
+.. math::
+
+   \sigma_E^2
+   =\boldsymbol{d}^\dagger\widetilde G\boldsymbol{d}
+    -(\boldsymbol{d}^\dagger\widetilde{\cal H}\boldsymbol{d})^2.
+
+Computational cost
+^^^^^^^^^^^^^^^^^^
+
+The new cost introduced by the second step is the evaluation of the
+local powers :math:`F_2(x)` and :math:`F_3(x)` for every sample, among
+which
+:math:`F_3(x)=\langle x|\hat H^3|\psi\rangle/\langle x|\psi\rangle`
+dominates.
+
+In the current second-step implementation, the Hamiltonian is limited to
+spin-conserving ``Transfer`` terms and number-operator-type diagonal
+interactions. The
+evaluation of :math:`F_3` runs nested outer and inner loops over the
+off-diagonal ``Transfer`` terms. Since the product of two ``Transfer``
+terms combines into the two-body operator
+
+.. math::
+
+   CACA \equiv
+   c_{i\sigma}^\dagger c_{j\sigma} c_{k\tau}^\dagger c_{l\tau},
+
+the double loop generates :math:`O(N_{\mathrm{Transfer}}^2)` ``CACA``
+operators, and for each of them the matrix element containing the
+remaining :math:`\hat H`,
+:math:`\langle \psi|\hat H\,CACA|x\rangle/\langle \psi|x\rangle`, must
+be evaluated.
+
+With the identity quantum projection (``NQPFull=1``), this matrix
+element factorizes: ``CACA`` is applied to the sampled configuration
+:math:`x` to form a temporary configuration :math:`x'`, and the local
+estimator of :math:`\hat H` at :math:`x'` is multiplied by the overlap
+ratio :math:`\langle \psi|CACA|x\rangle/\langle \psi|x\rangle`. The
+double loop generates :math:`O(N_{\mathrm{Transfer}}^2)` ``CACA``
+operators, but the Hamiltonian local estimator for each ``CACA`` has
+another ``Transfer`` loop. Therefore, the worst-case complexity of this
+path is also :math:`O(N_{\mathrm{Transfer}}^3)`. Its prefactor is
+smaller than that of the nontrivial-projection path because it can use
+the ordinary local estimator and a rank-two update and avoids the
+``GreenFuncN`` work proportional to ``NQPFull``.
+
+For a nontrivial quantum projection (``NQPFull>1``), this factorization
+does not preserve the sum over quantum-projection components. The second
+power-Lanczos implementation therefore expands
+:math:`\hat H=\sum_\mu h_\mu\hat O_\mu` and treats
+:math:`\hat O_\mu\,CACA` as one many-body operator for every term.
+``GreenFuncN`` evaluates the corresponding many-body Green function from
+the original configuration :math:`x`, including the quantum-projection
+components, and the results are accumulated with weights :math:`h_\mu`.
+This direct evaluation introduces one additional internal loop over
+``Transfer`` terms for each :math:`\hat O_\mu\,CACA` many-body Green
+function, so the dominant operator count of this path grows as
+:math:`O(N_{\mathrm{Transfer}}^3)`, and the ``GreenFuncN`` work is also
+proportional to ``NQPFull``. Wall-clock cost therefore depends strongly
+on the projection as well as the wave function and execution
+environment.
+
+Calculation of physical quantities after the first power-Lanczos step
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For ``NLanczosMode=2``, by using the optimized parameter
+:math:`\alpha`, the physical quantities (one-body and two-body Green
+functions) are calculated for the first-step wave function
+:math:`|\phi_1\rangle` (Green functions for the second step are not
+supported). The numerator of the expectation value of an operator
+:math:`\hat{A}` is expanded with respect to :math:`\alpha` as
+
+.. math::
+
+   \begin{aligned}
+   \langle \phi_1| \hat{A} |\phi_1\rangle = \langle \psi| \hat{A} |\psi\rangle
+   + \alpha \langle \psi| \hat{H}\hat{A} |\psi\rangle
+   + \alpha \langle \psi| \hat{A}\hat{H} |\psi\rangle
+   + \alpha^2 \langle \psi| \hat{H}\hat{A}\hat{H} |\psi\rangle.
+   \end{aligned}
+
+As in the case of the energy, each term is estimated by splitting it
+into the bra part :math:`\hat{H}^i` and the ket part
+:math:`\hat{A}\hat{H}^j`:
 
 .. math::
 
@@ -420,3 +735,20 @@ where we define :math:`A_0`, :math:`A_{1(10)},~A_{1(01)},` and
    &A_{1(01)}=\sum_{x} \rho(x) F(x, \hat{A}\hat{H}),\\
    &A_{2(11)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{A}\hat{H}).
    \end{aligned}
+
+Here, as in the case of the energy, the subscript :math:`n(ij)` denotes
+the total power :math:`n=i+j` of :math:`\hat{H}` and its assignment to
+the bra side (:math:`\hat{H}^i`) and the ket side
+(:math:`\hat{A}\hat{H}^j`). With these estimators, the expectation
+value is calculated as
+
+.. math::
+
+   \begin{aligned}
+   A_{LS}(\alpha) =\frac{\langle \phi_1| \hat{A} |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle}=\frac{A_0 + \alpha(A_{1(10)} + A_{1(01)}) + \alpha^2 A_{2(11)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}},
+   \end{aligned}
+
+where the denominator is the same normalization factor
+:math:`\langle \phi_1 | \phi_1 \rangle` as that for the energy. In the
+program, the one-body and two-body Green functions are calculated based
+on this expression.

--- a/doc/en/source/expert.rst
+++ b/doc/en/source/expert.rst
@@ -551,16 +551,30 @@ Keywords and parameters
    ``InterAll``, ``NBodyInterAll``, and ``NBodyG`` are rejected before
    sampling. Second-step Green's functions are not calculated.
    The Gutzwiller ``ProjRatio`` path is checked against an independent
-   ED oracle. Nontrivial spin and momentum projections currently have
-   runtime and structural smoke coverage, but not an independent
+   ED oracle. A nontrivial :math:`k=\pi` momentum projection is checked
+   against independent real and complex projected-ED value oracles.
+   The real oracle covers serial, MPI, and OpenMP paths; the complex
+   oracle currently covers the serial path. Nontrivial spin projection
+   has runtime and structural smoke coverage, but not an independent
    projected-ED value oracle.
 
-   The :math:`H^3` local power is evaluated by nested outer and inner
-   loops over ``Transfer`` terms, so its dominant operator count grows as
-   :math:`O(N_{\mathrm{Transfer}}^2)`. Wall-clock cost also depends on the
-   system, projection, compiler, and machine. Benchmark a small instance
-   first and use a baseline from the target Linux/HPC environment for
-   performance decisions.
+   With ``NQPFull=1``, the :math:`H^3` local power is evaluated by nested
+   outer and inner loops over ``Transfer`` terms, so its dominant operator
+   count grows as :math:`O(N_{\mathrm{Transfer}}^2)`.  With a nontrivial
+   quantum projection (``NQPFull>1``), the direct-contraction path for
+   projected :math:`H\,CACA` matrix elements adds another ``Transfer``
+   loop.  Its dominant operator count is therefore
+   :math:`O(N_{\mathrm{Transfer}}^3)`, and its ``GreenFuncN`` work is
+   proportional to ``NQPFull``.
+
+   Projection can consequently increase second-step measurement time
+   substantially. Benchmark a small instance with the same
+   ``NSPGaussLeg`` and ``NMPTrans`` intended for the production run, and
+   use a baseline from the target Linux/HPC environment for performance
+   decisions. The manual, non-CI source-tree probe
+   ``test/python/lanczos2_cost_probe.py`` accepts ``--nspgaussleg`` and
+   ``--nmptrans`` grids and records ``NQPFull``, Timer 41, and Timer 95 in
+   its JSON output.
 
    A non-finite local power or moment, an invalid overlap matrix, a
    failed generalized eigensolve, or an output error terminates the run

--- a/doc/en/source/expert.rst
+++ b/doc/en/source/expert.rst
@@ -414,6 +414,7 @@ file format is shown as follows.
     --------------------
     NVMCCalMode    0
     NLanczosMode   0
+    NLanczosStep   1
     --------------------
     NDataIdxStart  1
     NDataQtySmp    1
@@ -526,8 +527,50 @@ Keywords and parameters
    ``NLanczosMode=1`` is supported. In these cases the Hamiltonian is
    limited to ``Transfer`` and diagonal number-operator interactions
    (``CoulombIntra``, ``CoulombInter``, and ``Hund``).
-   ``NLanczosMode=2``, the second Lanczos step, and Lanczos corrections
-   for ``NBodyG`` / ``NBodyInterAll`` are not supported.
+   ``NLanczosMode=2`` and Lanczos corrections for ``NBodyG`` /
+   ``NBodyInterAll`` are not supported.
+
+-  ``NLanczosStep``
+
+   **Type :** int-type (default value: 1)
+
+   **Description :** Selects the order of the power-Lanczos calculation.
+   [1] keeps the legacy single-step calculation and output unchanged.
+   [2] optimizes a wave function
+   :math:`(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle` in the
+   three-dimensional Krylov subspace.
+
+   The initial second-step implementation requires
+   ``NVMCCalMode=1``, ``NLanczosMode=1``, and ``NExUpdatePath=0``.
+   It supports real or complex non-FSZ pair orbitals, including the
+   existing spin and momentum projections. Its Hamiltonian is limited
+   to spin-conserving ``Transfer`` terms
+   (:math:`\sigma_1=\sigma_2`) and diagonal number-operator interactions
+   (``CoulombIntra``, ``CoulombInter``, and ``Hund``).
+   ``OrbitalGeneral`` / FSZ, BackFlow, RBM, ``PairHop``, ``Exchange``,
+   ``InterAll``, ``NBodyInterAll``, and ``NBodyG`` are rejected before
+   sampling. Second-step Green's functions are not calculated.
+   The Gutzwiller ``ProjRatio`` path is checked against an independent
+   ED oracle. Nontrivial spin and momentum projections currently have
+   runtime and structural smoke coverage, but not an independent
+   projected-ED value oracle.
+
+   The :math:`H^3` local power is evaluated by nested outer and inner
+   loops over ``Transfer`` terms, so its dominant operator count grows as
+   :math:`O(N_{\mathrm{Transfer}}^2)`. Wall-clock cost also depends on the
+   system, projection, compiler, and machine. Benchmark a small instance
+   first and use a baseline from the target Linux/HPC environment for
+   performance decisions.
+
+   A non-finite local power or moment, an invalid overlap matrix, a
+   failed generalized eigensolve, or an output error terminates the run
+   with a diagnostic. The
+   ``MVMC_LANCZOS2_TEST_NONFINITE_SAMPLE`` environment variable used
+   to test this failure path is test-only: it is compiled into
+   ``Testing=ON`` builds and is absent from normal ``Testing=OFF``
+   builds. If the overlap matrix is not positive definite,
+   the solver retries once with a relative diagonal regularization of
+   :math:`10^{-12}` and records this in ``solve_flag``.
 
 -  ``NDataIdxStart``
 

--- a/doc/en/source/output.rst
+++ b/doc/en/source/output.rst
@@ -484,11 +484,67 @@ This file is the outputted files for :math:`\langle H \rangle`,
 :math:`(\langle H^2\rangle - \langle H \rangle^2)/\langle H \rangle^2`, and the optimized parameter :math:`\alpha`
 obtained by Power Lanczos method. This file is outputted when
 ``NVMCCalMode`` = 1, ``NLanczosmode`` = 1 or 2 are set in ``ModPara``
-file. Here, xxx is the header indicated by ``CDataFileHead`` in
+file and ``NLanczosStep`` = 1. Here, xxx is the header indicated by ``CDataFileHead`` in
 ``ModPara`` file and yyy is a number given by
 ``NDataIdxStart`` :math:`\cdots` ``NDataIdxStart`` + ``NDataQtySmp``,
 where both ``NDataIdxStart`` and ``NDataQtySmp`` are defined in
 ``ModPara`` file.
+
+xxx\_ls2\_out\_yyy.dat
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This two-line file is written for ``NVMCCalMode=1``,
+``NLanczosMode=1``, and ``NLanczosStep=2``. The first line is a
+versioned header. The second line has the following 17 fields:
+``E``, ``sigma2_over_E2``, the real and imaginary parts of
+``c0``, ``c1``, and ``c2``, the real and imaginary parts of
+``alpha1=c1/c0`` and ``alpha2=c2/c0``, ``solve_flag``, ``epsilon``,
+``shift``, ``antihermitian_residual``, and ``hankel_residual``.
+The coefficients refer to the unshifted polynomial
+:math:`c_0+c_1H+c_2H^2`. ``shift`` is the total energy shift used by the
+conditioned generalized eigenproblem; it is normally equal, up to roundoff,
+to the accumulation shift recorded in ``xxx_ls2_moment_yyy.dat``.
+
+``solve_flag`` is a bit mask. Bit 0 means that the single
+:math:`10^{-12}` overlap regularization retry was used. Bit 1 means
+that ``alpha1`` and ``alpha2`` are undefined because ``c0`` is
+numerically zero; their fields contain NaN in this case.
+
+``antihermitian_residual`` measures departure from
+:math:`M'_{ba}=M_{ab}^{\prime *}`. Because every table entry is formed
+from the same sample-local outer product, this value is structurally
+near roundoff and mainly detects corruption in accumulation or reduction;
+it is not an independent physics-accuracy measure.
+``hankel_residual`` measures departures among entries with the same
+:math:`a+b`, normalized separately on each anti-diagonal by the Cauchy
+scale :math:`\max_{a+b=k}\sqrt{|M_{aa}M_{bb}|}` (and by the largest
+observed entry magnitude) before taking the maximum. A large high-order
+moment therefore cannot hide a lower-order mismatch, while an
+anti-diagonal with zero expectation still has a finite scale of the same
+order. For independent finite samples it is a statistical diagnostic
+that is expected to decrease approximately as
+:math:`O(1/\sqrt{N_{\mathrm{VMCSample}}})`; it is not a solver tolerance.
+
+xxx\_ls2\_moment\_yyy.dat
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This two-line diagnostic file accompanies ``xxx_ls2_out_yyy.dat``.
+The version-2 header contains ``basis_shift=<sigma>``, where
+:math:`\sigma=\langle H\rangle` is the globally weighted shift applied
+before moment accumulation. The data line stores all 16 centered moments
+
+.. math::
+
+   M'_{ab}=\left\langle
+   (\hat H-\sigma)^a\psi\mid(\hat H-\sigma)^b\psi
+   \right\rangle
+
+in row-major order, from :math:`M'_{00}` to :math:`M'_{33}`. Each moment
+is represented by adjacent real and imaginary fields, for 32 numeric
+fields in total. The shift and centered moments reproduce the solver
+input while avoiding the precision loss of raw high-order moments at
+large :math:`|E|`. They can be used for independent checks of
+Hermiticity and the Hankel identities.
 
 xxx\_ls\_cisajs\_yyy.dat
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/ja/source/algorithm.rst
+++ b/doc/ja/source/algorithm.rst
@@ -313,6 +313,65 @@ Power-Lanczos法での最適化パラメータ :math:`\alpha` の決定方法に
 それを解くことで :math:`\alpha` が決定されます。
 分散に関しても同様の手法で計算することが可能です。
 
+2nd power-Lanczos step
+~~~~~~~~~~~~~~~~~~~~~~
+
+``NLanczosStep=2`` では、まず4個のlocal power
+
+.. math::
+
+   F_a(x)=\frac{\langle x|\hat{H}^a|\psi\rangle}
+                 {\langle x|\psi\rangle},\qquad a=0,1,2,3
+
+をsamplingして各sampleについて保持します。sample loopの終了後にglobalな
+weighted平均エネルギー :math:`\sigma=\langle H\rangle` を求め、momentの積を
+蓄積する前に
+
+.. math::
+
+   F'_a(x)=\sum_{j=0}^{a}{a\choose j}(-\sigma)^{a-j}F_j(x)
+
+へ変換します。:math:`F'_a` は :math:`(\hat H-\sigma)^a` のlocal estimator
+です。mVMCはcentered moment行列
+
+.. math::
+
+   M'_{ab}=\sum_x \rho(x)F'_a(x)^\dagger F'_b(x)
+
+を構成します。
+このaccumulation前の中心化により、extensiveなエネルギーが大きい場合に
+:math:`\langle H^6\rangle` などのraw momentを形成して生じる桁落ちを避けます。
+必要な追加memoryはMonte Carlo sampleあたり4個のlocal powerに比例します。
+ただし、中心化が縮小するのは主に平均エネルギーによるoffsetです。
+:math:`|\langle H\rangle|` がエネルギー分布の広がりに比べて小さい場合は
+高次local powerの動的範囲が十分に縮まらないため、中心化だけで任意の系の
+数値精度が保証されるわけではありません。
+
+:math:`H^3` のlocal powerは ``Transfer`` 項のouter/inner二重loopで評価し、
+支配的なoperator数は :math:`O(N_{\mathrm{Transfer}}^2)` で増加します。
+実時間は波動関数、射影、計算環境にも依存します。
+
+:math:`X=\hat H-\sigma` とすると、
+:math:`\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\}`
+を基底としたoverlap行列、centered Hamiltonian行列、centered Hamiltonian
+二乗行列は
+
+.. math::
+
+   S_{ab}=M'_{ab},\qquad
+   H'_{ab}=\frac{M'_{a,b+1}+M'_{a+1,b}}{2},\qquad
+   G'_{ab}=M'_{a+1,b+1}
+
+です。ここで :math:`a,b=0,1,2` です。一般化固有値問題
+:math:`H'd=E'Sd` の最低解から :math:`E=E'+\sigma` を求めます。
+多項式係数はunshifted basisへ戻してから出力するため、
+:math:`|\phi\rangle=(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle`
+を得ます。出力する分散は :math:`d^\dagger Sd=1` の規格化のもとで
+:math:`d^\dagger G'd-(d^\dagger H'd)^2` としてcentered basisで評価します。
+また、:math:`c_0` が
+数値的に定義できる場合は :math:`\alpha_1=c_1/c_0` と
+:math:`\alpha_2=c_2/c_0` も出力します。
+
 物理量の計算
 ~~~~~~~~~~~~
 

--- a/doc/ja/source/algorithm.rst
+++ b/doc/ja/source/algorithm.rst
@@ -227,7 +227,7 @@ mVMC ver1.0以降ではこの表式を使用しています。
    (\Phi_{\downarrow})_{in}=\Phi_{in\downarrow}, \\
    &\Sigma={\rm diag}[\underbrace{1,\cdots,1}_{N_e/2},0,0,0],\end{aligned}
 
-として定義します。前節のように :math:`f_{ij}` (すなわち:math:`F`)が単一スレーター行列と関係づけられて
+として定義します。前節のように :math:`f_{ij}` （すなわち :math:`F`）が単一スレーター行列と関係づけられて
 いるとき、 :math:`F` の特異値分解は
 
 .. math::
@@ -247,35 +247,84 @@ mVMC ver1.0以降ではこの表式を使用しています。
 Power-Lanczos法
 ---------------
 
-このセクションでは,
-Power-Lanczos法での最適化パラメータ :math:`\alpha` の決定方法について述べます。
-また,
-ここではシングルステップのLanczos法を適用した後の物理量の計算についても説明します。
+Power-Lanczos法では、最適化済みのVMC波動関数 :math:`|\psi\rangle` に
+Hamiltonianの多項式を作用させた
 
-:math:`\alpha` の決定
-~~~~~~~~~~~~~~~~~~~~~
+.. math::
+
+   |\phi_p\rangle
+   =P_p(\hat H)|\psi\rangle
+   =\sum_{k=0}^{p}c_k\hat H^k|\psi\rangle
+
+を改良された試行波動関数とします。これは
+:math:`\{|\psi\rangle,\hat H|\psi\rangle,\ldots,\hat H^p|\psi\rangle\}`
+が張るKrylov部分空間で、エネルギーを最小にする係数 :math:`c_k` を求める方法です。
+mVMCで用いる1st stepと2nd stepの試行波動関数は、それぞれ
+
+.. math::
+
+   \begin{aligned}
+   |\phi_1\rangle &= (1+\alpha\hat H)|\psi\rangle,\\
+   |\phi_2\rangle &= (1+\alpha\hat H+\beta\hat H^2)|\psi\rangle
+   \end{aligned}
+
+です。1st stepは ``NVMCCalMode=1``、``NLanczosMode>=1``、
+``NLanczosStep=1`` で実行されます。2nd stepには
+``NVMCCalMode=1``、``NLanczosMode=1``、``NLanczosStep=2`` が必要です。
+
+以下では、まず1st stepの :math:`\alpha` の決定方法を説明し、
+次に2nd stepの :math:`\alpha,\beta` を決める変分原理と、
+その問題を数値的に安定して解くための実装を分けて説明します。
+最後に、1st stepを適用した後の物理量の計算方法を説明します。
+
+1st power-Lanczos stepと :math:`\alpha` の決定
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 最初に, 変分モンテカルロ法のサンプリングに関して簡単に説明します。
-物理量 :math:`\hat{A}` は以下の手順で計算されます:
+ここで :math:`x` は基底VMC波動関数 :math:`|\psi\rangle` からサンプリングする
+配置です。物理量 :math:`\hat{A}` の期待値は
 
 .. math::
 
    \begin{aligned}
-   &\langle \hat{A}\rangle = \frac{\langle \phi| \hat{A}|\phi \rangle}{\langle \phi| \phi \rangle} = \sum_{x} \rho(x) F(x, {\hat{A}}),\\
-   & \rho(x)=\frac{|\langle \phi|x\rangle|^2}{\langle \phi | \phi \rangle}, ~~~~F(x,  {\hat{A}}) =  \frac{\langle x| \hat{A}|\phi \rangle}{\langle x| \phi \rangle}.\end{aligned}
+   &\langle \hat{A}\rangle_\psi
+   = \frac{\langle \psi|\hat{A}|\psi\rangle}{\langle \psi|\psi\rangle}
+   = \sum_x \rho_\psi(x)F(x,\hat{A}),\\
+   &\rho_\psi(x)=\frac{|\langle x|\psi\rangle|^2}{\langle \psi|\psi\rangle},
+   \qquad
+   F(x,\hat{A})=\frac{\langle x|\hat{A}|\psi\rangle}
+                      {\langle x|\psi\rangle}
+   \end{aligned}
 
-演算子の積 :math:`\hat{A}\hat{B}` を計算する場合には,
-以下の二通りの方法があります。
+と書けます。:math:`F(x,\hat A)` は配置 :math:`x` における
+:math:`\hat A` のlocal estimatorです。演算子の積
+:math:`\hat{A}\hat{B}` の期待値には、以下の二通りの表現があります。
 
 .. math::
 
    \begin{aligned}
-   &\langle \hat{A} \hat{B}\rangle = \sum_{x} \rho(x) F(x, {\hat{A}\hat{B}}),\\
-   &\langle \hat{A} \hat{B}\rangle = \sum_{x} \rho(x) F^{\dagger}(x, {\hat{A})F(x, \hat{B}}).\end{aligned}
+   &\langle \hat{A}\hat{B}\rangle_\psi
+   = \sum_x \rho_\psi(x)F(x,\hat{A}\hat{B}),\\
+   &\langle \hat{A}\hat{B}\rangle_\psi
+   = \sum_x \rho_\psi(x)F^\dagger(x,\hat{A})F(x,\hat{B})
+   \end{aligned}
 
-後述するように, 後者の表記の方が数値的には安定します。 例えば,
-エネルギーの期待値の分散 :math:`\sigma^2=\langle (\hat{H}-\langle \hat{H}\rangle)^2\rangle` を考えてみると,
-分散は以下の2通りの方法で計算できます。
+前者は積 :math:`\hat{A}\hat{B}` 全体を1つのlocal estimatorとして
+評価する方法、後者は :math:`\hat{A}` と :math:`\hat{B}` の間に完全系
+:math:`\sum_{x} |x\rangle \langle x|` を挿入し、:math:`\hat{A}` を
+ブラ側、:math:`\hat{B}` をケット側に分割して評価する方法です。
+後者の式では :math:`\hat A` がHermite演算子であることを仮定しています。
+一般の :math:`\hat A` に対しては
+:math:`F^\dagger(x,\hat A)` を :math:`F^\dagger(x,\hat A^\dagger)` で
+置き換える必要があります。
+両者はサンプル数無限大の極限では同じ期待値を与えますが、
+有限のサンプル数では一致せず、一般に後者の方が数値的に安定です。
+以下では表記を簡単にするため :math:`\rho_\psi(x)` を
+:math:`\rho(x)` と略記します。
+
+例えば、エネルギーの分散
+:math:`\sigma^2=\langle (\hat{H}-\langle \hat{H}\rangle)^2\rangle` を
+それぞれの方法で計算すると以下のようになります。
 
 .. math::
 
@@ -285,20 +334,37 @@ Power-Lanczos法での最適化パラメータ :math:`\alpha` の決定方法に
    &= \sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}) F(x, \hat{H})- \left[ \sum_{x} \rho(x) F(x,  \hat{H})\right]^2
    \end{aligned}
 
-この定義から,
-後者の方法では常に正の値となることが保証されているのに対して,
-前者の方法では分散が正の値になることが必ずしも保証されないことが分かります。次に,
-シングルステップでのpower-Lanczos波動関数 :math:`|\phi\rangle =(1+\alpha \hat{H}) |\psi \rangle`
-に対するエネルギーの期待値とその分散を考えます。エネルギーは以下の式で計算されます：
+後者の方法では有限サンプリングでも分散が非負となることが
+保証されているのに対して、前者の方法ではそれが保証されません。
+
+次に、1st stepの波動関数
+:math:`|\phi_1\rangle =(1+\alpha \hat{H}) |\psi \rangle` の
+エネルギー期待値を考えます。:math:`\alpha` について展開すると
+(分子・分母を :math:`\langle \psi | \psi \rangle` で割っています)、
 
 .. math::
 
    \begin{aligned}
-   E_{LS}(\alpha) =\frac{\langle \phi| \hat{H} |\phi\rangle}{\langle \phi|\phi\rangle}=\frac{h_1 + \alpha(h_{2(20)} + h_{2(11)}) + \alpha^2 h_{3(12)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}},
+   E_{LS}(\alpha) =\frac{\langle \phi_1| \hat{H} |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle}
+   =\frac{\langle \hat{H} \rangle_\psi + 2\alpha \langle \hat{H}^2 \rangle_\psi + \alpha^2 \langle \hat{H}^3 \rangle_\psi}
+   {1 + 2\alpha \langle \hat{H} \rangle_\psi + \alpha^2 \langle \hat{H}^2 \rangle_\psi}
    \end{aligned}
 
-ここで, :math:`h_1`, :math:`h_{2(11)},~h_{2(20)},` and
-:math:`h_{3(12)}` を以下のように定義しました：
+となり、:math:`\hat{H}` の3次までのモーメントが必要になります。
+これらのモーメントを上述の「分割」によって推定するため、
+以下の記法を導入します:
+
+.. math::
+
+   \begin{aligned}
+   h_{n(ij)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}^i) F(x, \hat{H}^j), ~~~~ i+j=n.
+   \end{aligned}
+
+すなわち、:math:`h_{n(ij)}` は :math:`n` 次のモーメント
+:math:`\langle \hat{H}^n \rangle_\psi` を、ブラ側に :math:`\hat{H}^i`、
+ケット側に :math:`\hat{H}^j` を割り振って推定した量です
+(:math:`F(x, \hat{H}^0)=1` とし、:math:`h_{1(10)}` は :math:`h_1` と
+略記します)。計算に必要となるのは以下の量です:
 
 .. math::
 
@@ -306,39 +372,186 @@ Power-Lanczos法での最適化パラメータ :math:`\alpha` の決定方法に
    &h_1 =\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}),\\
    &h_{2(11)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}) F(x, \hat{H}),\\
    &h_{2(20)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}^2),\\
-   &h_{3(12)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{H}^2).\end{aligned}
+   &h_{3(12)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{H}^2),\\
+   &h_{4(22)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H}^2)F(x,  \hat{H}^2).\end{aligned}
 
-:math:`\frac{\partial E_{LS}(\alpha)}{\partial \alpha}=0` の条件から
-:math:`\alpha` の二次方程式が導出され,
-それを解くことで :math:`\alpha` が決定されます。
-分散に関しても同様の手法で計算することが可能です。
+:math:`h_{2(11)}` と :math:`h_{2(20)}` はどちらも
+:math:`\langle \hat{H}^2 \rangle_\psi` の推定量ですが、
+分割の仕方が異なるため有限のサンプル数では一致しません。
+また、次数をブラ側とケット側へできるだけ均等に割り振ることで、
+local estimatorとしては :math:`F(x, \hat{H}^2)` までしか現れず、
+:math:`\hat{H}^3` や :math:`\hat{H}^4` のlocal estimatorを
+直接評価する必要がなくなっています。
+
+これらの推定量を用いると、エネルギー期待値は
+
+.. math::
+
+   \begin{aligned}
+   E_{LS}(\alpha) =\frac{h_1 + \alpha(h_{2(20)} + h_{2(11)}) + \alpha^2 h_{3(12)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}}
+   \end{aligned}
+
+と評価されます。分子の :math:`\alpha` の1次の項に現れる2つの
+:math:`\langle \hat{H}^2 \rangle_\psi` は、それぞれブラ側・ケット側の
+:math:`(1+\alpha \hat{H})` に由来する別々の項であるため、
+一方を :math:`h_{2(11)}`、もう一方を :math:`h_{2(20)}` で推定しています。
+
+停留条件 :math:`\partial E_{LS}(\alpha)/\partial \alpha=0` は、
+:math:`\alpha` に関する以下の二次方程式に帰着します:
+
+.. math::
+
+   \begin{aligned}
+   \left[2 h_1 h_{3(12)} - h_{2(11)}\left(h_{2(11)}+h_{2(20)}\right)\right] \alpha^2
+   + 2\left[h_{3(12)} - h_1 h_{2(11)}\right] \alpha
+   + \left(h_{2(11)}+h_{2(20)}\right) - 2h_1^2 = 0.
+   \end{aligned}
+
+この二次方程式の2つの実数解 :math:`\alpha_{\pm}` のそれぞれについて
+:math:`E_{LS}(\alpha_{\pm})` を評価し、エネルギーが低くなる方を
+最適な :math:`\alpha` として採用します
+(判別式が負となり実数解が存在しない場合には、
+Lanczos計算はエラーとして終了します)。
+また、最適化された :math:`|\phi_1\rangle` に対するエネルギーの分散も
+
+.. math::
+
+   \begin{aligned}
+   \sigma^2_{LS}(\alpha) = \frac{\langle \phi_1| \hat{H}^2 |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle} - E_{LS}(\alpha)^2,~~~~
+   \frac{\langle \phi_1| \hat{H}^2 |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle}
+   = \frac{h_{2(11)} + 2\alpha h_{3(12)} + \alpha^2 h_{4(22)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}}
+   \end{aligned}
+
+から同様に計算できます。
 
 2nd power-Lanczos step
 ~~~~~~~~~~~~~~~~~~~~~~
 
-``NLanczosStep=2`` では、まず4個のlocal power
+変分原理による :math:`\alpha,\beta` の決定
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``NLanczosStep=2`` では、
+:math:`|\phi_2\rangle=(1+\alpha\hat H+\beta\hat H^2)|\psi\rangle`
+の変分エネルギー
 
 .. math::
 
-   F_a(x)=\frac{\langle x|\hat{H}^a|\psi\rangle}
-                 {\langle x|\psi\rangle},\qquad a=0,1,2,3
+   E_2(\alpha,\beta)
+   =\frac{\langle\phi_2|\hat H|\phi_2\rangle}
+          {\langle\phi_2|\phi_2\rangle}
 
-をsamplingして各sampleについて保持します。sample loopの終了後にglobalな
-weighted平均エネルギー :math:`\sigma=\langle H\rangle` を求め、momentの積を
-蓄積する前に
+を最小にする :math:`\alpha,\beta` を求めます。これは1st stepで
+:math:`E_{LS}(\alpha)` の停留条件から :math:`\alpha` を決めることの
+直接の拡張です。
+
+この最小化は、Krylov基底
 
 .. math::
 
-   F'_a(x)=\sum_{j=0}^{a}{a\choose j}(-\sigma)^{a-j}F_j(x)
+   |v_a\rangle=\hat H^a|\psi\rangle,\qquad a=0,1,2
 
-へ変換します。:math:`F'_a` は :math:`(\hat H-\sigma)^a` のlocal estimator
+における一般化固有値問題として表せます。overlap行列とHamiltonian行列を
+
+.. math::
+
+   S_{ab}=\frac{\langle v_a|v_b\rangle}{\langle\psi|\psi\rangle},
+   \qquad
+   {\cal H}_{ab}
+   =\frac{\langle v_a|\hat H|v_b\rangle}{\langle\psi|\psi\rangle}
+
+と定義します。:math:`|v_a\rangle` の定義から、これらの行列要素は
+基底波動関数に対するHamiltonianのモーメントそのものです:
+
+.. math::
+
+   S_{ab}=\langle \hat H^{a+b}\rangle_\psi,
+   \qquad
+   {\cal H}_{ab}=\langle \hat H^{a+b+1}\rangle_\psi.
+
+したがって2nd stepでは :math:`\langle \hat H^5\rangle_\psi` までの
+モーメント(後述する分散の評価まで含めると
+:math:`\langle \hat H^6\rangle_\psi` まで)が必要になります。
+:math:`\boldsymbol{c}=(c_0,c_1,c_2)^{\mathsf T}` とすると、
+
+.. math::
+
+   |\phi_2\rangle=\sum_{a=0}^{2}c_a|v_a\rangle,\qquad
+   E_2(\boldsymbol{c})
+   =\frac{\boldsymbol{c}^\dagger{\cal H}\boldsymbol{c}}
+          {\boldsymbol{c}^\dagger S\boldsymbol{c}}.
+
+したがって停留条件は
+
+.. math::
+
+   {\cal H}\boldsymbol{c}=E_2 S\boldsymbol{c}
+
+となり、最低固有値に対応する固有ベクトルが最適な係数を与えます。
+固有ベクトルの全体のスケールは任意なので、
+:math:`\alpha=c_1/c_0`、:math:`\beta=c_2/c_0` とすれば、
+冒頭の :math:`(1+\alpha\hat H+\beta\hat H^2)|\psi\rangle`
+という表式に戻ります。以上が2nd power-Lanczos stepの原理です。
+なお、:math:`c_2=0` に固定して :math:`c_1/c_0` のみを最適化すると、
+この一般化固有値問題は1st stepの二次方程式と等価になります。
+つまり2nd stepは、1st stepと同じ変分原理を、Krylov部分空間の次元を
+2から3へ広げて適用したものです。
+
+数値的安定性のための実装
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ここからは上の変分原理を変えるものではなく、同じ行列要素をMonte Carlo
+sampleから安定に評価し、一般化固有値問題を安定に解くための手順です。
+
+まず、上で定義したlocal estimator :math:`F(x,\hat A)` へ
+:math:`\hat A=\hat H^a` を代入したlocal power
+
+.. math::
+
+   F_a(x)\equiv F(x,\hat H^a)
+   =\frac{\langle x|\hat H^a|\psi\rangle}
+          {\langle x|\psi\rangle},
+   \qquad a=0,1,2,3
+
+を各配置 :math:`x` で計算し、Monte Carlo sampleごとに保持します。
+:math:`F_0(x)=1`、:math:`F_1(x)` は通常のlocal energyであり、
+:math:`F_2(x)` と :math:`F_3(x)` はそれぞれ :math:`\hat H^2` と
+:math:`\hat H^3` のlocal estimatorです。これらは試行波動関数そのものではなく、
+:math:`S`、:math:`{\cal H}` および分散計算用の
+Hamiltonian二乗行列をMonte Carlo平均から構成するための量です。
+
+sample loopの終了後に、基底VMC波動関数のglobalなweighted平均エネルギー
+:math:`E_{\rm shift}=\langle\hat H\rangle_\psi` を求め、
+:math:`X=\hat H-E_{\rm shift}` とします。この置換は
+
+.. math::
+
+   {\rm span}\{|\psi\rangle,\hat H|\psi\rangle,\hat H^2|\psi\rangle\}
+   =
+   {\rm span}\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\}
+
+を満たすため、変分空間と最適解を変えません。これは数値的安定性のための
+基底変換です。momentの積を蓄積する前にlocal powerを
+
+.. math::
+
+   \widetilde F_a(x)
+   =\sum_{j=0}^{a}{a\choose j}(-E_{\rm shift})^{a-j}F_j(x)
+
+へ変換します。:math:`\widetilde F_a` は :math:`X^a` のlocal estimator
 です。mVMCはcentered moment行列
 
 .. math::
 
-   M'_{ab}=\sum_x \rho(x)F'_a(x)^\dagger F'_b(x)
+   \widetilde M_{ab}
+   =\sum_x \rho(x)\widetilde F_a(x)^\dagger\widetilde F_b(x)
 
-を構成します。
+を構成します。実装は :math:`a,b=0,\ldots,3` の全組合せを保持します。
+各 :math:`\widetilde M_{ab}` は、1st stepの :math:`h_{n(ij)}` と同様に、
+:math:`n=a+b` 次のモーメント :math:`\langle X^{a+b}\rangle_\psi` を
+ブラ側 :math:`\widetilde F_a^\dagger` とケット側
+:math:`\widetilde F_b` に分割した推定量です。各側の次数が最大3なので、
+:math:`\widetilde M_{33}` として :math:`X^6` のモーメントまで表しながら、
+local powerとして必要なのは :math:`F_3` までです。
 このaccumulation前の中心化により、extensiveなエネルギーが大きい場合に
 :math:`\langle H^6\rangle` などのraw momentを形成して生じる桁落ちを避けます。
 必要な追加memoryはMonte Carlo sampleあたり4個のlocal powerに比例します。
@@ -347,51 +560,143 @@ weighted平均エネルギー :math:`\sigma=\langle H\rangle` を求め、moment
 高次local powerの動的範囲が十分に縮まらないため、中心化だけで任意の系の
 数値精度が保証されるわけではありません。
 
-量子射影がidentity（``NQPFull=1``）の場合、:math:`H^3` のlocal powerは
-``Transfer`` 項のouter/inner二重loopで評価し、支配的なoperator数は
-:math:`O(N_{\mathrm{Transfer}}^2)` で増加します。非自明な量子射影
-（``NQPFull>1``）では、2nd power-Lanczosは射影された
-:math:`H\,CACA` 行列要素を元configurationから直接縮約します。
-この縮約は内部にもう1段の ``Transfer`` loopを含むため、この経路の支配的な
-operator数は :math:`O(N_{\mathrm{Transfer}}^3)` となり、
-``GreenFuncN`` の縮約量は ``NQPFull`` にも比例します。そのため実時間は
-波動関数と計算環境だけでなく、射影設定にも強く依存します。
-
-:math:`X=\hat H-\sigma` とすると、
-:math:`\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\}`
-を基底としたoverlap行列、centered Hamiltonian行列、centered Hamiltonian
-二乗行列は
+同じsampleから構成する :math:`\widetilde M_{ab}` と
+:math:`\widetilde M_{ba}^\dagger` は各sampleの寄与ごとに等しいため、
+有限sampleであること自体は両者の差を生みません。ただし、浮動小数点演算や
+並列reductionの丸め誤差によって小さな非Hermite成分が生じ得るため、
+mVMCはmoment行列をHermite化します。一方、
+:math:`a+b=c+d` を満たす異なる分割
+:math:`\widetilde M_{ab}` と :math:`\widetilde M_{cd}` の差には
+有限sampleの統計誤差が含まれ、``hankel_residual`` として出力されます。
+その後、centered Krylov基底のoverlap行列、
+Hamiltonian行列、Hamiltonian二乗行列を
 
 .. math::
 
-   S_{ab}=M'_{ab},\qquad
-   H'_{ab}=\frac{M'_{a,b+1}+M'_{a+1,b}}{2},\qquad
-   G'_{ab}=M'_{a+1,b+1}
+   \widetilde S_{ab}=\widetilde M_{ab},\qquad
+   \widetilde{\cal H}_{ab}
+   =\frac{\widetilde M_{a,b+1}+\widetilde M_{a+1,b}}{2},\qquad
+   \widetilde G_{ab}=\widetilde M_{a+1,b+1}
 
-です。ここで :math:`a,b=0,1,2` です。一般化固有値問題
-:math:`H'd=E'Sd` の最低解から :math:`E=E'+\sigma` を求めます。
-多項式係数はunshifted basisへ戻してから出力するため、
-:math:`|\phi\rangle=(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle`
-を得ます。出力する分散は :math:`d^\dagger Sd=1` の規格化のもとで
-:math:`d^\dagger G'd-(d^\dagger H'd)^2` としてcentered basisで評価します。
-また、:math:`c_0` が
-数値的に定義できる場合は :math:`\alpha_1=c_1/c_0` と
-:math:`\alpha_2=c_2/c_0` も出力します。
+と構成します。ここで :math:`a,b=0,1,2` です。
+:math:`\widetilde{\cal H}` の二つのmomentを平均することも、
+有限sampleでのHermite性を保つための処理です。
 
-物理量の計算
-~~~~~~~~~~~~
+さらに各基底ベクトルのノルムの差を抑えるため、
 
-最適化パラメータ :math:`\alpha` を用いることで,
-演算子 :math:`\hat{A}` の期待値を以下の式から計算することが出来ます：
+.. math::
+
+   D_{aa}=\frac{1}{\sqrt{\widetilde S_{aa}}}
+
+による対角scale変換を行い、
+
+.. math::
+
+   (D\widetilde{\cal H}D)\boldsymbol{u}
+   =E_X(D\widetilde S D)\boldsymbol{u}
+
+を解きます。overlap行列の分解に失敗した場合だけ、
+:math:`D\widetilde S D` の対角へ小さな正則化項を加えて再試行します。
+中心化、Hermite化、対角scale変換およびこのフォールバックの正則化が、
+原理とは別に導入されている数値安定化です。
+
+最低固有値から元のHamiltonianのエネルギー
+:math:`E=E_X+E_{\rm shift}` を得ます。centered basisの係数を
+:math:`\boldsymbol{d}=(d_0,d_1,d_2)^{\mathsf T}` とすると、
 
 .. math::
 
    \begin{aligned}
-   A_{LS}(\alpha) =\frac{\langle \phi| \hat{A} |\phi\rangle}{\langle \phi|\phi\rangle}=\frac{A_0 + \alpha(A_{1(10)} + A_{1(01)}) + \alpha^2 A_{2(11)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}},
+   c_0 &= d_0-E_{\rm shift}d_1+E_{\rm shift}^2d_2,\\
+   c_1 &= d_1-2E_{\rm shift}d_2,\\
+   c_2 &= d_2
    \end{aligned}
 
-ここで, :math:`A_0`, :math:`A_{1(10)},~A_{1(01)},` and
-:math:`A_{2(11)}` は
+によってunshifted basisへ戻します。mVMCは :math:`c_0,c_1,c_2` と、
+上で定義した :math:`\alpha,\beta` をそれぞれ
+:math:`\alpha_1,\alpha_2` として出力します。分散は
+:math:`\boldsymbol{d}^\dagger\widetilde S\boldsymbol{d}=1` の規格化のもとで
+
+.. math::
+
+   \sigma_E^2
+   =\boldsymbol{d}^\dagger\widetilde G\boldsymbol{d}
+    -(\boldsymbol{d}^\dagger\widetilde{\cal H}\boldsymbol{d})^2
+
+としてcentered basisで評価します。
+
+計算量
+^^^^^^
+
+2nd stepで新たに必要になるのは、sampleごとのlocal power
+:math:`F_2(x)` と :math:`F_3(x)` の評価であり、このうち
+:math:`F_3(x)=\langle x|\hat H^3|\psi\rangle/\langle x|\psi\rangle`
+が計算量を支配します。
+
+現在の2nd step実装では、Hamiltonianはspinを保存する ``Transfer`` 項と
+number-operator型の対角相互作用に限定されています。
+:math:`F_3` の評価では、非対角な ``Transfer`` 項に対する
+outer/innerの二重loopを回します。2つの ``Transfer`` 項の積は二体演算子
+
+.. math::
+
+   CACA \equiv
+   c_{i\sigma}^\dagger c_{j\sigma} c_{k\tau}^\dagger c_{l\tau}
+
+の形にまとまるため、二重loopで生成される
+:math:`O(N_{\mathrm{Transfer}}^2)` 個の ``CACA`` のそれぞれについて、
+残りの :math:`\hat H` を含む行列要素
+:math:`\langle \psi|\hat H\,CACA|x\rangle/\langle \psi|x\rangle`
+を評価することになります。
+
+量子射影がidentity（``NQPFull=1``）の場合は、``CACA`` を
+サンプリングされた配置 :math:`x` に作用させて一時的な配置
+:math:`x'` を作り、:math:`x'` における :math:`\hat H` の
+local estimatorに重なり比
+:math:`\langle \psi|CACA|x\rangle/\langle \psi|x\rangle` を掛ける、
+という分解で評価できます。二重loopが生成する ``CACA`` の個数は
+:math:`O(N_{\mathrm{Transfer}}^2)` ですが、各 ``CACA`` に対する
+Hamiltonianのlocal estimatorがさらに ``Transfer`` loopを含むため、
+この経路の最悪計算量も
+:math:`O(N_{\mathrm{Transfer}}^3)` です。ただし、通常のlocal
+estimatorとrank-two updateを利用でき、``NQPFull`` に比例する
+``GreenFuncN`` の評価を避けられるため、非自明な射影の経路より
+計算量の係数は小さくなります。
+
+非自明な量子射影（``NQPFull>1``）では、この分解は複数の量子射影成分の
+和を正しく保てません。そのため2nd power-Lanczosでは、
+:math:`\hat H=\sum_\mu h_\mu\hat O_\mu` の各項について
+:math:`\hat O_\mu\,CACA` を一つの多体演算子として扱い、
+``GreenFuncN`` で対応する多体Green関数を元の配置 :math:`x` から
+量子射影成分を含めて評価し、係数 :math:`h_\mu` 付きで加算します。
+この直接評価では、各 :math:`\hat O_\mu\,CACA` の多体Green関数を
+求める際に内部へもう1段の ``Transfer`` loopが加わるため、
+この経路の支配的なoperator数は :math:`O(N_{\mathrm{Transfer}}^3)`
+となり、``GreenFuncN`` の計算量は ``NQPFull`` にも比例します。
+したがって実時間は波動関数と計算環境だけでなく、
+射影設定にも強く依存します。
+
+1st power-Lanczos stepでの物理量の計算
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``NLanczosMode=2`` の場合には、最適化されたパラメータ :math:`\alpha` を
+用いて、1st step波動関数 :math:`|\phi_1\rangle` に対する物理量
+(一体・二体グリーン関数)を計算します
+(2nd stepでのGreen関数計算は未対応です)。
+演算子 :math:`\hat{A}` の期待値の分子を :math:`\alpha` について
+展開すると
+
+.. math::
+
+   \begin{aligned}
+   \langle \phi_1| \hat{A} |\phi_1\rangle = \langle \psi| \hat{A} |\psi\rangle
+   + \alpha \langle \psi| \hat{H}\hat{A} |\psi\rangle
+   + \alpha \langle \psi| \hat{A}\hat{H} |\psi\rangle
+   + \alpha^2 \langle \psi| \hat{H}\hat{A}\hat{H} |\psi\rangle
+   \end{aligned}
+
+となります。エネルギーの場合と同様に、各項をブラ側の :math:`\hat{H}^i` と
+ケット側の :math:`\hat{A}\hat{H}^j` に分割して推定します:
 
 .. math::
 
@@ -401,5 +706,18 @@ operator数は :math:`O(N_{\mathrm{Transfer}}^3)` となり、
    &A_{1(01)}=\sum_{x} \rho(x) F(x, \hat{A}\hat{H}),\\
    &A_{2(11)}=\sum_{x} \rho(x) F^{\dagger}(x,  \hat{H})F(x,  \hat{A}\hat{H}).\end{aligned}
 
-として定義される変数を表します。プログラムでは,
-この表式に基づき一体グリーン関数および二体グリーン関数の計算を行っています。
+ここで添字 :math:`n(ij)` は、エネルギーの場合と同様に、
+:math:`\hat{H}` の合計次数 :math:`n=i+j` と、
+ブラ側(:math:`\hat{H}^i`)・ケット側(:math:`\hat{A}\hat{H}^j`)への
+割り振りを表します。これらの推定量を用いると、期待値は
+
+.. math::
+
+   \begin{aligned}
+   A_{LS}(\alpha) =\frac{\langle \phi_1| \hat{A} |\phi_1\rangle}{\langle \phi_1|\phi_1\rangle}=\frac{A_0 + \alpha(A_{1(10)} + A_{1(01)}) + \alpha^2 A_{2(11)}}{1 + 2\alpha h_1 + \alpha^2 h_{2(11)}}
+   \end{aligned}
+
+と計算されます。分母はエネルギーの場合と同じ規格化因子
+:math:`\langle \phi_1 | \phi_1 \rangle` です。プログラムでは、
+この表式に基づき一体グリーン関数および二体グリーン関数の計算を
+行っています。

--- a/doc/ja/source/algorithm.rst
+++ b/doc/ja/source/algorithm.rst
@@ -347,9 +347,15 @@ weighted平均エネルギー :math:`\sigma=\langle H\rangle` を求め、moment
 高次local powerの動的範囲が十分に縮まらないため、中心化だけで任意の系の
 数値精度が保証されるわけではありません。
 
-:math:`H^3` のlocal powerは ``Transfer`` 項のouter/inner二重loopで評価し、
-支配的なoperator数は :math:`O(N_{\mathrm{Transfer}}^2)` で増加します。
-実時間は波動関数、射影、計算環境にも依存します。
+量子射影がidentity（``NQPFull=1``）の場合、:math:`H^3` のlocal powerは
+``Transfer`` 項のouter/inner二重loopで評価し、支配的なoperator数は
+:math:`O(N_{\mathrm{Transfer}}^2)` で増加します。非自明な量子射影
+（``NQPFull>1``）では、2nd power-Lanczosは射影された
+:math:`H\,CACA` 行列要素を元configurationから直接縮約します。
+この縮約は内部にもう1段の ``Transfer`` loopを含むため、この経路の支配的な
+operator数は :math:`O(N_{\mathrm{Transfer}}^3)` となり、
+``GreenFuncN`` の縮約量は ``NQPFull`` にも比例します。そのため実時間は
+波動関数と計算環境だけでなく、射影設定にも強く依存します。
 
 :math:`X=\hat H-\sigma` とすると、
 :math:`\{|\psi\rangle,X|\psi\rangle,X^2|\psi\rangle\}`

--- a/doc/ja/source/expert.rst
+++ b/doc/ja/source/expert.rst
@@ -547,14 +547,27 @@ ModParaファイル (modpara.def)
    ``Exchange``、``InterAll``、``NBodyInterAll``、``NBodyG`` は
    sampling開始前にエラー終了します。2nd stepのGreen関数は計算しません。
    Gutzwillerの ``ProjRatio`` 経路は独立ED oracleで値を検証しています。
-   非自明なスピン射影・運動量射影はruntimeおよび構造のsmoke testまでで、
+   非自明な :math:`k=\pi` 運動量射影は、real/complexの独立projected ED
+   value oracleで検証しています。real oracleはserial、MPI、OpenMP経路を
+   対象とし、complex oracleは現時点でserial経路を対象とします。
+   非自明なスピン射影はruntimeおよび構造のsmoke testまでで、
    projected EDによる独立な値oracleは現時点ではありません。
 
-   :math:`H^3` のlocal powerは ``Transfer`` 項に対するouter/inner二重loopで
-   評価するため、支配的なoperator数は :math:`O(N_{\mathrm{Transfer}}^2)` で
-   増加します。実時間は系・射影・compiler・計算機に依存するので、実サイズの
-   計算前に小さい系で測定し、性能判断には対象Linux/HPC環境のbaselineを使用して
-   ください。
+   ``NQPFull=1`` の場合、:math:`H^3` のlocal powerは ``Transfer`` 項に対する
+   outer/inner二重loopで評価するため、支配的なoperator数は
+   :math:`O(N_{\mathrm{Transfer}}^2)` で増加します。非自明な量子射影
+   （``NQPFull>1``）では、射影された :math:`H\,CACA` 行列要素の直接縮約経路に
+   もう1段の ``Transfer`` loopが加わります。そのため支配的なoperator数は
+   :math:`O(N_{\mathrm{Transfer}}^3)` となり、``GreenFuncN`` の縮約量は
+   ``NQPFull`` にも比例します。
+
+   したがって、射影により2nd stepの測定時間が大幅に増える場合があります。
+   実サイズの計算前に、実計算と同じ ``NSPGaussLeg`` と ``NMPTrans`` を使った
+   小さい系で測定し、性能判断には対象Linux/HPC環境のbaselineを使用してください。
+   source treeにある非CIの手動probe
+   ``test/python/lanczos2_cost_probe.py`` は ``--nspgaussleg`` と
+   ``--nmptrans`` のgridを受け取り、JSON出力へ ``NQPFull``、Timer 41、
+   Timer 95を記録します。
 
    local powerまたはmomentの非有限値、不正なoverlap行列、一般化固有値
    solverの失敗、出力エラーを検出すると診断を表示して終了します。

--- a/doc/ja/source/expert.rst
+++ b/doc/ja/source/expert.rst
@@ -410,6 +410,7 @@ ModParaファイル (modpara.def)
     --------------------
     NVMCCalMode    0
     NLanczosMode   0
+    NLanczosStep   1
     --------------------
     NDataIdxStart  1
     NDataQtySmp    1
@@ -524,8 +525,46 @@ ModParaファイル (modpara.def)
    のみ対応します。この場合、Hamiltonian は ``Transfer`` と
    number-operator 型の対角相互作用（``CoulombIntra``,
    ``CoulombInter``, ``Hund``）に限定されます。``NLanczosMode=2``、
-   2nd Lanczos、``NBodyG`` / ``NBodyInterAll`` の Lanczos 補正は
-   未対応です。
+   ``NBodyG`` / ``NBodyInterAll`` の Lanczos 補正は未対応です。
+
+-  ``NLanczosStep``
+
+   **形式 :** int型 (デフォルト値 = 1)
+
+   **説明 :** Power-Lanczos計算の次数を指定します。[1] は従来の
+   single-step計算および出力を変更せずに使用します。[2] は3次元Krylov
+   部分空間で
+   :math:`(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle`
+   を最適化します。
+
+   初期実装の2nd stepには ``NVMCCalMode=1``、``NLanczosMode=1``、
+   ``NExUpdatePath=0`` が必要です。実数または複素数のnon-FSZペア軌道に
+   対応し、既存のスピン射影・運動量射影を使用できます。Hamiltonianは
+   spinを保存する ``Transfer`` 項（:math:`\sigma_1=\sigma_2`）と
+   number-operator型の対角相互作用
+   （``CoulombIntra``, ``CoulombInter``, ``Hund``）に限定されます。
+   ``OrbitalGeneral`` / FSZ、BackFlow、RBM、``PairHop``、
+   ``Exchange``、``InterAll``、``NBodyInterAll``、``NBodyG`` は
+   sampling開始前にエラー終了します。2nd stepのGreen関数は計算しません。
+   Gutzwillerの ``ProjRatio`` 経路は独立ED oracleで値を検証しています。
+   非自明なスピン射影・運動量射影はruntimeおよび構造のsmoke testまでで、
+   projected EDによる独立な値oracleは現時点ではありません。
+
+   :math:`H^3` のlocal powerは ``Transfer`` 項に対するouter/inner二重loopで
+   評価するため、支配的なoperator数は :math:`O(N_{\mathrm{Transfer}}^2)` で
+   増加します。実時間は系・射影・compiler・計算機に依存するので、実サイズの
+   計算前に小さい系で測定し、性能判断には対象Linux/HPC環境のbaselineを使用して
+   ください。
+
+   local powerまたはmomentの非有限値、不正なoverlap行列、一般化固有値
+   solverの失敗、出力エラーを検出すると診断を表示して終了します。
+   非有限値のエラー経路を検証する環境変数
+   ``MVMC_LANCZOS2_TEST_NONFINITE_SAMPLE`` はテスト専用です。
+   ``Testing=ON`` のbuildだけにコンパイルされ、通常の
+   ``Testing=OFF`` buildには故障注入コードが含まれません。
+   overlap行列が正定値でない場合は、相対対角regularization
+   :math:`10^{-12}` を加えて1回だけ再試行し、結果を ``solve_flag`` に
+   記録します。
 
 -  ``NDataIdxStart``
 

--- a/doc/ja/source/output.rst
+++ b/doc/ja/source/output.rst
@@ -441,9 +441,61 @@ xxx\_ls\_out\_yyy.dat
 Power Lanczos法により求めた :math:`\langle H \rangle`,
 :math:`(\langle H^2\rangle - \langle H \rangle^2)/\langle H \rangle^2` および最適化パラメータ :math:`\alpha` の順に出力されます。
 ``ModPara`` 指定ファイルで ``NVMCCalMode`` =1, ``NLanczosmode`` =1,
-2に設定することで計算されます。
+2、``NLanczosStep`` = 1に設定することで計算されます。
 xxxには ``CDataFileHead`` で指定されるヘッダが、yyyには ``ModPara`` ファイルの ``NDataIdxStart``,
 ``NDataQtySmp`` に従い ``NDataIdxStart`` :math:`\cdots` ``NDataIdxStart`` + ``NDataQtySmp`` の順に記載されます。
+
+xxx\_ls2\_out\_yyy.dat
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``NVMCCalMode=1``、``NLanczosMode=1``、``NLanczosStep=2`` の場合に
+出力する2行のファイルです。1行目はversion付きheaderです。2行目には次の
+17項目を出力します: ``E``、``sigma2_over_E2``、``c0``・``c1``・
+``c2`` の実部と虚部、``alpha1=c1/c0``・``alpha2=c2/c0`` の実部と
+虚部、``solve_flag``、``epsilon``、``shift``、
+``antihermitian_residual``、``hankel_residual``。
+係数はunshiftedな多項式 :math:`c_0+c_1H+c_2H^2` に対する値です。
+``shift`` はconditioned一般化固有値問題で使用した全energy shiftであり、通常は
+丸め誤差の範囲で ``xxx_ls2_moment_yyy.dat`` に記録するaccumulation shiftと
+一致します。
+
+``solve_flag`` はbit maskです。bit 0は :math:`10^{-12}` のoverlap
+regularizationによる1回だけの再試行を使用したことを表します。bit 1は
+``c0`` が数値的に0で ``alpha1``・``alpha2`` を定義できないことを表し、
+この場合のalpha欄にはNaNを出力します。
+
+``antihermitian_residual`` は
+:math:`M'_{ba}=M_{ab}^{\prime *}` からのずれです。全ての表要素を同じ
+sample-local outer productから構成するため、構造上ほぼ丸め誤差となり、
+主にaccumulationやreductionの破損検出に使用します。独立な物理精度の指標
+ではありません。``hankel_residual`` は :math:`a+b` が同じ要素間のずれを
+各反対角ごとに
+:math:`\max_{a+b=k}\sqrt{|M_{aa}M_{bb}|}` というCauchyスケール
+（および観測要素の最大絶対値）で正規化してから、その最大値を取ります。
+このため高次momentが低次の不一致を隠さず、期待値が0の反対角にも同次数の
+有限なスケールを与えます。独立な有限sampleでは
+:math:`O(1/\sqrt{N_{\mathrm{VMCSample}}})` 程度で減少する統計的診断であり、
+solver toleranceではありません。
+
+xxx\_ls2\_moment\_yyy.dat
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``xxx_ls2_out_yyy.dat`` と同時に出力する2行の診断用ファイルです。
+version 2のheaderには ``basis_shift=<sigma>`` を記録します。ここで
+:math:`\sigma=\langle H\rangle` はmoment accumulation前に適用するglobalな
+weighted shiftです。data行には16個のcentered moment
+
+.. math::
+
+   M'_{ab}=\left\langle
+   (\hat H-\sigma)^a\psi\mid(\hat H-\sigma)^b\psi
+   \right\rangle
+
+を :math:`M'_{00}` から :math:`M'_{33}` までrow-major順で出力します。
+各momentは実部・虚部の2項目で表し、数値項目は合計32個です。
+shiftとcentered momentによりsolver入力を再現でき、:math:`|E|` が大きい場合の
+raw高次momentの桁落ちを避けられます。HermiticityおよびHankel恒等式の独立検証
+にも使用できます。
 
 xxx\_ls\_cisajs\_yyy.dat
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -11,7 +11,8 @@ include_directories("${STDFACE_DIR}/src")
 add_definitions(-DMEXP=19937)
 
 set(SOURCES_vmcmain
-        vmcmain.c physcal_lanczos.c splitloop.c 
+        vmcmain.c physcal_lanczos.c physcal_lanczos2.c
+        lanczos2_contract.c splitloop.c
  )
 
 set(SOURCES_sfmt
@@ -23,6 +24,10 @@ link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../pfapack)
 add_executable(vmcdry.out vmcdry.c)
 target_link_libraries(vmcdry.out StdFace_mvmc m)
 add_executable(vmc.out ${SOURCES_vmcmain} ${SOURCES_sfmt})
+if(Testing)
+  # Compile deliberate fault injection only into test-enabled builds.
+  target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION)
+endif(Testing)
 target_link_libraries(vmc.out StdFace_mvmc m)
 target_link_libraries(vmc.out pfapack)
 target_link_libraries(vmc.out ltl2inv)

--- a/src/mVMC/average.c
+++ b/src/mVMC/average.c
@@ -28,6 +28,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #include <complex.h>
 #include "global.h"
 #include "average.h"
+#include "physcal_lanczos2.h"
 #ifndef _SRC_AVERAGE
 #define _SRC_AVERAGE
 
@@ -222,7 +223,7 @@ void WeightAverageGreenFunc(MPI_Comm comm) {
     weightAverageReduce_fcmp(NNBodyG,vec,comm);
   }
 
-  if(NLanczosMode>0){
+  if(NLanczosMode>0 && NLanczosStep==1){
     /* QQQQ */
     n = NLSHam*NLSHam*NLSHam*NLSHam;
     //if(AllComplexFlag==0 && iFlgOrbitalGeneral==0){
@@ -245,6 +246,43 @@ void WeightAverageGreenFunc(MPI_Comm comm) {
         vec = QCisAjsQ;
         weightAverageReduce_fcmp(n, vec, comm);
       }
+    }
+  }
+  if(NLanczosMode>0 && NLanczosStep==2){
+    Lanczos2SolveStatus lanczos2Status;
+    int rank = 0;
+    MPI_Comm_rank(comm,&rank);
+    LS2MomentBasisShift = creal(Etot);
+    /*
+     * Every rank must center its local moments in the same basis before
+     * their reduction.  WeightAverageWE already all-reduces Etot; keep
+     * that invariant local to this use site as defensive hardening.
+     */
+    SafeMpiBcast(&LS2MomentBasisShift,1,comm);
+    if(AllComplexFlag==0){
+      lanczos2Status = BuildLanczos2ShiftedMomentReal(
+          LS2Moment_real,LS2SamplePower_real,LS2SampleWeight,
+          LS2SampleValid,(size_t)NVMCSample,LS2MomentBasisShift);
+      if(lanczos2Status != LANCZOS2_SOLVE_OK) {
+        fprintf(stderr,
+                "Error: Lanczos2 shifted moment construction failed on "
+                "rank %d: %s.\n",
+                rank,Lanczos2SolveError(lanczos2Status));
+        MPI_Abort(comm,EXIT_FAILURE);
+      }
+      weightAverageReduce_real(LANCZOS2_MOMENT_COUNT,LS2Moment_real,comm);
+    }else{
+      lanczos2Status = BuildLanczos2ShiftedMomentComplex(
+          LS2Moment,LS2SamplePower,LS2SampleWeight,LS2SampleValid,
+          (size_t)NVMCSample,LS2MomentBasisShift);
+      if(lanczos2Status != LANCZOS2_SOLVE_OK) {
+        fprintf(stderr,
+                "Error: Lanczos2 shifted moment construction failed on "
+                "rank %d: %s.\n",
+                rank,Lanczos2SolveError(lanczos2Status));
+        MPI_Abort(comm,EXIT_FAILURE);
+      }
+      weightAverageReduce_fcmp(LANCZOS2_MOMENT_COUNT,LS2Moment,comm);
     }
   }
   return;

--- a/src/mVMC/include/blas_externs.h
+++ b/src/mVMC/include/blas_externs.h
@@ -42,9 +42,11 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #define M_DGETRF dgetrf_
 #define M_DGETRI dgetri_
 #define M_DPOSV  dposv_
+#define M_DSYGV  dsygv_
 #define M_ZGETRF zgetrf_
 #define M_ZGETRI zgetri_
 #define M_ZPOSV  zposv_
+#define M_ZHEGV  zhegv_
 
 // Pfapack
 #define M_DSKPFA dskpfa_
@@ -92,6 +94,10 @@ extern void M_ZAXPY(const int *n, const double complex *alpha, const double comp
 // LAPACK
 extern void M_DPOSV(const char* uplo, const int* n, const int* nrhs, double* a,
                     const int* lda, double* b, const int* ldb, int* info );
+extern void M_DSYGV(const int* itype, const char* jobz, const char* uplo,
+                    const int* n, double* a, const int* lda, double* b,
+                    const int* ldb, double* w, double* work,
+                    const int* lwork, int* info);
 extern void M_DGETRF(const int* m, const int* n, double* a, const int* lda,
                      int* ipiv, int* info );
 extern void M_DGETRI(const int* n, double* a, const int* lda,
@@ -100,6 +106,11 @@ extern void M_DGETRI(const int* n, double* a, const int* lda,
 extern void M_ZPOSV(const char* uplo, const int* n, const int* nrhs,
                     double complex* a, const int* lda, double complex* b,
                     const int* ldb, int* info );
+extern void M_ZHEGV(const int* itype, const char* jobz, const char* uplo,
+                    const int* n, double complex* a, const int* lda,
+                    double complex* b, const int* ldb, double* w,
+                    double complex* work, const int* lwork, double* rwork,
+                    int* info);
 extern void M_ZGETRF(const int* m, const int* n, double complex* a,
                      const int* lda, int* ipiv, int* info );
 extern void M_ZGETRI(const int* n, double complex* a, const int* lda,

--- a/src/mVMC/include/global.h
+++ b/src/mVMC/include/global.h
@@ -41,6 +41,7 @@ int NVMCCalMode; /* calculation mode
                     1: calculation of expectation values */
 int NLanczosMode; /* mode of the single Lanczos step
                      0: none, 1: only energy, 2: Green functions */
+int NLanczosStep; /* polynomial order of the Lanczos wave function: 1 or 2 */
 
 int NStoreO; /* choice of store O: 0-> normal other-> store  */
 int NSRCG; /* choice of solver for Sx=g: 0-> (Sca)LAPACK other-> CG  */
@@ -339,6 +340,16 @@ double complex *LSLQ; /* [NLSHam][NLSHam]*/                      //TBC
 double *QQQQ_real; /* QQQQ[NLSHam][NLSHam][NLSHam][NLSHam]*/  //TBC
 double *LSLQ_real; /* [NLSHam][NLSHam]*/                      //TBC
 
+double complex *LS2Moment; /* row-major [4][4], NLanczosStep==2 */
+double complex *LS2LocalPower; /* [I,H,H^2,H^3] */
+double complex *LS2SamplePower; /* [NVMCSample][I,H,H^2,H^3] */
+double *LS2Moment_real; /* row-major [4][4], NLanczosStep==2 */
+double *LS2LocalPower_real; /* [I,H,H^2,H^3] */
+double *LS2SamplePower_real; /* [NVMCSample][I,H,H^2,H^3] */
+double *LS2SampleWeight; /* [NVMCSample] */
+unsigned char *LS2SampleValid; /* [NVMCSample] */
+double LS2MomentBasisShift; /* basis is (H-LS2MomentBasisShift)^k */
+
 double complex *QCisAjsQ; /* QCisAjsQ[NLSHam][NLSHam][NCisAjs]*/ //TBC
 double complex *QCisAjsCktAltQ; /* QCisAjsCktAltQ[NLSHam][NLSHam][NCisAjsCktAlt]*/ //TBC
 double complex *QCisAjsCktAltQDC; /* QCisAjsCktAltQ[NLSHam][NLSHam][NCisAjsCktAlt]
@@ -369,6 +380,8 @@ FILE *FileLSQCisAjsCktAltQ;
 FILE *FileLSCisAjs;
 FILE *FileLSCisAjsCktAlt;
 FILE *FileLSCisAjsCktAltDC;
+FILE *FileLS2;
+FILE *FileLS2Moment;
 
 
 /* FILE *FileTimerList; */

--- a/src/mVMC/include/lanczos2_contract.h
+++ b/src/mVMC/include/lanczos2_contract.h
@@ -1,0 +1,42 @@
+#ifndef _LANCZOS2_CONTRACT_H
+#define _LANCZOS2_CONTRACT_H
+
+typedef struct {
+  int step;
+  int lanczosMode;
+  int vmcCalMode;
+  int orbitalGeneral;
+  int nProjBF;
+  int flagRBM;
+  int exUpdatePath;
+  int nPairHopping;
+  int nExchangeCoupling;
+  int nInterAll;
+  int nNBodyInterAll;
+  int nNBodyG;
+  int nSpinFlipTransfer;
+} Lanczos2Contract;
+
+typedef enum {
+  LANCZOS2_CONTRACT_OK = 0,
+  LANCZOS2_CONTRACT_INVALID_STEP,
+  LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1,
+  LANCZOS2_CONTRACT_REQUIRES_VMC_CAL_MODE_1,
+  LANCZOS2_CONTRACT_UNSUPPORTED_ORBITAL_GENERAL,
+  LANCZOS2_CONTRACT_UNSUPPORTED_BACKFLOW,
+  LANCZOS2_CONTRACT_UNSUPPORTED_RBM,
+  LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH,
+  LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING,
+  LANCZOS2_CONTRACT_UNSUPPORTED_EXCHANGE,
+  LANCZOS2_CONTRACT_UNSUPPORTED_INTER_ALL,
+  LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_INTER_ALL,
+  LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_G,
+  LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER
+} Lanczos2ContractStatus;
+
+Lanczos2ContractStatus ValidateLanczos2Contract(
+    const Lanczos2Contract *contract);
+
+const char *Lanczos2ContractError(Lanczos2ContractStatus status);
+
+#endif

--- a/src/mVMC/include/lslocgrn.h
+++ b/src/mVMC/include/lslocgrn.h
@@ -5,6 +5,12 @@
 
 void LSLocalQ(const double complex h1, const double complex ip, int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt, double complex *rbmCnt, double complex* _LSLocalQ);
 
+void CalculateLS2LocalPower(const double complex h1,
+                            const double complex ip, int *eleIdx,
+                            int *eleCfg, int *eleNum, int *eleProjCnt,
+                            double complex *rbmCnt,
+                            double complex *localPower);
+
 void LSLocalCisAjs(const double complex h1, const double complex ip, int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt, double complex *rbmCnt);
 
 #endif

--- a/src/mVMC/include/lslocgrn_real.h
+++ b/src/mVMC/include/lslocgrn_real.h
@@ -3,6 +3,10 @@
 
 void LSLocalQ_real(const double h1, const double ip, int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt, double *_LSLQ_real);
 
+void CalculateLS2LocalPower_real(const double h1, const double ip,
+                                 int *eleIdx, int *eleCfg, int *eleNum,
+                                 int *eleProjCnt, double *localPower);
+
 double calculateHK_real(const double h1, const double ip, int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt);
 
 double calHCA_real(const int ri, const int rj, const int s,

--- a/src/mVMC/include/physcal_lanczos2.h
+++ b/src/mVMC/include/physcal_lanczos2.h
@@ -1,0 +1,103 @@
+#ifndef _PHYSCAL_LANCZOS2_H
+#define _PHYSCAL_LANCZOS2_H
+
+#include <complex.h>
+#include <stddef.h>
+#include <stdio.h>
+
+enum {
+  LANCZOS2_MAX_DIMENSION = 3,
+  LANCZOS2_POWER_COUNT = 4,
+  LANCZOS2_MOMENT_COUNT = 16
+};
+
+typedef enum {
+  LANCZOS2_SOLVE_OK = 0,
+  LANCZOS2_SOLVE_INVALID_ARGUMENT,
+  LANCZOS2_SOLVE_NONFINITE_MOMENT,
+  LANCZOS2_SOLVE_INVALID_M00,
+  LANCZOS2_SOLVE_NONPOSITIVE_DIAGONAL,
+  LANCZOS2_SOLVE_LAPACK_FAILURE,
+  LANCZOS2_SOLVE_NORMALIZATION_FAILURE,
+  LANCZOS2_SOLVE_IO_FAILURE
+} Lanczos2SolveStatus;
+
+enum {
+  LANCZOS2_FLAG_REGULARIZED = 1 << 0,
+  LANCZOS2_FLAG_ALPHA_UNDEFINED = 1 << 1
+};
+
+typedef struct {
+  int dimension;
+  int solveFlags;
+  int lapackInfo;
+  double energy;
+  double variance;
+  double varianceOverEnergySquared;
+  double complex coefficient[LANCZOS2_MAX_DIMENSION];
+  double complex alpha[LANCZOS2_MAX_DIMENSION - 1];
+  double epsilon;
+  double shift;
+  double antiHermitianResidual;
+  double hankelResidual;
+  double eigenvalueResidual;
+} Lanczos2Result;
+
+Lanczos2SolveStatus BuildLanczos2MatricesReal(
+    const double moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double *overlap, double *hamiltonian, double *hamiltonianSquared,
+    double *antiHermitianResidual, double *hankelResidual);
+
+Lanczos2SolveStatus BuildLanczos2MatricesComplex(
+    const double complex moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double complex *overlap, double complex *hamiltonian,
+    double complex *hamiltonianSquared, double *antiHermitianResidual,
+    double *hankelResidual);
+
+Lanczos2SolveStatus SolveLanczos2Real(
+    const double moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    Lanczos2Result *result);
+
+Lanczos2SolveStatus SolveLanczos2Complex(
+    const double complex moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    Lanczos2Result *result);
+
+Lanczos2SolveStatus SolveLanczos2ShiftedReal(
+    const double moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double basisShift, Lanczos2Result *result);
+
+Lanczos2SolveStatus SolveLanczos2ShiftedComplex(
+    const double complex moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double basisShift, Lanczos2Result *result);
+
+Lanczos2SolveStatus BuildLanczos2ShiftedMomentReal(
+    double moment[LANCZOS2_MOMENT_COUNT], const double *samplePower,
+    const double *sampleWeight, const unsigned char *sampleValid,
+    size_t sampleCount, double shift);
+
+Lanczos2SolveStatus BuildLanczos2ShiftedMomentComplex(
+    double complex moment[LANCZOS2_MOMENT_COUNT],
+    const double complex *samplePower, const double *sampleWeight,
+    const unsigned char *sampleValid, size_t sampleCount, double shift);
+
+Lanczos2SolveStatus AccumulateLanczos2MomentReal(
+    double moment[LANCZOS2_MOMENT_COUNT],
+    const double localPower[LANCZOS2_POWER_COUNT], double weight);
+
+Lanczos2SolveStatus AccumulateLanczos2MomentComplex(
+    double complex moment[LANCZOS2_MOMENT_COUNT],
+    const double complex localPower[LANCZOS2_POWER_COUNT], double weight);
+
+Lanczos2SolveStatus WriteLanczos2OutputReal(
+    FILE *output, FILE *momentOutput,
+    const double moment[LANCZOS2_MOMENT_COUNT], double basisShift,
+    Lanczos2Result *result);
+
+Lanczos2SolveStatus WriteLanczos2OutputComplex(
+    FILE *output, FILE *momentOutput,
+    const double complex moment[LANCZOS2_MOMENT_COUNT],
+    double basisShift, Lanczos2Result *result);
+
+const char *Lanczos2SolveError(Lanczos2SolveStatus status);
+
+#endif

--- a/src/mVMC/include/readdef.h
+++ b/src/mVMC/include/readdef.h
@@ -97,7 +97,7 @@ extern char (*cFileNameListFile)[D_CharTmpReadDef];
 
 
 enum ParamIdxInt{
-  IdxVMCCalcMode, IdxLanczosMode, IdxDataIdxStart,
+  IdxVMCCalcMode, IdxLanczosMode, IdxLanczosStep, IdxDataIdxStart,
   IdxDataQtySmp, IdxNsite, IdxNe,
   //RBM
   IdxNneuron, IdxNneuronCharge, IdxNneuronSpin,IdxNneuronGeneral,

--- a/src/mVMC/initfile.c
+++ b/src/mVMC/initfile.c
@@ -120,7 +120,7 @@ void InitFilePhysCal(int i, int rank) {
     FileNBodyG = fopen(fileName, "w");
   }
 
-  if(NLanczosMode>0){
+  if(NLanczosMode>0 && NLanczosStep==1){
     sprintf(fileName, "%s_ls_out_%03d.dat", CDataFileHead, idx);
     FileLS = fopen(fileName, "w");
 
@@ -150,6 +150,23 @@ void InitFilePhysCal(int i, int rank) {
       sprintf(fileName, "%s_ls_cisajscktalt_%03d.dat",
               CDataFileHead, idx);
       FileLSCisAjsCktAltDC = fopen(fileName, "w");
+    }
+  }
+  if(NLanczosMode>0 && NLanczosStep==2){
+    sprintf(fileName, "%s_ls2_out_%03d.dat", CDataFileHead, idx);
+    FileLS2 = fopen(fileName, "w");
+    if(FileLS2 == NULL){
+      fprintf(stderr, "Error: failed to open Lanczos2 output file '%s'.\n",
+              fileName);
+      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+    sprintf(fileName, "%s_ls2_moment_%03d.dat", CDataFileHead, idx);
+    FileLS2Moment = fopen(fileName, "w");
+    if(FileLS2Moment == NULL){
+      fprintf(stderr, "Error: failed to open Lanczos2 moment file '%s'.\n",
+              fileName);
+      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
     }
   }
 
@@ -192,7 +209,7 @@ void CloseFilePhysCal(int rank) {
     fclose(FileNBodyG);
   }
 
-  if(NLanczosMode>0){
+  if(NLanczosMode>0 && NLanczosStep==1){
     fclose(FileLS);
     fclose(FileLSQQQQ);
 
@@ -205,6 +222,10 @@ void CloseFilePhysCal(int rank) {
       fclose(FileLSCisAjsCktAlt);
       fclose(FileLSCisAjsCktAltDC);
     }
+  }
+  if(NLanczosMode>0 && NLanczosStep==2){
+    fclose(FileLS2);
+    fclose(FileLS2Moment);
   }
 
   return;

--- a/src/mVMC/lanczos2_contract.c
+++ b/src/mVMC/lanczos2_contract.c
@@ -1,0 +1,83 @@
+#include <stddef.h>
+
+#include "lanczos2_contract.h"
+
+Lanczos2ContractStatus ValidateLanczos2Contract(
+    const Lanczos2Contract *contract) {
+  if (contract == NULL || (contract->step != 1 && contract->step != 2)) {
+    return LANCZOS2_CONTRACT_INVALID_STEP;
+  }
+  if (contract->step == 1) return LANCZOS2_CONTRACT_OK;
+
+  if (contract->lanczosMode != 1) {
+    return LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1;
+  }
+  if (contract->vmcCalMode != 1) {
+    return LANCZOS2_CONTRACT_REQUIRES_VMC_CAL_MODE_1;
+  }
+  if (contract->orbitalGeneral != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_ORBITAL_GENERAL;
+  }
+  if (contract->nProjBF != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_BACKFLOW;
+  }
+  if (contract->flagRBM != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_RBM;
+  }
+  if (contract->exUpdatePath != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH;
+  }
+  if (contract->nPairHopping != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING;
+  }
+  if (contract->nExchangeCoupling != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_EXCHANGE;
+  }
+  if (contract->nInterAll != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_INTER_ALL;
+  }
+  if (contract->nNBodyInterAll != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_INTER_ALL;
+  }
+  if (contract->nNBodyG != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_G;
+  }
+  if (contract->nSpinFlipTransfer != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER;
+  }
+  return LANCZOS2_CONTRACT_OK;
+}
+
+const char *Lanczos2ContractError(Lanczos2ContractStatus status) {
+  switch (status) {
+    case LANCZOS2_CONTRACT_OK:
+      return "";
+    case LANCZOS2_CONTRACT_INVALID_STEP:
+      return "NLanczosStep must be 1 or 2";
+    case LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1:
+      return "NLanczosStep=2 requires NLanczosMode=1";
+    case LANCZOS2_CONTRACT_REQUIRES_VMC_CAL_MODE_1:
+      return "NLanczosStep=2 requires NVMCCalMode=1";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_ORBITAL_GENERAL:
+      return "NLanczosStep=2 does not support orbital-general (FSZ) mode";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_BACKFLOW:
+      return "NLanczosStep=2 does not support BackFlow";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_RBM:
+      return "NLanczosStep=2 does not support RBM";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH:
+      return "NLanczosStep=2 requires NExUpdatePath=0";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING:
+      return "NLanczosStep=2 does not support PairHopping";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_EXCHANGE:
+      return "NLanczosStep=2 does not support Exchange";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_INTER_ALL:
+      return "NLanczosStep=2 does not support InterAll";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_INTER_ALL:
+      return "NLanczosStep=2 does not support NBodyInterAll";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_G:
+      return "NLanczosStep=2 does not support NBodyG";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER:
+      return "NLanczosStep=2 supports only spin-conserving Transfer terms";
+  }
+  return "unknown NLanczosStep contract error";
+}

--- a/src/mVMC/lslocgrn.c
+++ b/src/mVMC/lslocgrn.c
@@ -94,6 +94,71 @@ void LSLocalQ(const double complex h1, const double complex ip, int *eleIdx, int
   return;
 }
 
+/*
+ * Complex counterpart of LS2LocalPower_real.  The rightmost Transfer
+ * operator is the second operator passed to calHCACA, matching the
+ * ket-oriented recursion H O_inner O_outer |x>.
+ */
+void CalculateLS2LocalPower(const double complex h1,
+                            const double complex ip, int *eleIdx,
+                            int *eleCfg, int *eleNum, int *eleProjCnt,
+                            double complex *rbmCnt,
+                            double complex *localPower) {
+  double complex legacyLocalPower[4];
+  double complex h3;
+  const double complex diagonalEnergy = CalculateHamiltonian0(eleNum);
+  int outer;
+
+  LSLocalQ(h1, ip, eleIdx, eleCfg, eleNum, eleProjCnt, rbmCnt,
+           legacyLocalPower);
+  localPower[0] = 1.0;
+  localPower[1] = h1;
+  localPower[2] = legacyLocalPower[3];
+  h3 = diagonalEnergy * localPower[2];
+
+  for (outer = 0; outer < NTransfer; outer++) {
+    const int outerRi = Transfer[outer][0];
+    const int outerRj = Transfer[outer][2];
+    const int outerSpin = Transfer[outer][3];
+    const int outerRsi = outerRi + outerSpin * Nsite;
+    const int outerRsj = outerRj + outerSpin * Nsite;
+    const double complex outerCoefficient = -ParaTransfer[outer];
+    double complex outerDiagonalEnergy;
+    double complex innerContribution = 0.0;
+    double complex hca;
+    int inner;
+
+    if (outerRsi == outerRsj) {
+      if (eleNum[outerRsi] == 0) continue;
+      outerDiagonalEnergy = diagonalEnergy;
+    } else {
+      if (eleNum[outerRsj] == 0 || eleNum[outerRsi] != 0) continue;
+      eleNum[outerRsj] = 0;
+      eleNum[outerRsi] = 1;
+      outerDiagonalEnergy = CalculateHamiltonian0(eleNum);
+      eleNum[outerRsj] = 1;
+      eleNum[outerRsi] = 0;
+    }
+
+    hca = calHCA(outerRi, outerRj, outerSpin, h1, ip, eleIdx, eleCfg,
+                 eleNum, eleProjCnt, rbmCnt);
+    for (inner = 0; inner < NTransfer; inner++) {
+      const int innerRi = Transfer[inner][0];
+      const int innerRj = Transfer[inner][2];
+      const int innerSpin = Transfer[inner][3];
+      const double complex innerCoefficient = -ParaTransfer[inner];
+      innerContribution +=
+          innerCoefficient *
+          calHCACA(innerRi, innerRj, outerRi, outerRj, innerSpin,
+                   outerSpin, h1, ip, eleIdx, eleCfg, eleNum, eleProjCnt,
+                   rbmCnt);
+    }
+    h3 += outerCoefficient *
+          (outerDiagonalEnergy * hca + innerContribution);
+  }
+  localPower[3] = h3;
+}
+
 /* Calculate <psi|QCisAjs|x>/<psi|x> */
 void LSLocalCisAjs(const double complex h1, const double complex ip, int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt, double complex *rbmCnt) {
   const int nCisAjs=NCisAjs;
@@ -353,7 +418,7 @@ double complex calHCA2(const int ri, const int rj, const int s,
   /* end of H0 term */
 
 #pragma omp parallel default(shared)\
-  private(myRBMCntNew,myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj,myRWork)  \
+  private(idx,myRBMCntNew,myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj,myRWork)  \
   reduction(+:v)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);
@@ -496,7 +561,15 @@ double complex calHCACA(const int ri, const int rj, const int rk, const int rl,
   if(!WouldPreserve_2hopPre(rsi,rsj,rsk,rsl,eleNum)) return 0.0;
 
   g = checkGF2(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum);
-  if(cabs(g)>1.0e-12) {
+  /*
+   * The mutate-and-rank-two-update path does not preserve the projected
+   * H*CACA matrix element when several quantum-projection components are
+   * summed.  GreenFuncN contracts that projected matrix element directly
+   * from the original state, so keep the legacy fast path only for the
+   * identity quantum projection.  Do not alter the established first-step
+   * Lanczos path.
+   */
+  if(cabs(g)>1.0e-12 && (NLanczosStep != 2 || NQPFull == 1)) {
     val = calHCACA1(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt);
   } else {
     val = calHCACA2(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt);
@@ -701,7 +774,7 @@ double complex calHCACA2(const int ri, const int rj, const int rk, const int rl,
   /* end of H0 term */
 
 #pragma omp parallel default(shared)\
-  private(myRBMCntNew,myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj,myRWork)  \
+  private(idx,myRBMCntNew,myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj,myRWork)  \
   reduction(+:v)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);

--- a/src/mVMC/lslocgrn.c
+++ b/src/mVMC/lslocgrn.c
@@ -39,6 +39,13 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #include "pfupdate_two_fcmp.h"
 #include "projection.h"
 
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+static int Lanczos2CalHCAGuardAuditComplexEnabled = 0;
+static long long Lanczos2CalHCAGuardAuditComplexDirectCount = 0;
+static long long Lanczos2CalHCAGuardAuditComplexZeroComponentCount = 0;
+static int Lanczos2CalHCAGuardAuditComplexLastMovedHasZeroComponent = 0;
+#endif
+
 double complex calculateHK(const double complex h1, const double complex ip, int *eleIdx, int *eleCfg,
                    int *eleNum, int *eleProjCnt, double complex *rbmCnt);
 double complex calculateHW(const double complex h1, const double complex ip, int *eleIdx, int *eleCfg,
@@ -262,9 +269,26 @@ double complex calHCA(const int ri, const int rj, const int s,
   if(!IsSectorPreserved_1hopPre(ri,rj,s,eleNum)) return 0.0;
 
   g = checkGF1(ri,rj,s,ip,eleIdx,eleCfg,eleNum);
-  if(cabs(g)>1.0e-12) {
+  /*
+   * In a multi-component projected state, the moved configuration may
+   * have a zero Pfaffian in one component even though its total projected
+   * overlap is nonzero.  Updating that singular component leaves an invalid
+   * inverse for CalculateHamiltonian.  Contract the second-Lanczos matrix
+   * element directly from the original state in this case, matching the
+   * multi-component calHCACA guard below.
+   */
+  if(cabs(g)>1.0e-12 && (NLanczosStep != 2 || NQPFull == 1)) {
     val = calHCA1(ri,rj,s,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt);
   } else {
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+    if(Lanczos2CalHCAGuardAuditComplexEnabled &&
+       cabs(g)>1.0e-12 && NLanczosStep == 2 && NQPFull > 1) {
+      Lanczos2CalHCAGuardAuditComplexDirectCount++;
+      if(Lanczos2CalHCAGuardAuditComplexLastMovedHasZeroComponent) {
+        Lanczos2CalHCAGuardAuditComplexZeroComponentCount++;
+      }
+    }
+#endif
     val = calHCA2(ri,rj,s,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt);
   }
 
@@ -276,6 +300,9 @@ double complex checkGF1(const int ri, const int rj, const int s, const double co
   double complex z;
   int mj,msj,rsi,rsj;
   double complex pfMNew[NQPFull];
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  int qpidx;
+#endif
 
   mj = eleCfg[rj+s*Nsite];
   msj = mj + s*Ne;
@@ -288,8 +315,19 @@ double complex checkGF1(const int ri, const int rj, const int s, const double co
   eleNum[rsi] = 1;
 
   /* calculate Pfaffian */
-    CalculateNewPfM(mj, s, pfMNew, eleIdx, 0, NQPFull);
-    z = CalculateIP_fcmp(pfMNew, 0, NQPFull, MPI_COMM_SELF);
+  CalculateNewPfM(mj, s, pfMNew, eleIdx, 0, NQPFull);
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if(Lanczos2CalHCAGuardAuditComplexEnabled) {
+    Lanczos2CalHCAGuardAuditComplexLastMovedHasZeroComponent = 0;
+    for(qpidx=0; qpidx<NQPFull; qpidx++) {
+      if(cabs(pfMNew[qpidx]) <= 1.0e-12) {
+        Lanczos2CalHCAGuardAuditComplexLastMovedHasZeroComponent = 1;
+        break;
+      }
+    }
+  }
+#endif
+  z = CalculateIP_fcmp(pfMNew, 0, NQPFull, MPI_COMM_SELF);
 
   /* revert hopping */
   eleIdx[msj] = rj;

--- a/src/mVMC/lslocgrn_real.c
+++ b/src/mVMC/lslocgrn_real.c
@@ -41,6 +41,13 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #include "qp_real.c"
 #include "projection.h"
 
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+static int Lanczos2CalHCAGuardAuditRealEnabled = 0;
+static long long Lanczos2CalHCAGuardAuditRealDirectCount = 0;
+static long long Lanczos2CalHCAGuardAuditRealZeroComponentCount = 0;
+static int Lanczos2CalHCAGuardAuditRealLastMovedHasZeroComponent = 0;
+#endif
+
 /* Calculate <psi|QQ|x>/<psi|x> */
 void LSLocalQ_real(const double h1, const double ip, int *eleIdx, int *eleCfg, int *eleNum, int *eleProjCnt, double *_LSLQ_real)
 {
@@ -184,9 +191,26 @@ double calHCA_real(const int ri, const int rj, const int s,
   if(!IsSectorPreserved_1hopPre(ri,rj,s,eleNum)) return 0.0;
 
   g = checkGF1_real(ri,rj,s,ip,eleIdx,eleCfg,eleNum);
-  if(fabs(g)>1.0e-12) {
+  /*
+   * In a multi-component projected state, the moved configuration may
+   * have a zero Pfaffian in one component even though its total projected
+   * overlap is nonzero.  Updating that singular component leaves an invalid
+   * inverse for CalculateHamiltonian.  Contract the second-Lanczos matrix
+   * element directly from the original state in this case, matching the
+   * multi-component calHCACA guard below.
+   */
+  if(fabs(g)>1.0e-12 && (NLanczosStep != 2 || NQPFull == 1)) {
     val = calHCA1_real(ri,rj,s,ip,eleIdx,eleCfg,eleNum,eleProjCnt);
   } else {
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+    if(Lanczos2CalHCAGuardAuditRealEnabled &&
+       fabs(g)>1.0e-12 && NLanczosStep == 2 && NQPFull > 1) {
+      Lanczos2CalHCAGuardAuditRealDirectCount++;
+      if(Lanczos2CalHCAGuardAuditRealLastMovedHasZeroComponent) {
+        Lanczos2CalHCAGuardAuditRealZeroComponentCount++;
+      }
+    }
+#endif
     val = calHCA2_real(ri,rj,s,ip,eleIdx,eleCfg,eleNum,eleProjCnt);
   }
 
@@ -208,6 +232,9 @@ double checkGF1_real(const int ri, const int rj, const int s, const double ip,
   double z;
   int mj,msj,rsi,rsj;
   double pfMNew[NQPFull];
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  int qpidx;
+#endif
 
   mj = eleCfg[rj+s*Nsite];
   msj = mj + s*Ne;
@@ -221,6 +248,17 @@ double checkGF1_real(const int ri, const int rj, const int s, const double ip,
 
   /* calculate Pfaffian */
   CalculateNewPfM_real(mj, s, pfMNew, eleIdx, 0, NQPFull);
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if(Lanczos2CalHCAGuardAuditRealEnabled) {
+    Lanczos2CalHCAGuardAuditRealLastMovedHasZeroComponent = 0;
+    for(qpidx=0; qpidx<NQPFull; qpidx++) {
+      if(fabs(pfMNew[qpidx]) <= 1.0e-12) {
+        Lanczos2CalHCAGuardAuditRealLastMovedHasZeroComponent = 1;
+        break;
+      }
+    }
+  }
+#endif
   z = CalculateIP_real(pfMNew, 0, NQPFull, MPI_COMM_SELF);
 
   /* revert hopping */

--- a/src/mVMC/lslocgrn_real.c
+++ b/src/mVMC/lslocgrn_real.c
@@ -63,6 +63,69 @@ void LSLocalQ_real(const double h1, const double ip, int *eleIdx, int *eleCfg, i
   return;
 }
 
+/*
+ * Calculate F[k] = <psi|H^k|x>/<psi|x>, k=0..3, for the initial
+ * second-step scope H=V+K.  The outer loops intentionally do not acquire the
+ * serial workspace arena: calHCA_real/calHCACA_real own their scratch.
+ */
+void CalculateLS2LocalPower_real(const double h1, const double ip,
+                                 int *eleIdx, int *eleCfg, int *eleNum,
+                                 int *eleProjCnt, double *localPower) {
+  double legacyLocalPower[4];
+  double h3;
+  const double diagonalEnergy = CalculateHamiltonian0_real(eleNum);
+  int outer;
+
+  LSLocalQ_real(h1, ip, eleIdx, eleCfg, eleNum, eleProjCnt,
+                legacyLocalPower);
+  localPower[0] = 1.0;
+  localPower[1] = h1;
+  localPower[2] = legacyLocalPower[3];
+  h3 = diagonalEnergy * localPower[2];
+
+  for (outer = 0; outer < NTransfer; outer++) {
+    const int outerRi = Transfer[outer][0];
+    const int outerRj = Transfer[outer][2];
+    const int outerSpin = Transfer[outer][3];
+    const int outerRsi = outerRi + outerSpin * Nsite;
+    const int outerRsj = outerRj + outerSpin * Nsite;
+    const double outerCoefficient = -creal(ParaTransfer[outer]);
+    double outerDiagonalEnergy;
+    double innerContribution = 0.0;
+    double hca;
+    int inner;
+
+    if (outerRsi == outerRsj) {
+      if (eleNum[outerRsi] == 0) continue;
+      outerDiagonalEnergy = diagonalEnergy;
+    } else {
+      if (eleNum[outerRsj] == 0 || eleNum[outerRsi] != 0) continue;
+      eleNum[outerRsj] = 0;
+      eleNum[outerRsi] = 1;
+      outerDiagonalEnergy = CalculateHamiltonian0_real(eleNum);
+      eleNum[outerRsj] = 1;
+      eleNum[outerRsi] = 0;
+    }
+
+    hca = calHCA_real(outerRi, outerRj, outerSpin, h1, ip, eleIdx,
+                      eleCfg, eleNum, eleProjCnt);
+    for (inner = 0; inner < NTransfer; inner++) {
+      const int innerRi = Transfer[inner][0];
+      const int innerRj = Transfer[inner][2];
+      const int innerSpin = Transfer[inner][3];
+      const double innerCoefficient = -creal(ParaTransfer[inner]);
+      innerContribution +=
+          innerCoefficient *
+          calHCACA_real(innerRi, innerRj, outerRi, outerRj, innerSpin,
+                        outerSpin, h1, ip, eleIdx, eleCfg, eleNum,
+                        eleProjCnt);
+    }
+    h3 += outerCoefficient *
+          (outerDiagonalEnergy * hca + innerContribution);
+  }
+  localPower[3] = h3;
+}
+
 ///
 /// \param h1
 /// \param ip
@@ -285,7 +348,7 @@ double calHCA2_real(const int ri, const int rj, const int s,
   /* end of H0 term */
 
 #pragma omp parallel default(shared)\
-  private(myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj)  \
+  private(idx,myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj)  \
   reduction(+:v)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);
@@ -480,7 +543,15 @@ double calHCACA_real(const int ri, const int rj, const int rk, const int rl,
   if(!WouldPreserve_2hopPre(rsi,rsj,rsk,rsl,eleNum)) return 0.0;
 
   g = checkGF2_real(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum);
-  if(fabs(g)>1.0e-12) {
+  /*
+   * The mutate-and-rank-two-update path does not preserve the projected
+   * H*CACA matrix element when several quantum-projection components are
+   * summed.  GreenFuncN contracts that projected matrix element directly
+   * from the original state, so keep the legacy fast path only for the
+   * identity quantum projection.  Do not alter the established first-step
+   * Lanczos path.
+   */
+  if(fabs(g)>1.0e-12 && (NLanczosStep != 2 || NQPFull == 1)) {
     val = calHCACA1_real(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt);
   } else {
     val = calHCACA2_real(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt);
@@ -664,7 +735,7 @@ double calHCACA2_real(const int ri, const int rj, const int rk, const int rl,
   /* end of H0 term */
 
 #pragma omp parallel default(shared)\
-  private(myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj)  \
+  private(idx,myEleIdx,myEleNum,myBufferInt,myBuffer,myValue,myRsi,myRsj)  \
   reduction(+:v)
   {
     myEleIdx = GetWorkSpaceThreadInt(Nsize);

--- a/src/mVMC/physcal_lanczos.c
+++ b/src/mVMC/physcal_lanczos.c
@@ -61,8 +61,16 @@ int PhysCalLanczos_real
   LS_CisAjsCktAlt_real = (double*)malloc(sizeof(double)*_nCisAjsCktAlt);
   LS_CisAjsCktAltDC_real = (double*)malloc(sizeof(double)*_nCisAjsCktAltDC);
 
-  CalculateEne(_QQQQ_real[2], _QQQQ_real[3], _QQQQ_real[10], _QQQQ_real[11], _QQQQ_real[15],
-   &alpha_p,  &ene_p,  &ene_vp, &alpha_m,  &ene_m,  &ene_vm);
+  if (CalculateEne(_QQQQ_real[2], _QQQQ_real[3], _QQQQ_real[10],
+                   _QQQQ_real[11], _QQQQ_real[15], &alpha_p, &ene_p,
+                   &ene_vp, &alpha_m, &ene_m, &ene_vm) != 0) {
+    fprintf(stderr,
+            "Error: Lanczos method is failed due to illegal value of alpha.\n");
+    free(LS_CisAjs_real);
+    free(LS_CisAjsCktAlt_real);
+    free(LS_CisAjsCktAltDC_real);
+    return -1;
+  }
 
   //determine alpha
   if (ene_p > ene_m) {
@@ -183,12 +191,14 @@ int PhysCalLanczos_fcmp(
   LS_CisAjsCktAltDC = (double complex*)malloc(sizeof(double complex)*_nCisAjsCktAltDC);
 
   /* zvo_ls.dat */
-  if(!CalculateEne(creal(_QQQQ[2]),creal(_QQQQ[3]),
-           creal(_QQQQ[10]), creal(_QQQQ[11]), creal(_QQQQ[15]),
-         &alpha_p,  &ene_p,  &ene_vp, &alpha_m,  &ene_m,  &ene_vm)==0){
+  if (CalculateEne(creal(_QQQQ[2]), creal(_QQQQ[3]),
+                   creal(_QQQQ[10]), creal(_QQQQ[11]),
+                   creal(_QQQQ[15]), &alpha_p, &ene_p, &ene_vp, &alpha_m,
+                   &ene_m, &ene_vm) != 0) {
     fprintf(stderr,"Error: Lanczos method is failed due to illegal value of alpha.\n");
     free(LS_CisAjs);
     free(LS_CisAjsCktAlt);
+    free(LS_CisAjsCktAltDC);
     return -1;
   }
   //determine alpha

--- a/src/mVMC/physcal_lanczos2.c
+++ b/src/mVMC/physcal_lanczos2.c
@@ -1,0 +1,1178 @@
+#include <complex.h>
+#include <float.h>
+#include <math.h>
+#include <stddef.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#else
+typedef int MPI_Comm;
+#endif
+
+#include "blas_externs.h"
+#include "physcal_lanczos2.h"
+
+#define MATRIX_INDEX(row, column, leadingDimension) \
+  ((row) * (leadingDimension) + (column))
+
+static int ValidDimension(int dimension) {
+  return dimension == 2 || dimension == 3;
+}
+
+static void ClearResult(Lanczos2Result *result, int dimension) {
+  int i;
+  memset(result, 0, sizeof(*result));
+  result->dimension = dimension;
+  result->energy = NAN;
+  result->variance = NAN;
+  result->varianceOverEnergySquared = NAN;
+  result->eigenvalueResidual = NAN;
+  for (i = 0; i < LANCZOS2_MAX_DIMENSION - 1; i++) {
+    result->alpha[i] = NAN + I * NAN;
+  }
+}
+
+static double RelativeResidual(double numerator, double scale) {
+  return numerator / fmax(scale, DBL_MIN);
+}
+
+static double HankelResidualReal(const double *moment) {
+  double residual = 0.0;
+  int order;
+  int a;
+  int b;
+  int c;
+  int d;
+  for (order = 0; order <= 2 * (LANCZOS2_POWER_COUNT - 1); order++) {
+    double maximum = 0.0;
+    double scale = 0.0;
+    for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+      b = order - a;
+      if (b < 0 || b >= LANCZOS2_POWER_COUNT) continue;
+      scale = fmax(scale,
+                   sqrt(fabs(moment[MATRIX_INDEX(
+                                 a, a, LANCZOS2_POWER_COUNT)]) *
+                             fabs(moment[MATRIX_INDEX(
+                                 b, b, LANCZOS2_POWER_COUNT)])));
+      scale = fmax(
+          scale,
+          fabs(moment[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)]));
+      for (c = 0; c < LANCZOS2_POWER_COUNT; c++) {
+        d = order - c;
+        if (d >= 0 && d < LANCZOS2_POWER_COUNT) {
+          maximum = fmax(maximum,
+                         fabs(moment[MATRIX_INDEX(
+                                  a, b, LANCZOS2_POWER_COUNT)] -
+                              moment[MATRIX_INDEX(
+                                  c, d, LANCZOS2_POWER_COUNT)]));
+        }
+      }
+    }
+    residual = fmax(residual, RelativeResidual(maximum, scale));
+  }
+  return residual;
+}
+
+static double HankelResidualComplex(const double complex *moment) {
+  double residual = 0.0;
+  int order;
+  int a;
+  int b;
+  int c;
+  int d;
+  for (order = 0; order <= 2 * (LANCZOS2_POWER_COUNT - 1); order++) {
+    double maximum = 0.0;
+    double scale = 0.0;
+    for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+      b = order - a;
+      if (b < 0 || b >= LANCZOS2_POWER_COUNT) continue;
+      scale = fmax(scale,
+                   sqrt(cabs(moment[MATRIX_INDEX(
+                                  a, a, LANCZOS2_POWER_COUNT)]) *
+                             cabs(moment[MATRIX_INDEX(
+                                  b, b, LANCZOS2_POWER_COUNT)])));
+      scale = fmax(
+          scale,
+          cabs(moment[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)]));
+      for (c = 0; c < LANCZOS2_POWER_COUNT; c++) {
+        d = order - c;
+        if (d >= 0 && d < LANCZOS2_POWER_COUNT) {
+          maximum = fmax(maximum,
+                         cabs(moment[MATRIX_INDEX(
+                                  a, b, LANCZOS2_POWER_COUNT)] -
+                              moment[MATRIX_INDEX(
+                                  c, d, LANCZOS2_POWER_COUNT)]));
+        }
+      }
+    }
+    residual = fmax(residual, RelativeResidual(maximum, scale));
+  }
+  return residual;
+}
+
+static Lanczos2SolveStatus ProjectMomentReal(const double *moment,
+                                             double *projected,
+                                             double *residual) {
+  double maximum = 0.0;
+  double scale = 0.0;
+  int a;
+  int b;
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      const double mab =
+          moment[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)];
+      const double mba =
+          moment[MATRIX_INDEX(b, a, LANCZOS2_POWER_COUNT)];
+      if (!isfinite(mab)) return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+      maximum = fmax(maximum, fabs(mab - mba));
+      scale = fmax(scale, fabs(mab));
+      projected[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)] =
+          0.5 * (mab + mba);
+    }
+  }
+  *residual = RelativeResidual(maximum, scale);
+  return LANCZOS2_SOLVE_OK;
+}
+
+static Lanczos2SolveStatus ProjectMomentComplex(
+    const double complex *moment, double complex *projected,
+    double *residual) {
+  double maximum = 0.0;
+  double scale = 0.0;
+  int a;
+  int b;
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      const double complex mab =
+          moment[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)];
+      const double complex mba =
+          conj(moment[MATRIX_INDEX(b, a, LANCZOS2_POWER_COUNT)]);
+      if (!isfinite(creal(mab)) || !isfinite(cimag(mab))) {
+        return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+      }
+      maximum = fmax(maximum, cabs(mab - mba));
+      scale = fmax(scale, cabs(mab));
+      projected[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)] =
+          0.5 * (mab + mba);
+    }
+  }
+  *residual = RelativeResidual(maximum, scale);
+  return LANCZOS2_SOLVE_OK;
+}
+
+static void HermitianProjectReal(double *matrix, int dimension) {
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = a + 1; b < dimension; b++) {
+      const double value =
+          0.5 * (matrix[MATRIX_INDEX(a, b, dimension)] +
+                 matrix[MATRIX_INDEX(b, a, dimension)]);
+      matrix[MATRIX_INDEX(a, b, dimension)] = value;
+      matrix[MATRIX_INDEX(b, a, dimension)] = value;
+    }
+  }
+}
+
+static void HermitianProjectComplex(double complex *matrix, int dimension) {
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    matrix[MATRIX_INDEX(a, a, dimension)] =
+        creal(matrix[MATRIX_INDEX(a, a, dimension)]);
+    for (b = a + 1; b < dimension; b++) {
+      const double complex value =
+          0.5 * (matrix[MATRIX_INDEX(a, b, dimension)] +
+                 conj(matrix[MATRIX_INDEX(b, a, dimension)]));
+      matrix[MATRIX_INDEX(a, b, dimension)] = value;
+      matrix[MATRIX_INDEX(b, a, dimension)] = conj(value);
+    }
+  }
+}
+
+static void MatricesFromProjectedMomentReal(const double *moment,
+                                            int dimension, double *overlap,
+                                            double *hamiltonian,
+                                            double *hamiltonianSquared) {
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      overlap[MATRIX_INDEX(a, b, dimension)] =
+          moment[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)];
+      hamiltonian[MATRIX_INDEX(a, b, dimension)] =
+          0.5 *
+          (moment[MATRIX_INDEX(a, b + 1, LANCZOS2_POWER_COUNT)] +
+           moment[MATRIX_INDEX(a + 1, b, LANCZOS2_POWER_COUNT)]);
+      hamiltonianSquared[MATRIX_INDEX(a, b, dimension)] =
+          moment[MATRIX_INDEX(a + 1, b + 1, LANCZOS2_POWER_COUNT)];
+    }
+  }
+  HermitianProjectReal(overlap, dimension);
+  HermitianProjectReal(hamiltonian, dimension);
+  HermitianProjectReal(hamiltonianSquared, dimension);
+}
+
+static void MatricesFromProjectedMomentComplex(
+    const double complex *moment, int dimension, double complex *overlap,
+    double complex *hamiltonian, double complex *hamiltonianSquared) {
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      overlap[MATRIX_INDEX(a, b, dimension)] =
+          moment[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)];
+      hamiltonian[MATRIX_INDEX(a, b, dimension)] =
+          0.5 *
+          (moment[MATRIX_INDEX(a, b + 1, LANCZOS2_POWER_COUNT)] +
+           moment[MATRIX_INDEX(a + 1, b, LANCZOS2_POWER_COUNT)]);
+      hamiltonianSquared[MATRIX_INDEX(a, b, dimension)] =
+          moment[MATRIX_INDEX(a + 1, b + 1, LANCZOS2_POWER_COUNT)];
+    }
+  }
+  HermitianProjectComplex(overlap, dimension);
+  HermitianProjectComplex(hamiltonian, dimension);
+  HermitianProjectComplex(hamiltonianSquared, dimension);
+}
+
+Lanczos2SolveStatus BuildLanczos2MatricesReal(
+    const double moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double *overlap, double *hamiltonian, double *hamiltonianSquared,
+    double *antiHermitianResidual, double *hankelResidual) {
+  double projected[LANCZOS2_MOMENT_COUNT];
+  Lanczos2SolveStatus status;
+  if (moment == NULL || overlap == NULL || hamiltonian == NULL ||
+      hamiltonianSquared == NULL || antiHermitianResidual == NULL ||
+      hankelResidual == NULL || !ValidDimension(dimension)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  status = ProjectMomentReal(moment, projected, antiHermitianResidual);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  *hankelResidual = HankelResidualReal(projected);
+  MatricesFromProjectedMomentReal(projected, dimension, overlap, hamiltonian,
+                                  hamiltonianSquared);
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus BuildLanczos2MatricesComplex(
+    const double complex moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double complex *overlap, double complex *hamiltonian,
+    double complex *hamiltonianSquared, double *antiHermitianResidual,
+    double *hankelResidual) {
+  double complex projected[LANCZOS2_MOMENT_COUNT];
+  Lanczos2SolveStatus status;
+  if (moment == NULL || overlap == NULL || hamiltonian == NULL ||
+      hamiltonianSquared == NULL || antiHermitianResidual == NULL ||
+      hankelResidual == NULL || !ValidDimension(dimension)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  status = ProjectMomentComplex(moment, projected, antiHermitianResidual);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  *hankelResidual = HankelResidualComplex(projected);
+  MatricesFromProjectedMomentComplex(projected, dimension, overlap,
+                                     hamiltonian, hamiltonianSquared);
+  return LANCZOS2_SOLVE_OK;
+}
+
+static void BuildShiftTransform(double shift, double *transform) {
+  /*
+   * Rows are the shifted powers (H-shift)^k; columns are powers H^j.
+   * Only the 4x4 transform is needed by the second-step moment table.
+   */
+  static const double binomial[4][4] = {
+      {1.0, 0.0, 0.0, 0.0},
+      {1.0, 1.0, 0.0, 0.0},
+      {1.0, 2.0, 1.0, 0.0},
+      {1.0, 3.0, 3.0, 1.0}};
+  int k;
+  int j;
+  memset(transform, 0, LANCZOS2_MOMENT_COUNT * sizeof(*transform));
+  for (k = 0; k < LANCZOS2_POWER_COUNT; k++) {
+    for (j = 0; j <= k; j++) {
+      transform[MATRIX_INDEX(k, j, LANCZOS2_POWER_COUNT)] =
+          binomial[k][j] * pow(-shift, (double)(k - j));
+    }
+  }
+}
+
+static void TransformMomentReal(const double *transform, const double *moment,
+                                double *shifted) {
+  int a;
+  int b;
+  int j;
+  int k;
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      double value = 0.0;
+      for (j = 0; j < LANCZOS2_POWER_COUNT; j++) {
+        for (k = 0; k < LANCZOS2_POWER_COUNT; k++) {
+          value +=
+              transform[MATRIX_INDEX(a, j, LANCZOS2_POWER_COUNT)] *
+              moment[MATRIX_INDEX(j, k, LANCZOS2_POWER_COUNT)] *
+              transform[MATRIX_INDEX(b, k, LANCZOS2_POWER_COUNT)];
+        }
+      }
+      shifted[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)] = value;
+    }
+  }
+}
+
+static void TransformMomentComplex(const double *transform,
+                                   const double complex *moment,
+                                   double complex *shifted) {
+  int a;
+  int b;
+  int j;
+  int k;
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      double complex value = 0.0;
+      for (j = 0; j < LANCZOS2_POWER_COUNT; j++) {
+        for (k = 0; k < LANCZOS2_POWER_COUNT; k++) {
+          value +=
+              transform[MATRIX_INDEX(a, j, LANCZOS2_POWER_COUNT)] *
+              moment[MATRIX_INDEX(j, k, LANCZOS2_POWER_COUNT)] *
+              transform[MATRIX_INDEX(b, k, LANCZOS2_POWER_COUNT)];
+        }
+      }
+      shifted[MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT)] = value;
+    }
+  }
+}
+
+static Lanczos2SolveStatus TransformLocalPowerReal(
+    const double *transform, const double *localPower,
+    double *shiftedPower) {
+  int k;
+  int j;
+  for (k = 0; k < LANCZOS2_POWER_COUNT; k++) {
+    double value = 0.0;
+    for (j = 0; j <= k; j++) {
+      value = fma(
+          transform[MATRIX_INDEX(k, j, LANCZOS2_POWER_COUNT)],
+          localPower[j], value);
+    }
+    if (!isfinite(value)) return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+    shiftedPower[k] = value;
+  }
+  return LANCZOS2_SOLVE_OK;
+}
+
+static Lanczos2SolveStatus TransformLocalPowerComplex(
+    const double *transform, const double complex *localPower,
+    double complex *shiftedPower) {
+  int k;
+  int j;
+  for (k = 0; k < LANCZOS2_POWER_COUNT; k++) {
+    double realValue = 0.0;
+    double imaginaryValue = 0.0;
+    for (j = 0; j <= k; j++) {
+      const double coefficient =
+          transform[MATRIX_INDEX(k, j, LANCZOS2_POWER_COUNT)];
+      realValue = fma(coefficient, creal(localPower[j]), realValue);
+      imaginaryValue =
+          fma(coefficient, cimag(localPower[j]), imaginaryValue);
+    }
+    if (!isfinite(realValue) || !isfinite(imaginaryValue)) {
+      return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+    }
+    shiftedPower[k] = realValue + imaginaryValue * I;
+  }
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus BuildLanczos2ShiftedMomentReal(
+    double moment[LANCZOS2_MOMENT_COUNT], const double *samplePower,
+    const double *sampleWeight, const unsigned char *sampleValid,
+    size_t sampleCount, double shift) {
+  double updatedMoment[LANCZOS2_MOMENT_COUNT] = {0.0};
+  double transform[LANCZOS2_MOMENT_COUNT];
+  double shiftedPower[LANCZOS2_POWER_COUNT];
+  Lanczos2SolveStatus status;
+  size_t sample;
+  if (moment == NULL || samplePower == NULL || sampleWeight == NULL ||
+      sampleValid == NULL || sampleCount == 0) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  if (!isfinite(shift)) return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  BuildShiftTransform(shift, transform);
+  for (sample = 0; sample < sampleCount; sample++) {
+    if (sampleValid[sample] == 0) continue;
+    status = TransformLocalPowerReal(
+        transform, samplePower + sample * LANCZOS2_POWER_COUNT,
+        shiftedPower);
+    if (status != LANCZOS2_SOLVE_OK) return status;
+    status = AccumulateLanczos2MomentReal(
+        updatedMoment, shiftedPower, sampleWeight[sample]);
+    if (status != LANCZOS2_SOLVE_OK) return status;
+  }
+  memcpy(moment, updatedMoment, sizeof(updatedMoment));
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus BuildLanczos2ShiftedMomentComplex(
+    double complex moment[LANCZOS2_MOMENT_COUNT],
+    const double complex *samplePower, const double *sampleWeight,
+    const unsigned char *sampleValid, size_t sampleCount, double shift) {
+  double complex updatedMoment[LANCZOS2_MOMENT_COUNT] = {0.0};
+  double transform[LANCZOS2_MOMENT_COUNT];
+  double complex shiftedPower[LANCZOS2_POWER_COUNT];
+  Lanczos2SolveStatus status;
+  size_t sample;
+  if (moment == NULL || samplePower == NULL || sampleWeight == NULL ||
+      sampleValid == NULL || sampleCount == 0) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  if (!isfinite(shift)) return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  BuildShiftTransform(shift, transform);
+  for (sample = 0; sample < sampleCount; sample++) {
+    if (sampleValid[sample] == 0) continue;
+    status = TransformLocalPowerComplex(
+        transform, samplePower + sample * LANCZOS2_POWER_COUNT,
+        shiftedPower);
+    if (status != LANCZOS2_SOLVE_OK) return status;
+    status = AccumulateLanczos2MomentComplex(
+        updatedMoment, shiftedPower, sampleWeight[sample]);
+    if (status != LANCZOS2_SOLVE_OK) return status;
+  }
+  memcpy(moment, updatedMoment, sizeof(updatedMoment));
+  return LANCZOS2_SOLVE_OK;
+}
+
+static void RowMajorToColumnMajorReal(const double *source,
+                                      double *destination, int dimension) {
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      destination[a + b * dimension] =
+          source[MATRIX_INDEX(a, b, dimension)];
+    }
+  }
+}
+
+static void RowMajorToColumnMajorComplex(const double complex *source,
+                                         double complex *destination,
+                                         int dimension) {
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      destination[a + b * dimension] =
+          source[MATRIX_INDEX(a, b, dimension)];
+    }
+  }
+}
+
+static int GeneralizedEigenReal(const double *hamiltonian,
+                                const double *overlap, int dimension,
+                                double epsilon, double *eigenvalue,
+                                double *eigenvector) {
+  double a[LANCZOS2_MAX_DIMENSION * LANCZOS2_MAX_DIMENSION];
+  double b[LANCZOS2_MAX_DIMENSION * LANCZOS2_MAX_DIMENSION];
+  double eigenvalues[LANCZOS2_MAX_DIMENSION];
+  double work[64];
+  const int itype = 1;
+  const int leadingDimension = dimension;
+  const int workSize = (int)(sizeof(work) / sizeof(work[0]));
+  const char jobz = 'V';
+  const char uplo = 'U';
+  int i;
+  int info = 0;
+  RowMajorToColumnMajorReal(hamiltonian, a, dimension);
+  RowMajorToColumnMajorReal(overlap, b, dimension);
+  for (i = 0; i < dimension; i++) b[i + i * dimension] += epsilon;
+  M_DSYGV(&itype, &jobz, &uplo, &dimension, a, &leadingDimension, b,
+          &leadingDimension, eigenvalues, work, &workSize, &info);
+  if (info == 0) {
+    *eigenvalue = eigenvalues[0];
+    for (i = 0; i < dimension; i++) eigenvector[i] = a[i];
+  }
+  return info;
+}
+
+static int GeneralizedEigenComplex(const double complex *hamiltonian,
+                                   const double complex *overlap,
+                                   int dimension, double epsilon,
+                                   double *eigenvalue,
+                                   double complex *eigenvector) {
+  double complex a[LANCZOS2_MAX_DIMENSION * LANCZOS2_MAX_DIMENSION];
+  double complex b[LANCZOS2_MAX_DIMENSION * LANCZOS2_MAX_DIMENSION];
+  double eigenvalues[LANCZOS2_MAX_DIMENSION];
+  double complex work[64];
+  double realWork[3 * LANCZOS2_MAX_DIMENSION - 2];
+  const int itype = 1;
+  const int leadingDimension = dimension;
+  const int workSize = (int)(sizeof(work) / sizeof(work[0]));
+  const char jobz = 'V';
+  const char uplo = 'U';
+  int i;
+  int info = 0;
+  RowMajorToColumnMajorComplex(hamiltonian, a, dimension);
+  RowMajorToColumnMajorComplex(overlap, b, dimension);
+  for (i = 0; i < dimension; i++) b[i + i * dimension] += epsilon;
+  M_ZHEGV(&itype, &jobz, &uplo, &dimension, a, &leadingDimension, b,
+          &leadingDimension, eigenvalues, work, &workSize, realWork, &info);
+  if (info == 0) {
+    *eigenvalue = eigenvalues[0];
+    for (i = 0; i < dimension; i++) eigenvector[i] = a[i];
+  }
+  return info;
+}
+
+static double QuadraticReal(const double *coefficient, const double *matrix,
+                            int dimension) {
+  double value = 0.0;
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      value += coefficient[a] *
+               matrix[MATRIX_INDEX(a, b, dimension)] * coefficient[b];
+    }
+  }
+  return value;
+}
+
+static double complex QuadraticComplex(const double complex *coefficient,
+                                       const double complex *matrix,
+                                       int dimension) {
+  double complex value = 0.0;
+  int a;
+  int b;
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      value += conj(coefficient[a]) *
+               matrix[MATRIX_INDEX(a, b, dimension)] * coefficient[b];
+    }
+  }
+  return value;
+}
+
+static void FinalizeVariance(Lanczos2Result *result, double h2) {
+  const double energySquared = result->energy * result->energy;
+  const double scale = fmax(fmax(fabs(h2), energySquared), 1.0);
+  result->variance = h2 - energySquared;
+  if (result->variance < 0.0 &&
+      fabs(result->variance) <= 128.0 * DBL_EPSILON * scale) {
+    result->variance = 0.0;
+  }
+  if (energySquared > DBL_MIN) {
+    result->varianceOverEnergySquared =
+        result->variance / energySquared;
+  } else {
+    result->varianceOverEnergySquared = NAN;
+  }
+}
+
+static Lanczos2SolveStatus FinalizeReal(
+    const double *overlap, const double *hamiltonian,
+    const double *hamiltonianSquared, const double *transform,
+    const double *diagonalScale, const double *eigenvector,
+    double shiftedEigenvalue, Lanczos2Result *result) {
+  double shiftedCoefficient[LANCZOS2_MAX_DIMENSION] = {0.0, 0.0, 0.0};
+  double coefficient[LANCZOS2_MAX_DIMENSION] = {0.0, 0.0, 0.0};
+  double normalization;
+  double maximum = 0.0;
+  double h2;
+  int maximumIndex = 0;
+  int a;
+  int j;
+  for (a = 0; a < result->dimension; a++) {
+    shiftedCoefficient[a] = diagonalScale[a] * eigenvector[a];
+  }
+  for (j = 0; j < result->dimension; j++) {
+    for (a = j; a < result->dimension; a++) {
+      coefficient[j] +=
+          transform[MATRIX_INDEX(a, j, LANCZOS2_POWER_COUNT)] *
+          shiftedCoefficient[a];
+    }
+  }
+  normalization =
+      QuadraticReal(coefficient, overlap, result->dimension);
+  if (!isfinite(normalization) || !(normalization > 0.0)) {
+    return LANCZOS2_SOLVE_NORMALIZATION_FAILURE;
+  }
+  normalization = sqrt(normalization);
+  for (a = 0; a < result->dimension; a++) {
+    coefficient[a] /= normalization;
+    if (fabs(coefficient[a]) > maximum) {
+      maximum = fabs(coefficient[a]);
+      maximumIndex = a;
+    }
+  }
+  if (coefficient[maximumIndex] < 0.0) {
+    for (a = 0; a < result->dimension; a++) coefficient[a] = -coefficient[a];
+  }
+  for (a = 0; a < result->dimension; a++) {
+    result->coefficient[a] = coefficient[a];
+  }
+  result->energy =
+      QuadraticReal(coefficient, hamiltonian, result->dimension);
+  h2 = QuadraticReal(coefficient, hamiltonianSquared, result->dimension);
+  if (!isfinite(result->energy) || !isfinite(h2) ||
+      !isfinite(shiftedEigenvalue)) {
+    return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  }
+  FinalizeVariance(result, h2);
+  if (!isfinite(result->variance)) {
+    return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  }
+  result->eigenvalueResidual =
+      RelativeResidual(fabs((shiftedEigenvalue + result->shift) -
+                            result->energy),
+                       fmax(fabs(result->energy), 1.0));
+  if (fabs(coefficient[0]) >
+      64.0 * DBL_EPSILON * fmax(maximum, DBL_MIN)) {
+    for (a = 1; a < result->dimension; a++) {
+      result->alpha[a - 1] = coefficient[a] / coefficient[0];
+    }
+  } else {
+    result->solveFlags |= LANCZOS2_FLAG_ALPHA_UNDEFINED;
+  }
+  return LANCZOS2_SOLVE_OK;
+}
+
+static Lanczos2SolveStatus FinalizeComplex(
+    const double complex *overlap, const double complex *hamiltonian,
+    const double complex *hamiltonianSquared, const double *transform,
+    const double *diagonalScale, const double complex *eigenvector,
+    double shiftedEigenvalue, Lanczos2Result *result) {
+  double complex shiftedCoefficient[LANCZOS2_MAX_DIMENSION] = {0.0, 0.0,
+                                                               0.0};
+  double complex coefficient[LANCZOS2_MAX_DIMENSION] = {0.0, 0.0, 0.0};
+  double complex normalizationComplex;
+  double normalization;
+  double maximum = 0.0;
+  double h2;
+  double complex phase;
+  int maximumIndex = 0;
+  int a;
+  int j;
+  for (a = 0; a < result->dimension; a++) {
+    shiftedCoefficient[a] = diagonalScale[a] * eigenvector[a];
+  }
+  for (j = 0; j < result->dimension; j++) {
+    for (a = j; a < result->dimension; a++) {
+      coefficient[j] +=
+          transform[MATRIX_INDEX(a, j, LANCZOS2_POWER_COUNT)] *
+          shiftedCoefficient[a];
+    }
+  }
+  normalizationComplex =
+      QuadraticComplex(coefficient, overlap, result->dimension);
+  normalization = creal(normalizationComplex);
+  if (!isfinite(normalization) || !isfinite(cimag(normalizationComplex)) ||
+      !(normalization > 0.0)) {
+    return LANCZOS2_SOLVE_NORMALIZATION_FAILURE;
+  }
+  normalization = sqrt(normalization);
+  for (a = 0; a < result->dimension; a++) {
+    coefficient[a] /= normalization;
+    if (cabs(coefficient[a]) > maximum) {
+      maximum = cabs(coefficient[a]);
+      maximumIndex = a;
+    }
+  }
+  phase = conj(coefficient[maximumIndex]) / maximum;
+  for (a = 0; a < result->dimension; a++) coefficient[a] *= phase;
+  for (a = 0; a < result->dimension; a++) {
+    result->coefficient[a] = coefficient[a];
+  }
+  result->energy =
+      creal(QuadraticComplex(coefficient, hamiltonian, result->dimension));
+  h2 = creal(QuadraticComplex(coefficient, hamiltonianSquared,
+                             result->dimension));
+  if (!isfinite(result->energy) || !isfinite(h2) ||
+      !isfinite(shiftedEigenvalue)) {
+    return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  }
+  FinalizeVariance(result, h2);
+  if (!isfinite(result->variance)) {
+    return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  }
+  result->eigenvalueResidual =
+      RelativeResidual(fabs((shiftedEigenvalue + result->shift) -
+                            result->energy),
+                       fmax(fabs(result->energy), 1.0));
+  if (cabs(coefficient[0]) >
+      64.0 * DBL_EPSILON * fmax(maximum, DBL_MIN)) {
+    for (a = 1; a < result->dimension; a++) {
+      result->alpha[a - 1] = coefficient[a] / coefficient[0];
+    }
+  } else {
+    result->solveFlags |= LANCZOS2_FLAG_ALPHA_UNDEFINED;
+  }
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus SolveLanczos2Real(
+    const double moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    Lanczos2Result *result) {
+  double projected[LANCZOS2_MOMENT_COUNT];
+  double shifted[LANCZOS2_MOMENT_COUNT];
+  double transform[LANCZOS2_MOMENT_COUNT];
+  double overlap[9];
+  double hamiltonian[9];
+  double hamiltonianSquared[9];
+  double shiftedOverlap[9];
+  double shiftedHamiltonian[9];
+  double shiftedHamiltonianSquared[9];
+  double equilibratedOverlap[9];
+  double equilibratedHamiltonian[9];
+  double diagonalScale[LANCZOS2_MAX_DIMENSION];
+  double eigenvector[LANCZOS2_MAX_DIMENSION];
+  double shiftedEigenvalue = NAN;
+  double maximumDiagonal = 0.0;
+  Lanczos2SolveStatus status;
+  int a;
+  int b;
+  int info;
+
+  if (moment == NULL || result == NULL || !ValidDimension(dimension)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  ClearResult(result, dimension);
+  status = ProjectMomentReal(moment, projected,
+                             &result->antiHermitianResidual);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  result->hankelResidual = HankelResidualReal(projected);
+  if (!(projected[0] > 0.0) || !isfinite(projected[0])) {
+    return LANCZOS2_SOLVE_INVALID_M00;
+  }
+  result->shift = projected[1] / projected[0];
+  if (!isfinite(result->shift)) return LANCZOS2_SOLVE_INVALID_M00;
+
+  MatricesFromProjectedMomentReal(projected, dimension, overlap, hamiltonian,
+                                  hamiltonianSquared);
+  BuildShiftTransform(result->shift, transform);
+  TransformMomentReal(transform, projected, shifted);
+  MatricesFromProjectedMomentReal(shifted, dimension, shiftedOverlap,
+                                  shiftedHamiltonian,
+                                  shiftedHamiltonianSquared);
+
+  for (a = 0; a < dimension; a++) {
+    const double diagonal =
+        shiftedOverlap[MATRIX_INDEX(a, a, dimension)];
+    if (!isfinite(diagonal) || !(diagonal > 0.0)) {
+      return LANCZOS2_SOLVE_NONPOSITIVE_DIAGONAL;
+    }
+    diagonalScale[a] = 1.0 / sqrt(diagonal);
+  }
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      equilibratedOverlap[MATRIX_INDEX(a, b, dimension)] =
+          diagonalScale[a] *
+          shiftedOverlap[MATRIX_INDEX(a, b, dimension)] *
+          diagonalScale[b];
+      equilibratedHamiltonian[MATRIX_INDEX(a, b, dimension)] =
+          diagonalScale[a] *
+          shiftedHamiltonian[MATRIX_INDEX(a, b, dimension)] *
+          diagonalScale[b];
+      if (!isfinite(equilibratedOverlap[MATRIX_INDEX(a, b, dimension)]) ||
+          !isfinite(
+              equilibratedHamiltonian[MATRIX_INDEX(a, b, dimension)])) {
+        return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+      }
+    }
+    maximumDiagonal =
+        fmax(maximumDiagonal,
+             equilibratedOverlap[MATRIX_INDEX(a, a, dimension)]);
+  }
+
+  info = GeneralizedEigenReal(equilibratedHamiltonian,
+                              equilibratedOverlap, dimension, 0.0,
+                              &shiftedEigenvalue, eigenvector);
+  if (info > dimension) {
+    result->epsilon = fmax(maximumDiagonal, 1.0) * 1.0e-12;
+    result->solveFlags |= LANCZOS2_FLAG_REGULARIZED;
+    info = GeneralizedEigenReal(equilibratedHamiltonian,
+                                equilibratedOverlap, dimension,
+                                result->epsilon, &shiftedEigenvalue,
+                                eigenvector);
+  }
+  result->lapackInfo = info;
+  if (info != 0) return LANCZOS2_SOLVE_LAPACK_FAILURE;
+  return FinalizeReal(overlap, hamiltonian, hamiltonianSquared, transform,
+                      diagonalScale, eigenvector, shiftedEigenvalue, result);
+}
+
+Lanczos2SolveStatus SolveLanczos2Complex(
+    const double complex moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    Lanczos2Result *result) {
+  double complex projected[LANCZOS2_MOMENT_COUNT];
+  double complex shifted[LANCZOS2_MOMENT_COUNT];
+  double transform[LANCZOS2_MOMENT_COUNT];
+  double complex overlap[9];
+  double complex hamiltonian[9];
+  double complex hamiltonianSquared[9];
+  double complex shiftedOverlap[9];
+  double complex shiftedHamiltonian[9];
+  double complex shiftedHamiltonianSquared[9];
+  double complex equilibratedOverlap[9];
+  double complex equilibratedHamiltonian[9];
+  double diagonalScale[LANCZOS2_MAX_DIMENSION];
+  double complex eigenvector[LANCZOS2_MAX_DIMENSION];
+  double shiftedEigenvalue = NAN;
+  double maximumDiagonal = 0.0;
+  Lanczos2SolveStatus status;
+  int a;
+  int b;
+  int info;
+
+  if (moment == NULL || result == NULL || !ValidDimension(dimension)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  ClearResult(result, dimension);
+  status = ProjectMomentComplex(moment, projected,
+                                &result->antiHermitianResidual);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  result->hankelResidual = HankelResidualComplex(projected);
+  if (!(creal(projected[0]) > 0.0) || !isfinite(creal(projected[0]))) {
+    return LANCZOS2_SOLVE_INVALID_M00;
+  }
+  result->shift = creal(projected[1]) / creal(projected[0]);
+  if (!isfinite(result->shift)) return LANCZOS2_SOLVE_INVALID_M00;
+
+  MatricesFromProjectedMomentComplex(projected, dimension, overlap,
+                                     hamiltonian, hamiltonianSquared);
+  BuildShiftTransform(result->shift, transform);
+  TransformMomentComplex(transform, projected, shifted);
+  MatricesFromProjectedMomentComplex(
+      shifted, dimension, shiftedOverlap, shiftedHamiltonian,
+      shiftedHamiltonianSquared);
+
+  for (a = 0; a < dimension; a++) {
+    const double diagonal =
+        creal(shiftedOverlap[MATRIX_INDEX(a, a, dimension)]);
+    if (!isfinite(diagonal) || !(diagonal > 0.0)) {
+      return LANCZOS2_SOLVE_NONPOSITIVE_DIAGONAL;
+    }
+    diagonalScale[a] = 1.0 / sqrt(diagonal);
+  }
+  for (a = 0; a < dimension; a++) {
+    for (b = 0; b < dimension; b++) {
+      equilibratedOverlap[MATRIX_INDEX(a, b, dimension)] =
+          diagonalScale[a] *
+          shiftedOverlap[MATRIX_INDEX(a, b, dimension)] *
+          diagonalScale[b];
+      equilibratedHamiltonian[MATRIX_INDEX(a, b, dimension)] =
+          diagonalScale[a] *
+          shiftedHamiltonian[MATRIX_INDEX(a, b, dimension)] *
+          diagonalScale[b];
+      if (!isfinite(
+              creal(equilibratedOverlap[MATRIX_INDEX(a, b, dimension)])) ||
+          !isfinite(
+              cimag(equilibratedOverlap[MATRIX_INDEX(a, b, dimension)])) ||
+          !isfinite(creal(equilibratedHamiltonian[
+              MATRIX_INDEX(a, b, dimension)])) ||
+          !isfinite(cimag(equilibratedHamiltonian[
+              MATRIX_INDEX(a, b, dimension)]))) {
+        return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+      }
+    }
+    maximumDiagonal =
+        fmax(maximumDiagonal,
+             creal(equilibratedOverlap[MATRIX_INDEX(a, a, dimension)]));
+  }
+
+  info = GeneralizedEigenComplex(equilibratedHamiltonian,
+                                 equilibratedOverlap, dimension, 0.0,
+                                 &shiftedEigenvalue, eigenvector);
+  if (info > dimension) {
+    result->epsilon = fmax(maximumDiagonal, 1.0) * 1.0e-12;
+    result->solveFlags |= LANCZOS2_FLAG_REGULARIZED;
+    info = GeneralizedEigenComplex(equilibratedHamiltonian,
+                                   equilibratedOverlap, dimension,
+                                   result->epsilon, &shiftedEigenvalue,
+                                   eigenvector);
+  }
+  result->lapackInfo = info;
+  if (info != 0) return LANCZOS2_SOLVE_LAPACK_FAILURE;
+  return FinalizeComplex(overlap, hamiltonian, hamiltonianSquared, transform,
+                         diagonalScale, eigenvector, shiftedEigenvalue,
+                         result);
+}
+
+static Lanczos2SolveStatus RestoreExternalShift(
+    double basisShift, Lanczos2Result *result) {
+  double transform[LANCZOS2_MOMENT_COUNT];
+  double complex shiftedCoefficient[LANCZOS2_MAX_DIMENSION];
+  double maximum = 0.0;
+  double oldEnergyScale;
+  double newEnergyScale;
+  double complex phase;
+  int maximumIndex = 0;
+  int a;
+  int j;
+  if (result == NULL || !isfinite(basisShift)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  BuildShiftTransform(basisShift, transform);
+  memcpy(shiftedCoefficient, result->coefficient,
+         sizeof(shiftedCoefficient));
+  memset(result->coefficient, 0, sizeof(result->coefficient));
+  for (j = 0; j < result->dimension; j++) {
+    for (a = j; a < result->dimension; a++) {
+      result->coefficient[j] +=
+          transform[MATRIX_INDEX(a, j, LANCZOS2_POWER_COUNT)] *
+          shiftedCoefficient[a];
+    }
+  }
+  for (a = 0; a < result->dimension; a++) {
+    if (!isfinite(creal(result->coefficient[a])) ||
+        !isfinite(cimag(result->coefficient[a]))) {
+      return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+    }
+    if (cabs(result->coefficient[a]) > maximum) {
+      maximum = cabs(result->coefficient[a]);
+      maximumIndex = a;
+    }
+  }
+  if (!(maximum > 0.0) || !isfinite(maximum)) {
+    return LANCZOS2_SOLVE_NORMALIZATION_FAILURE;
+  }
+  phase = conj(result->coefficient[maximumIndex]) / maximum;
+  for (a = 0; a < result->dimension; a++) {
+    result->coefficient[a] *= phase;
+  }
+
+  oldEnergyScale = fmax(fabs(result->energy), 1.0);
+  result->energy += basisShift;
+  result->shift += basisShift;
+  if (!isfinite(result->energy) || !isfinite(result->shift)) {
+    return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+  }
+  newEnergyScale = fmax(fabs(result->energy), 1.0);
+  result->eigenvalueResidual *= oldEnergyScale / newEnergyScale;
+  if (result->energy * result->energy > DBL_MIN) {
+    result->varianceOverEnergySquared =
+        result->variance / (result->energy * result->energy);
+  } else {
+    result->varianceOverEnergySquared = NAN;
+  }
+
+  result->solveFlags &= ~LANCZOS2_FLAG_ALPHA_UNDEFINED;
+  memset(result->alpha, 0, sizeof(result->alpha));
+  if (cabs(result->coefficient[0]) >
+      64.0 * DBL_EPSILON * fmax(maximum, DBL_MIN)) {
+    for (a = 1; a < result->dimension; a++) {
+      result->alpha[a - 1] =
+          result->coefficient[a] / result->coefficient[0];
+    }
+  } else {
+    result->solveFlags |= LANCZOS2_FLAG_ALPHA_UNDEFINED;
+  }
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus SolveLanczos2ShiftedReal(
+    const double moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double basisShift, Lanczos2Result *result) {
+  Lanczos2SolveStatus status;
+  if (!isfinite(basisShift)) return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  status = SolveLanczos2Real(moment, dimension, result);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  return RestoreExternalShift(basisShift, result);
+}
+
+Lanczos2SolveStatus SolveLanczos2ShiftedComplex(
+    const double complex moment[LANCZOS2_MOMENT_COUNT], int dimension,
+    double basisShift, Lanczos2Result *result) {
+  Lanczos2SolveStatus status;
+  if (!isfinite(basisShift)) return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  status = SolveLanczos2Complex(moment, dimension, result);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  return RestoreExternalShift(basisShift, result);
+}
+
+const char *Lanczos2SolveError(Lanczos2SolveStatus status) {
+  switch (status) {
+    case LANCZOS2_SOLVE_OK:
+      return "";
+    case LANCZOS2_SOLVE_INVALID_ARGUMENT:
+      return "invalid Lanczos2 solver argument";
+    case LANCZOS2_SOLVE_NONFINITE_MOMENT:
+      return "Lanczos2 moment or transformed matrix is not finite";
+    case LANCZOS2_SOLVE_INVALID_M00:
+      return "Lanczos2 M[0,0] or energy shift is invalid";
+    case LANCZOS2_SOLVE_NONPOSITIVE_DIAGONAL:
+      return "Lanczos2 shifted overlap has a non-positive diagonal";
+    case LANCZOS2_SOLVE_LAPACK_FAILURE:
+      return "Lanczos2 generalized eigensolver failed";
+    case LANCZOS2_SOLVE_NORMALIZATION_FAILURE:
+      return "Lanczos2 coefficient has non-positive overlap norm";
+    case LANCZOS2_SOLVE_IO_FAILURE:
+      return "Lanczos2 output write failed";
+  }
+  return "unknown Lanczos2 solver error";
+}
+
+Lanczos2SolveStatus AccumulateLanczos2MomentReal(
+    double moment[LANCZOS2_MOMENT_COUNT],
+    const double localPower[LANCZOS2_POWER_COUNT], double weight) {
+  double updatedMoment[LANCZOS2_MOMENT_COUNT];
+  int a;
+  int b;
+  if (moment == NULL || localPower == NULL || !isfinite(weight)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    if (!isfinite(localPower[a])) {
+      return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+    }
+  }
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      const int index = MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT);
+      const double term = weight * localPower[a] * localPower[b];
+      updatedMoment[index] = moment[index] + term;
+      if (!isfinite(moment[index]) || !isfinite(term) ||
+          !isfinite(updatedMoment[index])) {
+        return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+      }
+    }
+  }
+  memcpy(moment, updatedMoment, sizeof(updatedMoment));
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus AccumulateLanczos2MomentComplex(
+    double complex moment[LANCZOS2_MOMENT_COUNT],
+    const double complex localPower[LANCZOS2_POWER_COUNT], double weight) {
+  double complex updatedMoment[LANCZOS2_MOMENT_COUNT];
+  int a;
+  int b;
+  if (moment == NULL || localPower == NULL || !isfinite(weight)) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    if (!isfinite(creal(localPower[a])) ||
+        !isfinite(cimag(localPower[a]))) {
+      return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+    }
+  }
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      const int index = MATRIX_INDEX(a, b, LANCZOS2_POWER_COUNT);
+      const double complex term =
+          weight * conj(localPower[a]) * localPower[b];
+      updatedMoment[index] = moment[index] + term;
+      if (!isfinite(creal(moment[index])) ||
+          !isfinite(cimag(moment[index])) || !isfinite(creal(term)) ||
+          !isfinite(cimag(term)) || !isfinite(creal(updatedMoment[index])) ||
+          !isfinite(cimag(updatedMoment[index]))) {
+        return LANCZOS2_SOLVE_NONFINITE_MOMENT;
+      }
+    }
+  }
+  memcpy(moment, updatedMoment, sizeof(updatedMoment));
+  return LANCZOS2_SOLVE_OK;
+}
+
+static int WriteLanczos2ResultRecord(FILE *output,
+                                     const Lanczos2Result *result) {
+  if (fprintf(
+          output,
+          "# mVMC ls2_out v1 E sigma2_over_E2 "
+          "c0_re c0_im c1_re c1_im c2_re c2_im "
+          "alpha1_re alpha1_im alpha2_re alpha2_im "
+          "solve_flag epsilon shift antihermitian_residual "
+          "hankel_residual\n") < 0) {
+    return -1;
+  }
+  if (fprintf(
+          output,
+          "% .18e % .18e "
+          "% .18e % .18e % .18e % .18e % .18e % .18e "
+          "% .18e % .18e % .18e % .18e "
+          "%d % .18e % .18e % .18e % .18e\n",
+          result->energy, result->varianceOverEnergySquared,
+          creal(result->coefficient[0]), cimag(result->coefficient[0]),
+          creal(result->coefficient[1]), cimag(result->coefficient[1]),
+          creal(result->coefficient[2]), cimag(result->coefficient[2]),
+          creal(result->alpha[0]), cimag(result->alpha[0]),
+          creal(result->alpha[1]), cimag(result->alpha[1]),
+          result->solveFlags, result->epsilon, result->shift,
+          result->antiHermitianResidual, result->hankelResidual) < 0) {
+    return -1;
+  }
+  return ferror(output) ? -1 : 0;
+}
+
+static int WriteLanczos2MomentHeader(FILE *momentOutput,
+                                     double basisShift) {
+  int a;
+  int b;
+  if (fprintf(momentOutput,
+              "# mVMC ls2_moment v2 basis_shift=% .18e",
+              basisShift) < 0) {
+    return -1;
+  }
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      if (fprintf(momentOutput, " M%d%d_re M%d%d_im", a, b, a, b) < 0) {
+        return -1;
+      }
+    }
+  }
+  return fprintf(momentOutput, "\n") < 0 ? -1 : 0;
+}
+
+Lanczos2SolveStatus WriteLanczos2OutputReal(
+    FILE *output, FILE *momentOutput,
+    const double moment[LANCZOS2_MOMENT_COUNT], double basisShift,
+    Lanczos2Result *result) {
+  Lanczos2SolveStatus status;
+  int i;
+  if (output == NULL || momentOutput == NULL || moment == NULL ||
+      result == NULL) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  status = SolveLanczos2ShiftedReal(moment, 3, basisShift, result);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  if (WriteLanczos2ResultRecord(output, result) != 0 ||
+      WriteLanczos2MomentHeader(momentOutput, basisShift) != 0) {
+    return LANCZOS2_SOLVE_IO_FAILURE;
+  }
+  for (i = 0; i < LANCZOS2_MOMENT_COUNT; i++) {
+    if (fprintf(momentOutput, "%s% .18e % .18e",
+                i == 0 ? "" : " ", moment[i], 0.0) < 0) {
+      return LANCZOS2_SOLVE_IO_FAILURE;
+    }
+  }
+  if (fprintf(momentOutput, "\n") < 0 || ferror(momentOutput)) {
+    return LANCZOS2_SOLVE_IO_FAILURE;
+  }
+  return LANCZOS2_SOLVE_OK;
+}
+
+Lanczos2SolveStatus WriteLanczos2OutputComplex(
+    FILE *output, FILE *momentOutput,
+    const double complex moment[LANCZOS2_MOMENT_COUNT],
+    double basisShift, Lanczos2Result *result) {
+  Lanczos2SolveStatus status;
+  int i;
+  if (output == NULL || momentOutput == NULL || moment == NULL ||
+      result == NULL) {
+    return LANCZOS2_SOLVE_INVALID_ARGUMENT;
+  }
+  status = SolveLanczos2ShiftedComplex(moment, 3, basisShift, result);
+  if (status != LANCZOS2_SOLVE_OK) return status;
+  if (WriteLanczos2ResultRecord(output, result) != 0 ||
+      WriteLanczos2MomentHeader(momentOutput, basisShift) != 0) {
+    return LANCZOS2_SOLVE_IO_FAILURE;
+  }
+  for (i = 0; i < LANCZOS2_MOMENT_COUNT; i++) {
+    if (fprintf(momentOutput, "%s% .18e % .18e",
+                i == 0 ? "" : " ", creal(moment[i]),
+                cimag(moment[i])) < 0) {
+      return LANCZOS2_SOLVE_IO_FAILURE;
+    }
+  }
+  if (fprintf(momentOutput, "\n") < 0 || ferror(momentOutput)) {
+    return LANCZOS2_SOLVE_IO_FAILURE;
+  }
+  return LANCZOS2_SOLVE_OK;
+}

--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -32,6 +32,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #include <math.h>
 #include <stdlib.h>
 #include "./include/backflow.h"
+#include "./include/lanczos2_contract.h"
 #include "./include/readdef.h"
 #include "./include/global.h"
 #include "safempi_fcmp.c"
@@ -965,6 +966,7 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
 
   NVMCCalMode = bufInt[IdxVMCCalcMode];
   NLanczosMode = bufInt[IdxLanczosMode];
+  NLanczosStep = bufInt[IdxLanczosStep];
   NDataIdxStart = bufInt[IdxDataIdxStart];
   NDataQtySmp = bufInt[IdxDataQtySmp];
   Nsite = bufInt[IdxNsite];
@@ -1277,6 +1279,40 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
 
   if (BFComputeSizes(NBackFlowIdx, Nrange, NzBF, &NrangeIdx, &NBFIdxTotal, &NProjBF) != 0) {
     MPI_Abort(comm, EXIT_FAILURE);
+  }
+
+  {
+    const Lanczos2Contract lanczos2Contract = {
+        NLanczosStep,
+        NLanczosMode,
+        NVMCCalMode,
+        iFlgOrbitalGeneral,
+        NProjBF,
+        FlagRBM,
+        NExUpdatePath,
+        NPairHopping,
+        NExchangeCoupling,
+        NInterAll,
+        NNBodyInterAll,
+        NNBodyG,
+        0 /* Transfer contents are validated after ReadDefFileIdxPara. */};
+    int lanczos2StatusCode = LANCZOS2_CONTRACT_OK;
+    Lanczos2ContractStatus lanczos2Status;
+    if (rank == 0) {
+      lanczos2StatusCode =
+          (int)ValidateLanczos2Contract(&lanczos2Contract);
+    }
+#ifdef _mpi_use
+    MPI_Bcast(&lanczos2StatusCode, 1, MPI_INT, 0, comm);
+#endif
+    lanczos2Status = (Lanczos2ContractStatus)lanczos2StatusCode;
+    if (lanczos2Status != LANCZOS2_CONTRACT_OK) {
+      if (rank == 0) {
+        fprintf(stderr, "Error: %s.\n",
+                Lanczos2ContractError(lanczos2Status));
+      }
+      MPI_Abort(comm, EXIT_FAILURE);
+    }
   }
 
   /* BFValidateSettings has already rejected unsupported BackFlow Twist and
@@ -1702,6 +1738,36 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
   SafeMpiBcast(ParaCoulombIntra, NTotalDefDouble, comm);
   SafeMpiBcast_fcmp(ParaQPTrans, NQPTrans, comm);
 #endif /* _mpi_use */
+
+  {
+    int nSpinFlipTransfer = 0;
+    Lanczos2ContractStatus lanczos2Status;
+    Lanczos2Contract lanczos2Contract;
+    for (i = 0; i < NTransfer; i++) {
+      if (Transfer[i][1] != Transfer[i][3]) nSpinFlipTransfer++;
+    }
+    lanczos2Contract.step = NLanczosStep;
+    lanczos2Contract.lanczosMode = NLanczosMode;
+    lanczos2Contract.vmcCalMode = NVMCCalMode;
+    lanczos2Contract.orbitalGeneral = iFlgOrbitalGeneral;
+    lanczos2Contract.nProjBF = NProjBF;
+    lanczos2Contract.flagRBM = FlagRBM;
+    lanczos2Contract.exUpdatePath = NExUpdatePath;
+    lanczos2Contract.nPairHopping = NPairHopping;
+    lanczos2Contract.nExchangeCoupling = NExchangeCoupling;
+    lanczos2Contract.nInterAll = NInterAll;
+    lanczos2Contract.nNBodyInterAll = NNBodyInterAll;
+    lanczos2Contract.nNBodyG = NNBodyG;
+    lanczos2Contract.nSpinFlipTransfer = nSpinFlipTransfer;
+    lanczos2Status = ValidateLanczos2Contract(&lanczos2Contract);
+    if (lanczos2Status != LANCZOS2_CONTRACT_OK) {
+      if (rank == 0) {
+        fprintf(stderr, "Error: %s.\n",
+                Lanczos2ContractError(lanczos2Status));
+      }
+      MPI_Abort(comm, EXIT_FAILURE);
+    }
+  }
 
   /* set FlagShift */
   if (NVMCCalMode == 0) {
@@ -2342,6 +2408,7 @@ int GetFileName(
 void SetDefaultValuesModPara(int *bufInt, double *bufDouble) {
   bufInt[IdxVMCCalcMode] = 0;
   bufInt[IdxLanczosMode] = 0;
+  bufInt[IdxLanczosStep] = 1;
   bufInt[IdxDataIdxStart] = 0;
   bufInt[IdxDataQtySmp] = 1;
   bufInt[IdxNsite] = 16;
@@ -2485,6 +2552,14 @@ int GetInfoFromModPara(int *bufInt, double *bufDouble) {
               bufInt[IdxVMCCalcMode] = (int) dtmp;
             } else if (CheckWords(ctmp, "NLanczosMode") == 0) {
               bufInt[IdxLanczosMode] = (int) dtmp;
+            } else if (CheckWords(ctmp, "NLanczosStep") == 0) {
+              /*
+               * Do not silently truncate a fractional or non-finite step.
+               * Store an invalid sentinel and let the rank-safe capability
+               * gate issue the single canonical diagnostic.
+               */
+              bufInt[IdxLanczosStep] =
+                  (dtmp == 1.0 || dtmp == 2.0) ? (int)dtmp : 0;
             } else if (CheckWords(ctmp, "NDataIdxStart") == 0) {
               bufInt[IdxDataIdxStart] = (int) dtmp;
             } else if (CheckWords(ctmp, "NDataQtySmp") == 0) {

--- a/src/mVMC/setmemory.c
+++ b/src/mVMC/setmemory.c
@@ -28,12 +28,35 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 
 
 #include <complex.h>
+#include <stdint.h>
 #include "backflow.h"
 #include "global.h"
+#include "physcal_lanczos2.h"
 #include "setmemory.h"
 
 #ifndef _SRC_SETMEMORY
 #define _SRC_SETMEMORY
+
+static void *CheckedLanczos2Calloc(size_t count, size_t elementSize) {
+  void *result;
+  int rank = 0;
+  if (elementSize != 0 && count > SIZE_MAX / elementSize) {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank == 0) {
+      fprintf(stderr, "Error: Lanczos2 allocation size overflow.\n");
+    }
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+  result = calloc(count, elementSize);
+  if (result == NULL && count != 0) {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank == 0) {
+      fprintf(stderr, "Error: failed to allocate Lanczos2 buffers.\n");
+    }
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+  }
+  return result;
+}
 
 void SetMemoryDef() {
   int i, j;
@@ -464,7 +487,7 @@ void SetMemory() {
       PhysNBodyG = NULL;
     }
 
-    if(NLanczosMode>0){
+    if(NLanczosMode>0 && NLanczosStep==1){
       QQQQ = (double complex*)malloc(sizeof(double complex)
         *(NLSHam*NLSHam*NLSHam*NLSHam + NLSHam*NLSHam) );
       LSLQ = QQQQ + NLSHam*NLSHam*NLSHam*NLSHam;
@@ -488,6 +511,38 @@ void SetMemory() {
 
       }
     }
+    if(NLanczosMode>0 && NLanczosStep==2){
+      const size_t sampleCount = (size_t)NVMCSample;
+      if(NVMCSample <= 0) {
+        int rank = 0;
+        MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+        if(rank == 0) {
+          fprintf(stderr,
+                  "Error: Lanczos2 requires a positive NVMCSample.\n");
+        }
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+      }
+      if(AllComplexFlag==0){
+        LS2Moment_real = (double*)CheckedLanczos2Calloc(
+            LANCZOS2_MOMENT_COUNT + LANCZOS2_POWER_COUNT,
+            sizeof(double));
+        LS2LocalPower_real = LS2Moment_real + LANCZOS2_MOMENT_COUNT;
+        LS2SamplePower_real = (double*)CheckedLanczos2Calloc(
+            sampleCount * LANCZOS2_POWER_COUNT, sizeof(double));
+      }else{
+        LS2Moment = (double complex*)CheckedLanczos2Calloc(
+            LANCZOS2_MOMENT_COUNT + LANCZOS2_POWER_COUNT,
+            sizeof(double complex));
+        LS2LocalPower = LS2Moment + LANCZOS2_MOMENT_COUNT;
+        LS2SamplePower = (double complex*)CheckedLanczos2Calloc(
+            sampleCount * LANCZOS2_POWER_COUNT,
+            sizeof(double complex));
+      }
+      LS2SampleWeight = (double*)CheckedLanczos2Calloc(
+          sampleCount, sizeof(double));
+      LS2SampleValid = (unsigned char*)CheckedLanczos2Calloc(
+          sampleCount, sizeof(unsigned char));
+    }
   }
 
   initializeWorkSpaceAll();
@@ -500,13 +555,21 @@ void FreeMemory() {
   if(NVMCCalMode==1){
     free(PhysCisAjs);
     free(PhysNBodyG);
-    if(NLanczosMode>0){
+    if(NLanczosMode>0 && NLanczosStep==1){
       free(QQQQ);
       free(QQQQ_real);
       if(NLanczosMode>1){
         free(QCisAjsQ);
         free(QCisAjsQ_real);
       }
+    }
+    if(NLanczosMode>0 && NLanczosStep==2){
+      free(LS2Moment);
+      free(LS2Moment_real);
+      free(LS2SamplePower);
+      free(LS2SamplePower_real);
+      free(LS2SampleWeight);
+      free(LS2SampleValid);
     }
   }
 

--- a/src/mVMC/vmccal.c
+++ b/src/mVMC/vmccal.c
@@ -246,6 +246,7 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
   Lanczos2StateSnapshot lanczos2StateSnapshot;
 #ifdef MVMC_ENABLE_FAULT_INJECTION
   int lanczos2InjectNonfinite = 0;
+  int lanczos2CalHCAGuardAudit = 0;
 #endif
   MPI_Comm_size(comm,&size);
   MPI_Comm_rank(comm,&rank);
@@ -273,6 +274,27 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
     lanczos2InjectNonfinite =
         injectValue != NULL && injectValue[0] != '\0' &&
         strcmp(injectValue, "0") != 0;
+  }
+  {
+    const char *auditValue =
+        getenv("MVMC_LANCZOS2_TEST_CALHCA_GUARD_AUDIT");
+    lanczos2CalHCAGuardAudit =
+        auditValue != NULL && auditValue[0] != '\0' &&
+        strcmp(auditValue, "0") != 0;
+    if(lanczos2CalHCAGuardAudit &&
+       (parentSize != 1 || NVMCCalMode != 1 || NLanczosMode <= 0 ||
+        NLanczosStep != 2 || NQPFull <= 1)) {
+      fprintf(stderr,
+              "Error: Lanczos2 calHCA guard audit requires single-rank "
+              "step=2 physical calculation with NQPFull>1.\n");
+      MPI_Abort(comm_parent, EXIT_FAILURE);
+    }
+    Lanczos2CalHCAGuardAuditRealDirectCount = 0;
+    Lanczos2CalHCAGuardAuditRealZeroComponentCount = 0;
+    Lanczos2CalHCAGuardAuditComplexDirectCount = 0;
+    Lanczos2CalHCAGuardAuditComplexZeroComponentCount = 0;
+    Lanczos2CalHCAGuardAuditRealEnabled = lanczos2CalHCAGuardAudit;
+    Lanczos2CalHCAGuardAuditComplexEnabled = lanczos2CalHCAGuardAudit;
   }
 #endif
   if(NVMCCalMode == 1 && NLanczosMode > 0 && NLanczosStep == 2 &&
@@ -625,6 +647,31 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
       }
     }
   } /* end of for(sample) */
+
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if(lanczos2CalHCAGuardAudit) {
+    const long long directCount =
+        AllComplexFlag == 0
+            ? Lanczos2CalHCAGuardAuditRealDirectCount
+            : Lanczos2CalHCAGuardAuditComplexDirectCount;
+    const long long zeroComponentCount =
+        AllComplexFlag == 0
+            ? Lanczos2CalHCAGuardAuditRealZeroComponentCount
+            : Lanczos2CalHCAGuardAuditComplexZeroComponentCount;
+    if(directCount <= 0 || zeroComponentCount <= 0) {
+      fprintf(stderr,
+              "Error: Lanczos2 calHCA guard audit did not exercise a direct "
+              "multi-QP zero-component branch "
+              "(direct=%lld, zero_component=%lld).\n",
+              directCount,zeroComponentCount);
+      MPI_Abort(comm_parent, EXIT_FAILURE);
+    }
+    printf("Lanczos2 calHCA guard audit: %s direct=%lld "
+           "zero_component=%lld\n",
+           AllComplexFlag == 0 ? "real" : "complex",
+           directCount,zeroComponentCount);
+  }
+#endif
 
   if(lanczosOracleDump != NULL) fclose(lanczosOracleDump);
   Lanczos2StateSnapshotFree(&lanczos2StateSnapshot);

--- a/src/mVMC/vmccal.c
+++ b/src/mVMC/vmccal.c
@@ -30,7 +30,9 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "vmccal.h"
@@ -40,6 +42,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #include "lslocgrn_real.c"
 #include "lslocgrn.c"
 #include "calgrn.c"
+#include "physcal_lanczos2.h"
 
 //#define _DEBUG_VMCCAL
 //#define _DEBUG_VMCCAL_DETAIL
@@ -103,6 +106,121 @@ static void clearStoredOSampleRange(const int sampleStart, const int sampleEnd) 
   }
 }
 
+typedef struct {
+  int enabled;
+  int *discrete;
+  double *matrixReal;
+  double complex *matrixComplex;
+  size_t discreteCount;
+  size_t matrixCount;
+} Lanczos2StateSnapshot;
+
+static int Lanczos2StateSnapshotInit(Lanczos2StateSnapshot *snapshot) {
+  const char *value = getenv("MVMC_LANCZOS2_STATE_CHECK");
+  size_t matrixStride;
+  size_t matrixSize;
+  memset(snapshot, 0, sizeof(*snapshot));
+  if (value == NULL || value[0] == '\0' || strcmp(value, "0") == 0) {
+    return 0;
+  }
+  snapshot->enabled = 1;
+  if (Nsize < 0 || Nsite2 < 0 || NProj < 0 || NQPFull < 0 ||
+      (size_t)Nsite2 >
+          (SIZE_MAX - (size_t)Nsize - (size_t)NProj) / 2) {
+    return -1;
+  }
+  snapshot->discreteCount =
+      (size_t)Nsize + 2 * (size_t)Nsite2 + (size_t)NProj;
+  if (Nsize != 0 &&
+      (size_t)Nsize > SIZE_MAX / (size_t)Nsize) return -1;
+  matrixStride = (size_t)Nsize * (size_t)Nsize + 1;
+  if (matrixStride != 0 &&
+      (size_t)NQPFull > SIZE_MAX / matrixStride) return -1;
+  snapshot->matrixCount = (size_t)NQPFull * matrixStride;
+  if (snapshot->discreteCount > SIZE_MAX / sizeof(*snapshot->discrete)) {
+    return -1;
+  }
+  snapshot->discrete =
+      (int *)malloc(snapshot->discreteCount * sizeof(*snapshot->discrete));
+  matrixSize = AllComplexFlag == 0 ? sizeof(*snapshot->matrixReal)
+                                   : sizeof(*snapshot->matrixComplex);
+  if (snapshot->matrixCount > SIZE_MAX / matrixSize) return -1;
+  if (AllComplexFlag == 0) {
+    snapshot->matrixReal =
+        (double *)malloc(snapshot->matrixCount * matrixSize);
+  } else {
+    snapshot->matrixComplex =
+        (double complex *)malloc(snapshot->matrixCount * matrixSize);
+  }
+  if (snapshot->discrete == NULL ||
+      (AllComplexFlag == 0 && snapshot->matrixReal == NULL) ||
+      (AllComplexFlag != 0 && snapshot->matrixComplex == NULL)) {
+    free(snapshot->discrete);
+    free(snapshot->matrixReal);
+    free(snapshot->matrixComplex);
+    memset(snapshot, 0, sizeof(*snapshot));
+    return -1;
+  }
+  return 0;
+}
+
+static void Lanczos2StateSnapshotCapture(
+    Lanczos2StateSnapshot *snapshot, const int *eleIdx, const int *eleCfg,
+    const int *eleNum, const int *eleProjCnt) {
+  int *destination;
+  if (!snapshot->enabled) return;
+  destination = snapshot->discrete;
+  memcpy(destination, eleIdx, (size_t)Nsize * sizeof(*destination));
+  destination += Nsize;
+  memcpy(destination, eleCfg, (size_t)Nsite2 * sizeof(*destination));
+  destination += Nsite2;
+  memcpy(destination, eleNum, (size_t)Nsite2 * sizeof(*destination));
+  destination += Nsite2;
+  if (NProj > 0) {
+    memcpy(destination, eleProjCnt, (size_t)NProj * sizeof(*destination));
+  }
+  if (AllComplexFlag == 0) {
+    memcpy(snapshot->matrixReal, InvM_real,
+           snapshot->matrixCount * sizeof(*snapshot->matrixReal));
+  } else {
+    memcpy(snapshot->matrixComplex, InvM,
+           snapshot->matrixCount * sizeof(*snapshot->matrixComplex));
+  }
+}
+
+static int Lanczos2StateSnapshotMatches(
+    const Lanczos2StateSnapshot *snapshot, const int *eleIdx,
+    const int *eleCfg, const int *eleNum, const int *eleProjCnt) {
+  const int *source;
+  if (!snapshot->enabled) return 1;
+  source = snapshot->discrete;
+  if (memcmp(source, eleIdx, (size_t)Nsize * sizeof(*source)) != 0) return 0;
+  source += Nsize;
+  if (memcmp(source, eleCfg, (size_t)Nsite2 * sizeof(*source)) != 0) return 0;
+  source += Nsite2;
+  if (memcmp(source, eleNum, (size_t)Nsite2 * sizeof(*source)) != 0) return 0;
+  source += Nsite2;
+  if (NProj > 0 &&
+      memcmp(source, eleProjCnt, (size_t)NProj * sizeof(*source)) != 0) {
+    return 0;
+  }
+  if (AllComplexFlag == 0) {
+    return memcmp(snapshot->matrixReal, InvM_real,
+                  snapshot->matrixCount *
+                      sizeof(*snapshot->matrixReal)) == 0;
+  }
+  return memcmp(snapshot->matrixComplex, InvM,
+                snapshot->matrixCount *
+                    sizeof(*snapshot->matrixComplex)) == 0;
+}
+
+static void Lanczos2StateSnapshotFree(Lanczos2StateSnapshot *snapshot) {
+  free(snapshot->discrete);
+  free(snapshot->matrixReal);
+  free(snapshot->matrixComplex);
+  memset(snapshot, 0, sizeof(*snapshot));
+}
+
 void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
   int *eleIdx,*eleCfg,*eleNum,*eleProjCnt;
   double complex e,ip;
@@ -125,6 +243,10 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
 
   int rank,size,parentRank,parentSize,int_i;
   FILE *lanczosOracleDump = NULL;
+  Lanczos2StateSnapshot lanczos2StateSnapshot;
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  int lanczos2InjectNonfinite = 0;
+#endif
   MPI_Comm_size(comm,&size);
   MPI_Comm_rank(comm,&rank);
   MPI_Comm_size(comm_parent,&parentSize);
@@ -138,6 +260,28 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
   StartTimer(24);
   clearPhysQuantity();
   StopTimer(24);
+
+  memset(&lanczos2StateSnapshot, 0, sizeof(lanczos2StateSnapshot));
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  /*
+   * Test-only hook for exercising the collective non-finite failure path.
+   * Production builds (Testing=OFF) do not compile this mutation.
+   */
+  {
+    const char *injectValue =
+        getenv("MVMC_LANCZOS2_TEST_NONFINITE_SAMPLE");
+    lanczos2InjectNonfinite =
+        injectValue != NULL && injectValue[0] != '\0' &&
+        strcmp(injectValue, "0") != 0;
+  }
+#endif
+  if(NVMCCalMode == 1 && NLanczosMode > 0 && NLanczosStep == 2 &&
+     Lanczos2StateSnapshotInit(&lanczos2StateSnapshot) != 0) {
+    fprintf(stderr,
+            "Error: failed to allocate Lanczos2 state snapshot on rank %d.\n",
+            parentRank);
+    MPI_Abort(comm_parent, EXIT_FAILURE);
+  }
 
   if(NVMCCalMode == 1 && NLanczosMode > 0) {
     const char *dumpValue = getenv("MVMC_LANCZOS_ORACLE_DUMP");
@@ -335,6 +479,7 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
 #ifdef _DEBUG_VMCCAL
   fprintf(stdout, "Debug: Start: Lanczos\n");
 #endif
+        if(NLanczosStep==1){
         // ignoring Lanczos: to be added
         /* Calculate local QQQQ */
         StartTimer(43);
@@ -387,11 +532,102 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
           }
           StopTimer(44);
         }
+        }else{
+          Lanczos2SolveStatus lanczos2Status;
+          StartTimer(95);
+          Lanczos2StateSnapshotCapture(
+              &lanczos2StateSnapshot,eleIdx,eleCfg,eleNum,eleProjCnt);
+          if(AllComplexFlag==0) {
+            CalculateLS2LocalPower_real(
+                creal(e),creal(ip),eleIdx,eleCfg,eleNum,eleProjCnt,
+                LS2LocalPower_real);
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+            if(lanczos2InjectNonfinite && parentRank == 0 &&
+               sample == sampleStart) {
+              LS2LocalPower_real[LANCZOS2_POWER_COUNT-1] = NAN;
+            }
+#endif
+            lanczos2Status = LANCZOS2_SOLVE_OK;
+            for(i=0; i<LANCZOS2_POWER_COUNT; i++) {
+              if(!isfinite(LS2LocalPower_real[i])) {
+                lanczos2Status = LANCZOS2_SOLVE_NONFINITE_MOMENT;
+                break;
+              }
+            }
+            if(lanczos2Status == LANCZOS2_SOLVE_OK) {
+              memcpy(LS2SamplePower_real +
+                         (size_t)sample * LANCZOS2_POWER_COUNT,
+                     LS2LocalPower_real,
+                     LANCZOS2_POWER_COUNT * sizeof(double));
+            }
+          }else{
+            CalculateLS2LocalPower(
+                e,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt,LS2LocalPower);
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+            if(lanczos2InjectNonfinite && parentRank == 0 &&
+               sample == sampleStart) {
+              LS2LocalPower[LANCZOS2_POWER_COUNT-1] = NAN + 0.0*I;
+            }
+#endif
+            lanczos2Status = LANCZOS2_SOLVE_OK;
+            for(i=0; i<LANCZOS2_POWER_COUNT; i++) {
+              if(!isfinite(creal(LS2LocalPower[i])) ||
+                 !isfinite(cimag(LS2LocalPower[i]))) {
+                lanczos2Status = LANCZOS2_SOLVE_NONFINITE_MOMENT;
+                break;
+              }
+            }
+            if(lanczos2Status == LANCZOS2_SOLVE_OK) {
+              memcpy(LS2SamplePower +
+                         (size_t)sample * LANCZOS2_POWER_COUNT,
+                     LS2LocalPower,
+                     LANCZOS2_POWER_COUNT * sizeof(double complex));
+            }
+          }
+          if(!Lanczos2StateSnapshotMatches(
+                 &lanczos2StateSnapshot,eleIdx,eleCfg,eleNum,eleProjCnt)) {
+            fprintf(stderr,
+                    "Error: Lanczos2 state restoration failure on rank %d, "
+                    "sample %d.\n",
+                    parentRank,sample);
+            MPI_Abort(comm_parent,EXIT_FAILURE);
+          }
+          if(lanczos2Status != LANCZOS2_SOLVE_OK) {
+            fprintf(stderr,
+                    "Error: Lanczos2 local power failure on rank %d, "
+                    "sample %d, stage accumulation: %s.\n",
+                    parentRank,sample,Lanczos2SolveError(lanczos2Status));
+            MPI_Abort(comm_parent,EXIT_FAILURE);
+          }
+          LS2SampleWeight[sample] = w;
+          LS2SampleValid[sample] = 1;
+          if(lanczosOracleDump != NULL) {
+            fprintf(lanczosOracleDump, "sample %d occ", sample);
+            for(i=0; i<Nsite2; i++) {
+              fprintf(lanczosOracleDump, " %d", eleNum[i]);
+            }
+            fprintf(lanczosOracleDump, " ls2power");
+            if(AllComplexFlag == 0) {
+              for(i=0; i<LANCZOS2_POWER_COUNT; i++) {
+                fprintf(lanczosOracleDump, " %.17e %.17e",
+                        LS2LocalPower_real[i],0.0);
+              }
+            }else{
+              for(i=0; i<LANCZOS2_POWER_COUNT; i++) {
+                fprintf(lanczosOracleDump, " %.17e %.17e",
+                        creal(LS2LocalPower[i]),cimag(LS2LocalPower[i]));
+              }
+            }
+            fprintf(lanczosOracleDump, "\n");
+          }
+          StopTimer(95);
+        }
       }
     }
   } /* end of for(sample) */
 
   if(lanczosOracleDump != NULL) fclose(lanczosOracleDump);
+  Lanczos2StateSnapshotFree(&lanczos2StateSnapshot);
 
 // calculate OO and HO at NVMCCalMode==0
   if(NVMCCalMode==0){
@@ -465,7 +701,7 @@ void clearPhysQuantity(){
 #pragma omp parallel for default(shared) private(i)
     for(i=0;i<NNBodyG;i++) vec[i] = 0.0+0.0*I;
 
-    if(NLanczosMode>0) {
+    if(NLanczosMode>0 && NLanczosStep==1) {
       /* QQQQ, LSLQ */
         //[TODO]: Check the value n
       n = NLSHam*NLSHam*NLSHam*NLSHam + NLSHam*NLSHam;
@@ -493,6 +729,28 @@ void clearPhysQuantity(){
 #pragma omp parallel for default(shared) private(i)
         for(i=0;i<n;i++) vec_real[i] = 0.0;
       }
+    }
+    if(NLanczosMode>0 && NLanczosStep==2) {
+      if(AllComplexFlag==0) {
+        for(i=0;i<LANCZOS2_MOMENT_COUNT+LANCZOS2_POWER_COUNT;i++) {
+          LS2Moment_real[i] = 0.0;
+        }
+        for(i=0;i<NVMCSample*LANCZOS2_POWER_COUNT;i++) {
+          LS2SamplePower_real[i] = 0.0;
+        }
+      }else{
+        for(i=0;i<LANCZOS2_MOMENT_COUNT+LANCZOS2_POWER_COUNT;i++) {
+          LS2Moment[i] = 0.0;
+        }
+        for(i=0;i<NVMCSample*LANCZOS2_POWER_COUNT;i++) {
+          LS2SamplePower[i] = 0.0;
+        }
+      }
+      for(i=0;i<NVMCSample;i++) {
+        LS2SampleWeight[i] = 0.0;
+        LS2SampleValid[i] = 0;
+      }
+      LS2MomentBasisShift = 0.0;
     }
   }
   return;

--- a/src/mVMC/vmcclock.c
+++ b/src/mVMC/vmcclock.c
@@ -914,6 +914,7 @@ void OutputTimerPhysCal() {
   OutputBFProfileCounters(fp);
   fprintf(fp,"    Lanczos1               [43] %12.5lf\n",Timer[43]);
   fprintf(fp,"    Lanczos2               [44] %12.5lf\n",Timer[44]);
+  fprintf(fp,"    2nd-step local powers  [95] %12.5lf\n",Timer[95]);
   fprintf(fp,"  UpdateSlaterElm          [20] %12.5lf\n",Timer[20]);
   fprintf(fp,"  WeightAverage            [21] %12.5lf\n",Timer[21]);
   fprintf(fp,"  outputData               [22] %12.5lf\n",Timer[22]);

--- a/src/mVMC/vmcmain.c
+++ b/src/mVMC/vmcmain.c
@@ -663,6 +663,7 @@ int VMCPhysCal(MPI_Comm comm_parent, MPI_Comm comm_child1, MPI_Comm comm_child2)
 
 void outputData() {
   int i, k, offset;
+  int lanczosStatus;
 
   /* zvo_out.dat */
 //[s] MERGE BY TM
@@ -737,17 +738,20 @@ void outputData() {
     if (NLanczosMode > 0) {
       if (NLanczosStep == 1) {
       if (AllComplexFlag == 0) { //real
-        PhysCalLanczos_real(
+        lanczosStatus = PhysCalLanczos_real(
           QQQQ_real, QCisAjsQ_real, QCisAjsCktAltQ_real, QCisAjsCktAltQDC_real,
           NLSHam, Nsite, NCisAjs, NCisAjs, iOneBodyGIdx, CisAjsIdx, NCisAjsCktAlt, NCisAjsCktAltDC, CisAjsCktAltDCIdx,
           NLanczosMode, FileLS, FileLSQQQQ, FileLSQCisAjsQ, FileLSQCisAjsCktAltQ,
           FileLSCisAjs, FileLSCisAjsCktAlt, FileLSCisAjsCktAltDC);
       }else { //complex
-        PhysCalLanczos_fcmp(
+        lanczosStatus = PhysCalLanczos_fcmp(
           QQQQ, QCisAjsQ, QCisAjsCktAltQ, QCisAjsCktAltQDC,
           NLSHam, Nsite, NCisAjs, NCisAjs, iOneBodyGIdx, CisAjsIdx, NCisAjsCktAlt, NCisAjsCktAltDC, CisAjsCktAltDCIdx,
           NLanczosMode, FileLS, FileLSQQQQ, FileLSQCisAjsQ, FileLSQCisAjsCktAltQ,
           FileLSCisAjs, FileLSCisAjsCktAlt, FileLSCisAjsCktAltDC);
+      }
+      if (lanczosStatus != 0) {
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
       }
       } else {
         Lanczos2Result lanczos2Result = {0};

--- a/src/mVMC/vmcmain.c
+++ b/src/mVMC/vmcmain.c
@@ -28,6 +28,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 /* #include "fjcoll.h" */
 #include "vmcmain.h"
 #include "physcal_lanczos.h"
+#include "physcal_lanczos2.h"
 
 // #define _DEBUG
 // #define _DEBUG_DUMP_SROPTO_STORE
@@ -734,6 +735,7 @@ void outputData() {
     }
 
     if (NLanczosMode > 0) {
+      if (NLanczosStep == 1) {
       if (AllComplexFlag == 0) { //real
         PhysCalLanczos_real(
           QQQQ_real, QCisAjsQ_real, QCisAjsCktAltQ_real, QCisAjsCktAltQDC_real,
@@ -746,6 +748,25 @@ void outputData() {
           NLSHam, Nsite, NCisAjs, NCisAjs, iOneBodyGIdx, CisAjsIdx, NCisAjsCktAlt, NCisAjsCktAltDC, CisAjsCktAltDCIdx,
           NLanczosMode, FileLS, FileLSQQQQ, FileLSQCisAjsQ, FileLSQCisAjsCktAltQ,
           FileLSCisAjs, FileLSCisAjsCktAlt, FileLSCisAjsCktAltDC);
+      }
+      } else {
+        Lanczos2Result lanczos2Result = {0};
+        Lanczos2SolveStatus lanczos2Status;
+        if (AllComplexFlag == 0) {
+          lanczos2Status = WriteLanczos2OutputReal(
+              FileLS2, FileLS2Moment, LS2Moment_real,
+              LS2MomentBasisShift, &lanczos2Result);
+        } else {
+          lanczos2Status = WriteLanczos2OutputComplex(
+              FileLS2, FileLS2Moment, LS2Moment,
+              LS2MomentBasisShift, &lanczos2Result);
+        }
+        if (lanczos2Status != LANCZOS2_SOLVE_OK) {
+          fprintf(stderr, "Error: Lanczos2 output failed: %s (LAPACK info=%d).\n",
+                  Lanczos2SolveError(lanczos2Status),
+                  lanczos2Result.lapackInfo);
+          MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+        }
       }
     }
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,4 +16,23 @@ target_include_directories(nbody_operator_unit PRIVATE
     ${CMAKE_SOURCE_DIR}/src/mVMC/include)
 add_test(NAME NBodyOperator_Unit COMMAND nbody_operator_unit)
 
+add_executable(lanczos2_contract_unit
+    lanczos2_contract_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/lanczos2_contract.c)
+target_include_directories(lanczos2_contract_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+add_test(NAME Lanczos2Contract_Unit COMMAND lanczos2_contract_unit)
+
+add_executable(lanczos2_solver_unit
+    lanczos2_solver_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/physcal_lanczos2.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/physcal_lanczos.c)
+target_include_directories(lanczos2_solver_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+target_link_libraries(lanczos2_solver_unit ${LAPACK_LIBRARIES} m)
+if(MPI_FOUND)
+    target_link_libraries(lanczos2_solver_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME Lanczos2Solver_Unit COMMAND lanczos2_solver_unit)
+
 add_subdirectory(python)

--- a/test/lanczos2_contract_unit.c
+++ b/test/lanczos2_contract_unit.c
@@ -1,0 +1,154 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "lanczos2_contract.h"
+
+static int failures = 0;
+
+#define CHECK(condition, ...)                                                   \
+  do {                                                                          \
+    if (!(condition)) {                                                         \
+      fprintf(stderr, "Lanczos2Contract_Unit FAIL: ");                         \
+      fprintf(stderr, __VA_ARGS__);                                             \
+      fprintf(stderr, "\n");                                                    \
+      failures++;                                                               \
+    }                                                                           \
+  } while (0)
+
+static Lanczos2Contract SupportedContract(void) {
+  Lanczos2Contract contract = {
+      2, /* step */
+      1, /* lanczosMode */
+      1, /* vmcCalMode */
+      0, /* orbitalGeneral */
+      0, /* nProjBF */
+      0, /* flagRBM */
+      0, /* exUpdatePath */
+      0, /* nPairHopping */
+      0, /* nExchangeCoupling */
+      0, /* nInterAll */
+      0, /* nNBodyInterAll */
+      0, /* nNBodyG */
+      0  /* nSpinFlipTransfer */
+  };
+  return contract;
+}
+
+static void CheckStatus(const Lanczos2Contract *contract,
+                        Lanczos2ContractStatus expected,
+                        const char *label) {
+  const Lanczos2ContractStatus actual = ValidateLanczos2Contract(contract);
+  CHECK(actual == expected, "%s: status=%d expected=%d", label, (int)actual,
+        (int)expected);
+  if (actual != LANCZOS2_CONTRACT_OK) {
+    CHECK(Lanczos2ContractError(actual)[0] != '\0',
+          "%s: empty error message", label);
+  }
+}
+
+static void TestAllowedInputs(void) {
+  Lanczos2Contract contract = SupportedContract();
+  CheckStatus(&contract, LANCZOS2_CONTRACT_OK, "supported step 2");
+
+  /*
+   * Step 1 is the compatibility path: the new step-2 capability gate must not
+   * reject combinations that remain owned by the existing Lanczos code.
+   */
+  memset(&contract, 0x5a, sizeof(contract));
+  contract.step = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_OK, "step 1 compatibility");
+}
+
+static void TestStepDomain(void) {
+  const int badSteps[] = {-2, -1, 0, 3, 17};
+  size_t i;
+  for (i = 0; i < sizeof(badSteps) / sizeof(badSteps[0]); i++) {
+    Lanczos2Contract contract = SupportedContract();
+    contract.step = badSteps[i];
+    CheckStatus(&contract, LANCZOS2_CONTRACT_INVALID_STEP,
+                "invalid step domain");
+  }
+  CheckStatus(NULL, LANCZOS2_CONTRACT_INVALID_STEP, "NULL contract");
+}
+
+static void TestEachUnsupportedCapability(void) {
+  Lanczos2Contract contract;
+
+  contract = SupportedContract();
+  contract.lanczosMode = 0;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1,
+              "Lanczos mode");
+
+  contract = SupportedContract();
+  contract.vmcCalMode = 0;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_VMC_CAL_MODE_1,
+              "VMC calculation mode");
+
+  contract = SupportedContract();
+  contract.orbitalGeneral = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_ORBITAL_GENERAL,
+              "orbital-general");
+
+  contract = SupportedContract();
+  contract.nProjBF = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_BACKFLOW, "BackFlow");
+
+  contract = SupportedContract();
+  contract.flagRBM = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_RBM, "RBM");
+
+  contract = SupportedContract();
+  contract.exUpdatePath = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH,
+              "update path");
+
+  contract = SupportedContract();
+  contract.nPairHopping = 2;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING,
+              "PairHopping");
+
+  contract = SupportedContract();
+  contract.nExchangeCoupling = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_EXCHANGE, "Exchange");
+
+  contract = SupportedContract();
+  contract.nInterAll = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_INTER_ALL, "InterAll");
+
+  contract = SupportedContract();
+  contract.nNBodyInterAll = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_INTER_ALL,
+              "NBodyInterAll");
+
+  contract = SupportedContract();
+  contract.nNBodyG = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_G, "NBodyG");
+
+  contract = SupportedContract();
+  contract.nSpinFlipTransfer = 1;
+  CheckStatus(
+      &contract, LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER,
+      "spin-flip Transfer");
+}
+
+static void TestFirstFailureIsStable(void) {
+  Lanczos2Contract contract = SupportedContract();
+  contract.lanczosMode = 0;
+  contract.nNBodyG = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1,
+              "first-failure order");
+}
+
+int main(void) {
+  TestAllowedInputs();
+  TestStepDomain();
+  TestEachUnsupportedCapability();
+  TestFirstFailureIsStable();
+
+  if (failures != 0) {
+    fprintf(stderr, "Lanczos2Contract_Unit: %d failure(s)\n", failures);
+    return 1;
+  }
+  printf("Lanczos2Contract_Unit: PASS\n");
+  return 0;
+}

--- a/test/lanczos2_solver_unit.c
+++ b/test/lanczos2_solver_unit.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "physcal_lanczos.h"
 #include "physcal_lanczos2.h"
 
 int CalculateEne(double H1, double H2_1, double H2_2, double H3, double H4,
@@ -399,6 +400,36 @@ static void TestLegacyDimensionTwoReduction(void) {
         legacyAlpha);
 }
 
+static void TestLegacyNegativeDiscriminantFails(void) {
+  double realMoment[16] = {0.0};
+  double complex complexMoment[16] = {0.0};
+  double alphaPlus;
+  double energyPlus;
+  double variancePlus;
+  double alphaMinus;
+  double energyMinus;
+  double varianceMinus;
+  int status;
+
+  realMoment[3] = -1.0;
+  complexMoment[3] = -1.0;
+
+  status = CalculateEne(0.0, -1.0, 0.0, 0.0, 0.0, &alphaPlus,
+                        &energyPlus, &variancePlus, &alphaMinus,
+                        &energyMinus, &varianceMinus);
+  CHECK(status != 0, "negative discriminant CalculateEne status=%d", status);
+
+  status = PhysCalLanczos_real(
+      realMoment, NULL, NULL, NULL, 2, 0, 0, 0, NULL, NULL, 0, 0, NULL, 1,
+      NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  CHECK(status != 0, "negative discriminant real path status=%d", status);
+
+  status = PhysCalLanczos_fcmp(
+      complexMoment, NULL, NULL, NULL, 2, 0, 0, 0, NULL, NULL, 0, 0, NULL, 1,
+      NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+  CHECK(status != 0, "negative discriminant complex path status=%d", status);
+}
+
 static void TestMomentAccumulation(void) {
   const double realPower[4] = {1.0, -2.0, 3.0, -4.0};
   const double complex complexPower[4] = {
@@ -551,6 +582,7 @@ int main(void) {
   TestAlphaUndefined();
   TestNonfiniteAndInvalidInputs();
   TestLegacyDimensionTwoReduction();
+  TestLegacyNegativeDiscriminantFails();
   TestMomentAccumulation();
   TestOutputLayout();
 

--- a/test/lanczos2_solver_unit.c
+++ b/test/lanczos2_solver_unit.c
@@ -1,0 +1,563 @@
+#include <complex.h>
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "physcal_lanczos2.h"
+
+int CalculateEne(double H1, double H2_1, double H2_2, double H3, double H4,
+                 double *alpha_p, double *ene_p, double *ene_vp,
+                 double *alpha_m, double *ene_m, double *ene_vm);
+
+static int failures = 0;
+
+#define CHECK(condition, ...)                                                   \
+  do {                                                                          \
+    if (!(condition)) {                                                         \
+      fprintf(stderr, "Lanczos2Solver_Unit FAIL: ");                           \
+      fprintf(stderr, __VA_ARGS__);                                             \
+      fprintf(stderr, "\n");                                                    \
+      failures++;                                                               \
+    }                                                                           \
+  } while (0)
+
+static int NearlyEqual(double actual, double expected, double relative) {
+  const double scale = fmax(fmax(fabs(actual), fabs(expected)), 1.0);
+  return fabs(actual - expected) <= relative * scale;
+}
+
+static int NearlyEqualRelative(double actual, double expected,
+                               double relative) {
+  const double scale = fmax(fabs(expected), DBL_MIN);
+  return fabs(actual - expected) <= relative * scale;
+}
+
+static int TokenCount(char *line) {
+  int count = 0;
+  char *token = strtok(line, " \t\r\n");
+  while (token != NULL) {
+    count++;
+    token = strtok(NULL, " \t\r\n");
+  }
+  return count;
+}
+
+static void FillHankelMoment(const double *eigenvalue, const double *weight,
+                             int count, double *moment) {
+  double powerMoment[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+  int i;
+  int power;
+  int a;
+  int b;
+  for (i = 0; i < count; i++) {
+    double value = 1.0;
+    for (power = 0; power <= 6; power++) {
+      powerMoment[power] += weight[i] * value;
+      value *= eigenvalue[i];
+    }
+  }
+  for (a = 0; a < LANCZOS2_POWER_COUNT; a++) {
+    for (b = 0; b < LANCZOS2_POWER_COUNT; b++) {
+      moment[4 * a + b] = powerMoment[a + b];
+    }
+  }
+}
+
+static void TestMatrixMapping(void) {
+  double moment[16] = {0.0};
+  double overlap[4];
+  double hamiltonian[4];
+  double hamiltonianSquared[4];
+  double antiHermitianResidual;
+  double hankelResidual;
+  Lanczos2SolveStatus status;
+
+  moment[0] = 1.0;
+  moment[1] = moment[4] = 0.2;
+  moment[2] = moment[8] = 0.9;
+  moment[5] = 1.3;
+  moment[6] = moment[9] = -0.4;
+  moment[10] = 2.2;
+
+  status = BuildLanczos2MatricesReal(
+      moment, 2, overlap, hamiltonian, hamiltonianSquared,
+      &antiHermitianResidual, &hankelResidual);
+  CHECK(status == LANCZOS2_SOLVE_OK, "matrix mapping status=%d", status);
+  CHECK(NearlyEqual(overlap[0], 1.0, 1.0e-15), "S00=%g", overlap[0]);
+  CHECK(NearlyEqual(overlap[1], 0.2, 1.0e-15), "S01=%g", overlap[1]);
+  CHECK(NearlyEqual(overlap[3], 1.3, 1.0e-15), "S11=%g", overlap[3]);
+  CHECK(NearlyEqual(hamiltonian[0], 0.2, 1.0e-15), "H00=%g",
+        hamiltonian[0]);
+  CHECK(NearlyEqual(hamiltonian[1], 1.1, 1.0e-15), "H01=%g",
+        hamiltonian[1]);
+  CHECK(NearlyEqual(hamiltonian[3], -0.4, 1.0e-15), "H11=%g",
+        hamiltonian[3]);
+  CHECK(NearlyEqual(hamiltonianSquared[0], 1.3, 1.0e-15), "G00=%g",
+        hamiltonianSquared[0]);
+  CHECK(NearlyEqual(hamiltonianSquared[1], -0.4, 1.0e-15), "G01=%g",
+        hamiltonianSquared[1]);
+  CHECK(NearlyEqual(hamiltonianSquared[3], 2.2, 1.0e-15), "G11=%g",
+        hamiltonianSquared[3]);
+  CHECK(antiHermitianResidual == 0.0, "anti-Hermitian residual=%g",
+        antiHermitianResidual);
+  CHECK(hankelResidual > 0.0,
+        "non-Hankel fixture unexpectedly has zero residual");
+}
+
+static void TestHankelResidualUsesAntidiagonalScale(void) {
+  double moment[16] = {0.0};
+  double overlap[4];
+  double hamiltonian[4];
+  double hamiltonianSquared[4];
+  double antiHermitianResidual;
+  double hankelResidual;
+  Lanczos2SolveStatus status;
+
+  moment[0] = 1.0;
+  moment[1] = moment[4] = 0.2;
+  moment[2] = moment[8] = 1.0;
+  moment[5] = 1.1;
+  moment[6] = moment[9] = 2.0;
+  moment[10] = 1.0;
+  moment[15] = 1.0e12;
+  status = BuildLanczos2MatricesReal(
+      moment, 2, overlap, hamiltonian, hamiltonianSquared,
+      &antiHermitianResidual, &hankelResidual);
+  CHECK(status == LANCZOS2_SOLVE_OK,
+        "antidiagonal-scale fixture status=%d", status);
+  CHECK(hankelResidual > 0.08,
+        "low-order Hankel mismatch hidden by high-order scale: %.17g",
+        hankelResidual);
+}
+
+static void TestExactThreeStateRealAndComplex(void) {
+  const double eigenvalue[3] = {-2.0, 1.0, 4.0};
+  const double weight[3] = {0.2, 0.3, 0.5};
+  double moment[16];
+  double complex complexMoment[16];
+  Lanczos2Result realResult;
+  Lanczos2Result complexResult;
+  Lanczos2SolveStatus status;
+  int i;
+
+  FillHankelMoment(eigenvalue, weight, 3, moment);
+  for (i = 0; i < 16; i++) complexMoment[i] = moment[i];
+
+  status = SolveLanczos2Real(moment, 3, &realResult);
+  CHECK(status == LANCZOS2_SOLVE_OK, "real exact solve status=%d (%s)",
+        status, Lanczos2SolveError(status));
+  CHECK(realResult.solveFlags == 0, "real solve flags=%d",
+        realResult.solveFlags);
+  CHECK(NearlyEqual(realResult.shift, 1.9, 1.0e-14), "real shift=%.17g",
+        realResult.shift);
+  CHECK(NearlyEqual(realResult.energy, -2.0, 1.0e-13),
+        "real energy=%.17g", realResult.energy);
+  CHECK(fabs(realResult.variance) <= 2.0e-13,
+        "real variance=%.17g", realResult.variance);
+  CHECK(realResult.antiHermitianResidual == 0.0,
+        "real anti-Hermitian residual=%g",
+        realResult.antiHermitianResidual);
+  CHECK(realResult.hankelResidual == 0.0, "real Hankel residual=%g",
+        realResult.hankelResidual);
+  CHECK(realResult.eigenvalueResidual <= 2.0e-13,
+        "real eigenvalue residual=%g", realResult.eigenvalueResidual);
+  CHECK(NearlyEqual(creal(realResult.alpha[0]), -1.25, 2.0e-13),
+        "real alpha1=%.17g", creal(realResult.alpha[0]));
+  CHECK(NearlyEqual(creal(realResult.alpha[1]), 0.25, 2.0e-13),
+        "real alpha2=%.17g", creal(realResult.alpha[1]));
+
+  status = SolveLanczos2Complex(complexMoment, 3, &complexResult);
+  CHECK(status == LANCZOS2_SOLVE_OK, "complex exact solve status=%d (%s)",
+        status, Lanczos2SolveError(status));
+  CHECK(NearlyEqual(complexResult.energy, -2.0, 1.0e-13),
+        "complex energy=%.17g", complexResult.energy);
+  CHECK(fabs(complexResult.variance) <= 2.0e-13,
+        "complex variance=%.17g", complexResult.variance);
+  CHECK(NearlyEqual(creal(complexResult.alpha[0]), -1.25, 2.0e-13),
+        "complex alpha1=%.17g", creal(complexResult.alpha[0]));
+  CHECK(NearlyEqual(creal(complexResult.alpha[1]), 0.25, 2.0e-13),
+        "complex alpha2=%.17g", creal(complexResult.alpha[1]));
+  for (i = 0; i < 3; i++) {
+    CHECK(fabs(cimag(complexResult.coefficient[i])) <= 2.0e-14,
+          "complex coefficient[%d] imaginary part=%.17g", i,
+          cimag(complexResult.coefficient[i]));
+  }
+  {
+    int maximumIndex = 0;
+    for (i = 1; i < 3; i++) {
+      if (cabs(complexResult.coefficient[i]) >
+          cabs(complexResult.coefficient[maximumIndex])) {
+        maximumIndex = i;
+      }
+    }
+    CHECK(creal(complexResult.coefficient[maximumIndex]) > 0.0,
+          "phase-fixed maximum coefficient is not positive");
+    CHECK(fabs(cimag(complexResult.coefficient[maximumIndex])) <= 2.0e-14,
+          "phase-fixed maximum coefficient is not real");
+  }
+}
+
+static void TestLargeEnergyShiftAccuracy(void) {
+  const double offset[6] = {0.0, 0.7, 1.6, 2.9, 4.1, 6.3};
+  const double weight[6] = {0.30, 0.25, 0.18, 0.12, 0.09, 0.06};
+  const unsigned char valid[6] = {1, 1, 1, 1, 1, 1};
+  const double energyShift = 100.0;
+  double shiftedEigenvalue[6];
+  double samplePower[6 * LANCZOS2_POWER_COUNT];
+  double centeredMoment[16];
+  double shiftedMoment[16];
+  Lanczos2Result centered;
+  Lanczos2Result shifted;
+  Lanczos2SolveStatus centeredStatus;
+  Lanczos2SolveStatus shiftedStatus;
+  double expectedEnergy;
+  double expectedVarianceRatio;
+  int i;
+  int k;
+
+  for (i = 0; i < 6; i++) {
+    shiftedEigenvalue[i] = offset[i] - energyShift;
+    for (k = 0; k < LANCZOS2_POWER_COUNT; k++) {
+      samplePower[i * LANCZOS2_POWER_COUNT + k] =
+          pow(shiftedEigenvalue[i], (double)k);
+    }
+  }
+  FillHankelMoment(offset, weight, 6, centeredMoment);
+  centeredStatus = SolveLanczos2Real(centeredMoment, 3, &centered);
+  shiftedStatus = BuildLanczos2ShiftedMomentReal(
+      shiftedMoment, samplePower, weight, valid, 6, -energyShift);
+  CHECK(shiftedStatus == LANCZOS2_SOLVE_OK,
+        "large-shift moment construction status=%d (%s)", shiftedStatus,
+        Lanczos2SolveError(shiftedStatus));
+  if (shiftedStatus == LANCZOS2_SOLVE_OK) {
+    shiftedStatus = SolveLanczos2ShiftedReal(
+        shiftedMoment, 3, -energyShift, &shifted);
+  }
+  CHECK(centeredStatus == LANCZOS2_SOLVE_OK,
+        "large-shift centered solve status=%d (%s)", centeredStatus,
+        Lanczos2SolveError(centeredStatus));
+  CHECK(shiftedStatus == LANCZOS2_SOLVE_OK,
+        "large-shift shifted solve status=%d (%s)", shiftedStatus,
+        Lanczos2SolveError(shiftedStatus));
+  if (centeredStatus != LANCZOS2_SOLVE_OK ||
+      shiftedStatus != LANCZOS2_SOLVE_OK) {
+    return;
+  }
+  expectedEnergy = centered.energy - energyShift;
+  expectedVarianceRatio =
+      centered.variance / (expectedEnergy * expectedEnergy);
+  CHECK(NearlyEqualRelative(shifted.energy, expectedEnergy, 1.0e-8),
+        "large-shift energy actual=%.17g expected=%.17g",
+        shifted.energy, expectedEnergy);
+  CHECK(NearlyEqualRelative(shifted.varianceOverEnergySquared,
+                            expectedVarianceRatio, 1.0e-8),
+        "large-shift variance/E2 actual=%.17g expected=%.17g",
+        shifted.varianceOverEnergySquared, expectedVarianceRatio);
+}
+
+static void TestRegularizedRetry(void) {
+  const double eigenvalue[2] = {-2.0, 4.0};
+  const double weight[2] = {0.5, 0.5};
+  double moment[16];
+  Lanczos2Result result;
+  const Lanczos2SolveStatus status = (
+      FillHankelMoment(eigenvalue, weight, 2, moment),
+      SolveLanczos2Real(moment, 3, &result));
+  CHECK(status == LANCZOS2_SOLVE_OK, "regularized solve status=%d (%s)",
+        status, Lanczos2SolveError(status));
+  CHECK((result.solveFlags & LANCZOS2_FLAG_REGULARIZED) != 0,
+        "regularized flag was not set (flags=%d)", result.solveFlags);
+  CHECK(NearlyEqual(result.epsilon, 1.0e-12, 1.0e-14),
+        "epsilon=%.17g", result.epsilon);
+  CHECK(NearlyEqual(result.energy, -2.0, 2.0e-11),
+        "regularized energy=%.17g", result.energy);
+}
+
+static void TestNonPositiveNormalizationFails(void) {
+  double moment[16] = {0.0};
+  Lanczos2Result result;
+  Lanczos2SolveStatus status;
+  const double rho = 1.0 + 5.0e-13;
+
+  moment[0] = 1.0;
+  moment[1] = moment[4] = 0.0;
+  moment[2] = moment[8] = rho;
+  moment[5] = 1.0;
+  moment[6] = moment[9] = 0.0;
+  moment[10] = 1.0;
+  moment[3] = moment[12] = 2.0;
+  moment[7] = moment[13] = -1.0;
+  moment[11] = moment[14] = 0.0;
+  moment[15] = 1.0;
+
+  status = SolveLanczos2Real(moment, 3, &result);
+  CHECK(status == LANCZOS2_SOLVE_NORMALIZATION_FAILURE,
+        "non-positive normalization status=%d (%s)", status,
+        Lanczos2SolveError(status));
+  CHECK((result.solveFlags & LANCZOS2_FLAG_REGULARIZED) != 0,
+        "non-positive normalization did not exercise retry");
+}
+
+static void TestAlphaUndefined(void) {
+  double moment[16] = {0.0};
+  Lanczos2Result result;
+  Lanczos2SolveStatus status;
+
+  moment[0] = 1.0;
+  moment[1] = moment[4] = 0.0;
+  moment[2] = moment[8] = -1.0;
+  moment[5] = 1.0;
+  moment[6] = moment[9] = -2.0;
+  moment[10] = 5.0;
+
+  status = SolveLanczos2Real(moment, 2, &result);
+  CHECK(status == LANCZOS2_SOLVE_OK, "alpha-undefined status=%d (%s)",
+        status, Lanczos2SolveError(status));
+  CHECK((result.solveFlags & LANCZOS2_FLAG_ALPHA_UNDEFINED) != 0,
+        "alpha-undefined flag not set (flags=%d)", result.solveFlags);
+  CHECK(isnan(creal(result.alpha[0])), "undefined alpha is not NaN");
+  CHECK(NearlyEqual(result.energy, -2.0, 1.0e-14),
+        "alpha-undefined energy=%.17g", result.energy);
+  CHECK(cabs(result.coefficient[0]) <= 1.0e-14,
+        "alpha-undefined c0 magnitude=%.17g",
+        cabs(result.coefficient[0]));
+}
+
+static void TestNonfiniteAndInvalidInputs(void) {
+  double moment[16] = {0.0};
+  Lanczos2Result result;
+  Lanczos2SolveStatus status;
+  moment[0] = 1.0;
+  moment[6] = NAN;
+  status = SolveLanczos2Real(moment, 3, &result);
+  CHECK(status == LANCZOS2_SOLVE_NONFINITE_MOMENT,
+        "NaN status=%d", status);
+
+  memset(moment, 0, sizeof(moment));
+  moment[0] = 1.0;
+  moment[5] = 0.0;
+  status = SolveLanczos2Real(moment, 2, &result);
+  CHECK(status == LANCZOS2_SOLVE_NONPOSITIVE_DIAGONAL,
+        "non-positive shifted diagonal status=%d", status);
+
+  status = SolveLanczos2Real(moment, 1, &result);
+  CHECK(status == LANCZOS2_SOLVE_INVALID_ARGUMENT,
+        "invalid dimension status=%d", status);
+  status = SolveLanczos2Real(NULL, 3, &result);
+  CHECK(status == LANCZOS2_SOLVE_INVALID_ARGUMENT,
+        "NULL moment status=%d", status);
+}
+
+static void TestLegacyDimensionTwoReduction(void) {
+  double moment[16] = {0.0};
+  Lanczos2Result result;
+  double alphaPlus;
+  double energyPlus;
+  double variancePlus;
+  double alphaMinus;
+  double energyMinus;
+  double varianceMinus;
+  double legacyAlpha;
+  double legacyEnergy;
+  double legacyVariance;
+  int legacyStatus;
+  Lanczos2SolveStatus status;
+
+  moment[0] = 1.0;
+  moment[1] = moment[4] = 0.2;   /* QQQQ[2]: H1 */
+  moment[5] = 1.3;               /* QQQQ[3]: H2_1 */
+  moment[2] = moment[8] = 0.9;   /* QQQQ[10]: H2_2 */
+  moment[6] = moment[9] = -0.4;  /* QQQQ[11]: H3 */
+  moment[10] = 2.2;              /* QQQQ[15]: H4 */
+
+  legacyStatus =
+      CalculateEne(0.2, 1.3, 0.9, -0.4, 2.2, &alphaPlus, &energyPlus,
+                   &variancePlus, &alphaMinus, &energyMinus, &varianceMinus);
+  CHECK(legacyStatus == 0, "legacy CalculateEne status=%d", legacyStatus);
+  if (energyPlus <= energyMinus) {
+    legacyAlpha = alphaPlus;
+    legacyEnergy = energyPlus;
+    legacyVariance = variancePlus;
+  } else {
+    legacyAlpha = alphaMinus;
+    legacyEnergy = energyMinus;
+    legacyVariance = varianceMinus;
+  }
+
+  status = SolveLanczos2Real(moment, 2, &result);
+  CHECK(status == LANCZOS2_SOLVE_OK, "d=2 solve status=%d (%s)", status,
+        Lanczos2SolveError(status));
+  CHECK(NearlyEqual(result.energy, legacyEnergy, 1.0e-13),
+        "d=2 energy new=%.17g legacy=%.17g", result.energy, legacyEnergy);
+  CHECK(NearlyEqual(result.varianceOverEnergySquared, legacyVariance,
+                    1.0e-13),
+        "d=2 variance/E2 new=%.17g legacy=%.17g",
+        result.varianceOverEnergySquared, legacyVariance);
+  CHECK(NearlyEqual(creal(result.alpha[0]), legacyAlpha, 1.0e-13),
+        "d=2 alpha new=%.17g legacy=%.17g", creal(result.alpha[0]),
+        legacyAlpha);
+}
+
+static void TestMomentAccumulation(void) {
+  const double realPower[4] = {1.0, -2.0, 3.0, -4.0};
+  const double complex complexPower[4] = {
+      1.0, 1.0 + 2.0 * I, -3.0 + 0.5 * I, 2.0 - I};
+  double realMoment[16] = {0.0};
+  double complex complexMoment[16] = {0.0};
+  Lanczos2SolveStatus status;
+
+  status = AccumulateLanczos2MomentReal(realMoment, realPower, 0.25);
+  CHECK(status == LANCZOS2_SOLVE_OK, "real accumulation status=%d", status);
+  CHECK(NearlyEqual(realMoment[1 * 4 + 3], 2.0, 1.0e-15),
+        "real M13=%.17g", realMoment[1 * 4 + 3]);
+
+  status =
+      AccumulateLanczos2MomentComplex(complexMoment, complexPower, 0.5);
+  CHECK(status == LANCZOS2_SOLVE_OK, "complex accumulation status=%d",
+        status);
+  CHECK(cabs(complexMoment[1 * 4 + 2] -
+             0.5 * conj(complexPower[1]) * complexPower[2]) <= 1.0e-15,
+        "complex M12 has wrong conjugation");
+  CHECK(cabs(complexMoment[2 * 4 + 1] -
+             conj(complexMoment[1 * 4 + 2])) <= 1.0e-15,
+        "complex accumulated moment is not Hermitian");
+
+  {
+    double badPower[4] = {1.0, 2.0, NAN, 4.0};
+    status = AccumulateLanczos2MomentReal(realMoment, badPower, 1.0);
+    CHECK(status == LANCZOS2_SOLVE_NONFINITE_MOMENT,
+          "non-finite power accumulation status=%d", status);
+  }
+  {
+    double overflowingPower[4] = {DBL_MAX, 1.0, 1.0, 1.0};
+    double overflowMoment[16] = {0.0};
+    double complex complexOverflowPower[4] = {
+        DBL_MAX + 0.0 * I, 1.0, 1.0, 1.0};
+    double complex complexOverflowMoment[16] = {0.0};
+    status =
+        AccumulateLanczos2MomentReal(overflowMoment, overflowingPower, 2.0);
+    CHECK(status == LANCZOS2_SOLVE_NONFINITE_MOMENT,
+          "real overflow accumulation status=%d", status);
+    CHECK(overflowMoment[0] == 0.0,
+          "real overflow partially updated the moment");
+    status = AccumulateLanczos2MomentComplex(
+        complexOverflowMoment, complexOverflowPower, 2.0);
+    CHECK(status == LANCZOS2_SOLVE_NONFINITE_MOMENT,
+          "complex overflow accumulation status=%d", status);
+    CHECK(complexOverflowMoment[0] == 0.0,
+          "complex overflow partially updated the moment");
+  }
+}
+
+static void TestOutputLayout(void) {
+  const double eigenvalue[3] = {-2.0, 1.0, 4.0};
+  const double weight[3] = {0.2, 0.3, 0.5};
+  double moment[16];
+  double complex complexMoment[16];
+  Lanczos2Result result;
+  FILE *output = tmpfile();
+  FILE *momentOutput = tmpfile();
+  char header[2048];
+  char data[4096];
+  char extra[8];
+  char tokenBuffer[4096];
+  Lanczos2SolveStatus status;
+  int i;
+
+  CHECK(output != NULL && momentOutput != NULL, "tmpfile failed");
+  if (output == NULL || momentOutput == NULL) {
+    if (output != NULL) fclose(output);
+    if (momentOutput != NULL) fclose(momentOutput);
+    return;
+  }
+  FillHankelMoment(eigenvalue, weight, 3, moment);
+  status = WriteLanczos2OutputReal(
+      output, momentOutput, moment, 0.0, &result);
+  CHECK(status == LANCZOS2_SOLVE_OK, "real output status=%d (%s)", status,
+        Lanczos2SolveError(status));
+
+  rewind(output);
+  CHECK(fgets(header, sizeof(header), output) != NULL,
+        "ls2_out header missing");
+  CHECK(strncmp(header, "# mVMC ls2_out v1 ",
+                strlen("# mVMC ls2_out v1 ")) == 0,
+        "ls2_out header version mismatch: %s", header);
+  CHECK(fgets(data, sizeof(data), output) != NULL, "ls2_out data missing");
+  CHECK(data[strlen(data) - 1] == '\n', "ls2_out data lacks final newline");
+  memcpy(tokenBuffer, data, strlen(data) + 1);
+  CHECK(TokenCount(tokenBuffer) == 17, "ls2_out numeric column count != 17");
+  CHECK(fgets(extra, sizeof(extra), output) == NULL,
+        "ls2_out has more than two lines");
+
+  rewind(momentOutput);
+  CHECK(fgets(header, sizeof(header), momentOutput) != NULL,
+        "ls2_moment header missing");
+  CHECK(strncmp(header, "# mVMC ls2_moment v2 basis_shift=",
+                strlen("# mVMC ls2_moment v2 basis_shift=")) == 0,
+        "ls2_moment header version mismatch: %s", header);
+  CHECK(fgets(data, sizeof(data), momentOutput) != NULL,
+        "ls2_moment data missing");
+  CHECK(data[strlen(data) - 1] == '\n',
+        "ls2_moment data lacks final newline");
+  memcpy(tokenBuffer, data, strlen(data) + 1);
+  CHECK(TokenCount(tokenBuffer) == 32,
+        "ls2_moment numeric column count != 32");
+  CHECK(fgets(extra, sizeof(extra), momentOutput) == NULL,
+        "ls2_moment has more than two lines");
+  fclose(output);
+  fclose(momentOutput);
+
+  output = tmpfile();
+  momentOutput = tmpfile();
+  CHECK(output != NULL && momentOutput != NULL, "complex tmpfile failed");
+  if (output == NULL || momentOutput == NULL) {
+    if (output != NULL) fclose(output);
+    if (momentOutput != NULL) fclose(momentOutput);
+    return;
+  }
+  for (i = 0; i < 16; i++) complexMoment[i] = moment[i];
+  status = WriteLanczos2OutputComplex(
+      output, momentOutput, complexMoment, 0.0, &result);
+  CHECK(status == LANCZOS2_SOLVE_OK, "complex output status=%d (%s)",
+        status, Lanczos2SolveError(status));
+  rewind(output);
+  CHECK(fgets(header, sizeof(header), output) != NULL,
+        "complex ls2_out header missing");
+  CHECK(fgets(data, sizeof(data), output) != NULL,
+        "complex ls2_out data missing");
+  memcpy(tokenBuffer, data, strlen(data) + 1);
+  CHECK(TokenCount(tokenBuffer) == 17,
+        "complex ls2_out numeric column count != 17");
+  rewind(momentOutput);
+  CHECK(fgets(header, sizeof(header), momentOutput) != NULL,
+        "complex ls2_moment header missing");
+  CHECK(fgets(data, sizeof(data), momentOutput) != NULL,
+        "complex ls2_moment data missing");
+  memcpy(tokenBuffer, data, strlen(data) + 1);
+  CHECK(TokenCount(tokenBuffer) == 32,
+        "complex ls2_moment numeric column count != 32");
+  fclose(output);
+  fclose(momentOutput);
+}
+
+int main(void) {
+  TestMatrixMapping();
+  TestHankelResidualUsesAntidiagonalScale();
+  TestExactThreeStateRealAndComplex();
+  TestLargeEnergyShiftAccuracy();
+  TestRegularizedRetry();
+  TestNonPositiveNormalizationFails();
+  TestAlphaUndefined();
+  TestNonfiniteAndInvalidInputs();
+  TestLegacyDimensionTwoReduction();
+  TestMomentAccumulation();
+  TestOutputLayout();
+
+  if (failures != 0) {
+    fprintf(stderr, "Lanczos2Solver_Unit: %d failure(s)\n", failures);
+    return 1;
+  }
+  printf("Lanczos2Solver_Unit: PASS\n");
+  return 0;
+}

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -17,6 +17,11 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_bf.py DESTINATION ${CMAKE_BINARY_D
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_bf_fsz.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos_expert.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos_sector_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_step1_compat.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_real_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_complex_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projected_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projection_smoke.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nbodyg.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyg_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyinterall_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
@@ -46,6 +51,14 @@ function(add_python_vmc_test_invalid_expert model expected_error)
     add_test(NAME ${model} COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py ${model} "${expected_error}")
     set_tests_properties(${model} PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
 endfunction(add_python_vmc_test_invalid_expert)
+
+function(add_python_vmc_test_invalid_expert_with_updates test_name model expected_error)
+    add_test(NAME ${test_name}
+        COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py
+        ${model} "${expected_error}" ${ARGN})
+    set_tests_properties(${test_name} PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1")
+endfunction(add_python_vmc_test_invalid_expert_with_updates)
 
 function(add_python_vmc_test_expert_phys model)
     add_test(NAME ${model} COMMAND ${PYTHON_EXECUTABLE} runtest_expert_phys.py ${model})
@@ -474,6 +487,8 @@ set(python_test_uhf_model
 foreach(model ${python_test_vmc_model})
     add_python_vmc_test(${model})
 endforeach(model)
+set_tests_properties(HubbardTetragonal_MomentumProjection PROPERTIES
+    FIXTURES_SETUP lanczos2_projection_input)
 
 foreach(model ${python_test_vmc_model_mpi})
     add_python_vmc_test(${model})
@@ -512,7 +527,142 @@ add_python_vmc_test_lanczos_expert(TJChainL4_Ncond2_J_path5_Lanczos)
 add_python_vmc_test_lanczos_expert(TJChainL4_Ncond2_J_path4_Lanczos2)
 add_python_vmc_test_lanczos_expert(DoublonOnly_Lanczos)
 add_python_vmc_test_lanczos_sector_ed(LanczosSectorED)
+add_test(NAME Lanczos2_Step1_OmittedExplicit_ByteEquivalent
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_step1_compat.py
+    HubbardChainLanczos)
+set_tests_properties(Lanczos2_Step1_OmittedExplicit_ByteEquivalent PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1"
+    RESOURCE_LOCK "lanczos2_step1_compat_workdir")
 
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidStepZero HubbardChain_SpinJastrow
+    "NLanczosStep must be 1 or 2" NLanczosStep=0)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidStepNegative HubbardChain_SpinJastrow
+    "NLanczosStep must be 1 or 2" NLanczosStep=-1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidStepThree HubbardChain_SpinJastrow
+    "NLanczosStep must be 1 or 2" NLanczosStep=3)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidStepFractional HubbardChain_SpinJastrow
+    "NLanczosStep must be 1 or 2" NLanczosStep=1.5)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidLanczosMode HubbardChain_SpinJastrow
+    "NLanczosStep=2 requires NLanczosMode=1"
+    NLanczosStep=2 NLanczosMode=0 NVMCCalMode=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidVmcCalMode HubbardChain_SpinJastrow
+    "NLanczosStep=2 requires NVMCCalMode=1"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=0)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidUpdatePath HubbardChain_SpinJastrow
+    "NLanczosStep=2 requires NExUpdatePath=0"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1 NExUpdatePath=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidFSZ HubbardChain_fsz_SpinJastrow
+    "does not support orbital-general (FSZ) mode"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1
+    NExUpdatePath=0 NMPTrans=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidRBM GeneralRBM_cmp
+    "does not support RBM"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidPairHopping DoublonOnly_Lanczos
+    "does not support PairHopping"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1 NExUpdatePath=0)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidExchange TJChainL4_Ncond2_J_path4_Lanczos
+    "does not support Exchange"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1 NExUpdatePath=0)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidInterAll UHF_InterAll_N2
+    "does not support InterAll"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidNBodyG NBodyG_Compare
+    "does not support NBodyG"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidSpinFlipTransfer HubbardChain_SpinJastrow
+    "supports only spin-conserving Transfer terms"
+    spin_flip_transfer NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1)
+add_test(NAME Lanczos2_InvalidBackFlow
+    COMMAND ${PYTHON_EXECUTABLE} runtest_bf.py BackFlow_Identity_Real
+    --expect-error "NLanczosStep=2 does not support BackFlow"
+    --lanczos-mode 1 --lanczos-step 2 --vmc-cal-mode 1)
+set_tests_properties(Lanczos2_InvalidBackFlow PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1")
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_InvalidLanczosMode_mpi HubbardChain_SpinJastrow
+    "NLanczosStep=2 requires NLanczosMode=1"
+    NLanczosStep=2 NLanczosMode=0 NVMCCalMode=1)
+set_tests_properties(Lanczos2_InvalidLanczosMode_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;MVMC_MPI_PROCS=2")
+add_test(NAME Lanczos2_ContractPositive_TwoSz0_NonFSZ
+    COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py
+    HubbardChain_SpinJastrow "Finish calculation." allow_success
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1)
+set_tests_properties(Lanczos2_ContractPositive_TwoSz0_NonFSZ PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1")
+add_test(NAME Lanczos2_Real_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py)
+set_tests_properties(Lanczos2_Real_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_real_ed_workdir")
+add_test(NAME Lanczos2_Real_ED_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py)
+set_tests_properties(Lanczos2_Real_ED_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_real_ed_mpi_workdir")
+add_test(NAME Lanczos2_Real_ED_Split2_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py)
+set_tests_properties(Lanczos2_Real_ED_Split2_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_NSPLIT_SIZE=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_real_ed_split2_mpi_workdir")
+add_test(NAME Lanczos2_Real_ED_omp
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py)
+set_tests_properties(Lanczos2_Real_ED_omp PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_real_ed_workdir")
+add_test(NAME Lanczos2_NonfiniteSample_Fails
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py
+    "Lanczos2 moment or transformed matrix is not finite")
+set_tests_properties(Lanczos2_NonfiniteSample_Fails PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_TEST_NONFINITE_SAMPLE=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_real_ed_workdir")
+add_test(NAME Lanczos2_NonfiniteSample_Fails_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py
+    "Lanczos2 moment or transformed matrix is not finite")
+set_tests_properties(Lanczos2_NonfiniteSample_Fails_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_TEST_NONFINITE_SAMPLE=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_real_ed_mpi_workdir")
+add_test(NAME Lanczos2_Complex_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_complex_ed.py)
+set_tests_properties(Lanczos2_Complex_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_complex_ed_workdir")
+add_test(NAME Lanczos2_Complex_ED_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_complex_ed.py)
+set_tests_properties(Lanczos2_Complex_ED_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_complex_ed_mpi_workdir")
+add_test(NAME Lanczos2_Projected_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py)
+set_tests_properties(Lanczos2_Projected_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_projected_ed_workdir")
+add_test(NAME Lanczos2_Projected_ED_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py)
+set_tests_properties(Lanczos2_Projected_ED_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_projected_ed_mpi_workdir")
+add_test(NAME Lanczos2_Projection_Smoke
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projection_smoke.py)
+set_tests_properties(Lanczos2_Projection_Smoke PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    FIXTURES_REQUIRED lanczos2_projection_input
+    RESOURCE_LOCK "lanczos2_projection_smoke_workdir")
 foreach(model ${python_test_vmc_model_sr})
     add_python_vmc_test_sr(${model})
 endforeach(model)

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -647,16 +647,31 @@ add_test(NAME Lanczos2_Complex_ED_mpi
 set_tests_properties(Lanczos2_Complex_ED_mpi PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
     RESOURCE_LOCK "lanczos2_complex_ed_mpi_workdir")
+add_test(NAME Lanczos2_Complex_ED_omp
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_complex_ed.py)
+set_tests_properties(Lanczos2_Complex_ED_omp PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_complex_ed_workdir")
 add_test(NAME Lanczos2_Projected_ED
     COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py)
 set_tests_properties(Lanczos2_Projected_ED PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1;MVMC_LANCZOS2_TEST_CALHCA_GUARD_AUDIT=1"
     RESOURCE_LOCK "lanczos2_projected_ed_workdir")
+add_test(NAME Lanczos2_Projected_Complex_ED_Guard
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py --complex)
+set_tests_properties(Lanczos2_Projected_Complex_ED_Guard PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1;MVMC_LANCZOS2_TEST_CALHCA_GUARD_AUDIT=1"
+    RESOURCE_LOCK "lanczos2_projected_complex_ed_workdir")
 add_test(NAME Lanczos2_Projected_ED_mpi
     COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py)
 set_tests_properties(Lanczos2_Projected_ED_mpi PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
     RESOURCE_LOCK "lanczos2_projected_ed_mpi_workdir")
+add_test(NAME Lanczos2_Projected_ED_omp
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py)
+set_tests_properties(Lanczos2_Projected_ED_omp PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_projected_ed_workdir")
 add_test(NAME Lanczos2_Projection_Smoke
     COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projection_smoke.py)
 set_tests_properties(Lanczos2_Projection_Smoke PROPERTIES

--- a/test/python/lanczos2_cost_probe.py
+++ b/test/python/lanczos2_cost_probe.py
@@ -1,14 +1,17 @@
 """Manual, non-CI structural scaling probe for second power-Lanczos.
 
 The qualitative checks below verify that the expected H^3 work is exercised
-as NTransfer grows.  They are not a portable performance-regression gate:
-absolute ratios depend on the compiler, architecture, and linear-algebra
-stack.  Establish quantitative baselines on the same Linux/HPC environment.
+as NTransfer grows.  The projection grid records both the identity fast path
+and the NQPFull>1 direct-contraction path.  These measurements are not a
+portable performance-regression gate: absolute ratios depend on the compiler,
+architecture, and linear-algebra stack.  Establish quantitative baselines on
+the same Linux/HPC environment.
 """
 
 from __future__ import print_function
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -22,6 +25,14 @@ import tempfile
 
 
 TIMER_PATTERN = re.compile(r"\[(41|95)\]\s+([0-9.eE+-]+)\s*$")
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
 
 
 def write_standard_input(path, size, samples, warmup):
@@ -43,6 +54,40 @@ NLanczosMode = 1
 RndSeed = 2468
 """.format(size=size, samples=samples, warmup=warmup)
         )
+
+
+def write_momentum_projection(path, size, nmptrans):
+    """Write a k=0 projector for a cyclic translation subgroup."""
+    if size % nmptrans != 0:
+        raise RuntimeError(
+            "NMPTrans={} must divide L={} to form a cyclic subgroup".format(
+                nmptrans, size
+            )
+        )
+    stride = size // nmptrans
+    with open(path, "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("NQPTrans          {}\n".format(nmptrans))
+        destination.write("=============================================\n")
+        destination.write(
+            "======== TrIdx_TrWeight_and_TrIdx_i_xi ======\n"
+        )
+        destination.write("=============================================\n")
+        for index in range(nmptrans):
+            destination.write(
+                "{:5d} {:25.15f} {:25.15f}\n".format(index, 1.0, 0.0)
+            )
+        for index in range(nmptrans):
+            displacement = index * stride
+            for origin in range(size):
+                destination.write(
+                    "{:5d} {:5d} {:5d} {:5d}\n".format(
+                        index,
+                        origin,
+                        (origin + displacement) % size,
+                        1,
+                    )
+                )
 
 
 def replace_parameters(path, updates):
@@ -146,8 +191,26 @@ def run_checked(command, workdir, environment):
     return process.stdout
 
 
-def prepare_case(root, vmcdry, size, samples, warmup, environment):
-    case = os.path.join(root, "L{}".format(size), "template")
+def projection_label(nspgaussleg, nmptrans):
+    return "sp{}-mp{}".format(nspgaussleg, nmptrans)
+
+
+def prepare_case(
+    root,
+    vmcdry,
+    size,
+    samples,
+    warmup,
+    nspgaussleg,
+    nmptrans,
+    environment,
+):
+    case = os.path.join(
+        root,
+        projection_label(nspgaussleg, nmptrans),
+        "L{}".format(size),
+        "template",
+    )
     os.makedirs(case)
     standard_input = os.path.join(case, "StdFace.def")
     write_standard_input(standard_input, size, samples, warmup)
@@ -161,10 +224,13 @@ def prepare_case(root, vmcdry, size, samples, warmup, environment):
             "NVMCSample": str(samples),
             "NVMCWarmUp": str(warmup),
             "NExUpdatePath": "0",
-            "NSPGaussLeg": "1",
-            "NMPTrans": "1",
+            "NSPGaussLeg": str(nspgaussleg),
+            "NMPTrans": str(nmptrans),
             "NDataQtySmp": "1",
         },
+    )
+    write_momentum_projection(
+        os.path.join(case, "qptransidx.def"), size, nmptrans
     )
     write_initial_parameter(os.path.join(case, "initial.dat"), case)
     transfer_count = read_transfer_count(os.path.join(case, "trans.def"))
@@ -178,11 +244,23 @@ def prepare_case(root, vmcdry, size, samples, warmup, environment):
     return case, transfer_count
 
 
-def measure_case(root, template, vmc, size, repeats, environment):
+def measure_case(
+    root,
+    template,
+    vmc,
+    size,
+    repeats,
+    nspgaussleg,
+    nmptrans,
+    environment,
+):
     measurements = []
     for repeat in range(repeats):
         workdir = os.path.join(
-            root, "L{}".format(size), "repeat{}".format(repeat + 1)
+            root,
+            projection_label(nspgaussleg, nmptrans),
+            "L{}".format(size),
+            "repeat{}".format(repeat + 1),
         )
         shutil.copytree(template, workdir)
         replace_parameters(
@@ -207,7 +285,9 @@ def measure_case(root, template, vmc, size, repeats, environment):
     return measurements
 
 
-def summarize(size, transfer_count, measurements):
+def summarize(
+    size, transfer_count, nspgaussleg, nmptrans, measurements
+):
     timer41 = statistics.median(
         row["timer41_seconds"] for row in measurements
     )
@@ -220,6 +300,9 @@ def summarize(size, transfer_count, measurements):
     return {
         "L": size,
         "NTransfer": transfer_count,
+        "NSPGaussLeg": nspgaussleg,
+        "NMPTrans": nmptrans,
+        "NQPFull": nspgaussleg * nmptrans,
         "timer41_seconds_median": timer41,
         "timer95_seconds_median": timer95,
         "timer95_over_timer41_median": ratio,
@@ -228,23 +311,48 @@ def summarize(size, transfer_count, measurements):
     }
 
 
+def projection_groups(rows):
+    groups = {}
+    for row in rows:
+        key = (row["NSPGaussLeg"], row["NMPTrans"])
+        groups.setdefault(key, []).append(row)
+    return [
+        (key, sorted(group, key=lambda row: row["L"]))
+        for key, group in sorted(groups.items())
+    ]
+
+
 def check_scaling(rows):
     # Deliberately check only qualitative growth.  Cross-platform absolute
     # timing bands belong to a separately recorded Linux/HPC baseline.
-    ratios = [row["timer95_over_timer41_median"] for row in rows]
-    for previous, current in zip(ratios, ratios[1:]):
-        if current < 0.9 * previous:
+    for (nspgaussleg, nmptrans), group in projection_groups(rows):
+        if len(group) < 2:
             raise RuntimeError(
-                "Timer[95]/Timer[41] is not monotone within 10%: {}".format(
-                    ratios
+                "--check-scaling needs at least two sizes for "
+                "NSPGaussLeg={}, NMPTrans={}".format(
+                    nspgaussleg, nmptrans
                 )
             )
-    if ratios[-1] < 1.3 * ratios[0]:
-        raise RuntimeError(
-            "endpoint Timer[95]/Timer[41] growth is below 1.3x: {}".format(
-                ratios[-1] / ratios[0]
+        ratios = [
+            row["timer95_over_timer41_median"] for row in group
+        ]
+        for previous, current in zip(ratios, ratios[1:]):
+            if current < 0.9 * previous:
+                raise RuntimeError(
+                    "Timer[95]/Timer[41] is not monotone within 10% for "
+                    "NSPGaussLeg={}, NMPTrans={}: {}".format(
+                        nspgaussleg, nmptrans, ratios
+                    )
+                )
+        if ratios[-1] < 1.3 * ratios[0]:
+            raise RuntimeError(
+                "endpoint Timer[95]/Timer[41] growth is below 1.3x for "
+                "NSPGaussLeg={}, NMPTrans={}: {}".format(
+                    nspgaussleg,
+                    nmptrans,
+                    ratios[-1] / ratios[0],
+                )
             )
-        )
 
 
 def print_markdown(result):
@@ -261,36 +369,69 @@ def print_markdown(result):
     )
     print()
     print(
-        "| L | NTransfer | Timer[41] median (s) | Timer[95] median (s) "
+        "| L | NSPGaussLeg | NMPTrans | NQPFull | NTransfer "
+        "| Timer[41] median (s) | Timer[95] median (s) "
         "| [95]/[41] | ratio/NTransfer |"
     )
-    print("|---:|---:|---:|---:|---:|---:|")
+    print("|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
     for row in result["rows"]:
         print(
-            "| {L} | {NTransfer} | {timer41_seconds_median:.6g} "
+            "| {L} | {NSPGaussLeg} | {NMPTrans} | {NQPFull} "
+            "| {NTransfer} | {timer41_seconds_median:.6g} "
             "| {timer95_seconds_median:.6g} "
             "| {timer95_over_timer41_median:.6g} "
             "| {ratio_per_transfer:.6g} |".format(**row)
         )
-    endpoint = (
-        result["rows"][-1]["timer95_over_timer41_median"]
-        / result["rows"][0]["timer95_over_timer41_median"]
-    )
-    print()
-    print(
-        "Endpoint growth of Timer[95]/Timer[41]: {:.6g}x.".format(endpoint)
-    )
+    for (nspgaussleg, nmptrans), group in projection_groups(
+        result["rows"]
+    ):
+        if len(group) >= 2:
+            endpoint = (
+                group[-1]["timer95_over_timer41_median"]
+                / group[0]["timer95_over_timer41_median"]
+            )
+            print()
+            print(
+                "Endpoint growth of Timer[95]/Timer[41] for "
+                "NSPGaussLeg={}, NMPTrans={} (NQPFull={}): {:.6g}x.".format(
+                    nspgaussleg,
+                    nmptrans,
+                    nspgaussleg * nmptrans,
+                    endpoint,
+                )
+            )
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
         description=(
-            "Manual, non-CI L=4/6/8 Timer[95]/Timer[41] scaling probe."
+            "Manual, non-CI Timer[95]/Timer[41] scaling and projection "
+            "cost probe."
         )
     )
     parser.add_argument("--vmc", required=True, help="path to vmc.out")
     parser.add_argument("--vmcdry", required=True, help="path to vmcdry.out")
     parser.add_argument("--sizes", type=int, nargs="+", default=[4, 6, 8])
+    parser.add_argument(
+        "--nspgaussleg",
+        type=int,
+        nargs="+",
+        default=[1],
+        help=(
+            "spin-projection quadrature counts; all values are crossed "
+            "with --nmptrans (default: 1)"
+        ),
+    )
+    parser.add_argument(
+        "--nmptrans",
+        type=int,
+        nargs="+",
+        default=[1],
+        help=(
+            "cyclic momentum-projection subgroup sizes; each value must "
+            "divide every L (default: 1)"
+        ),
+    )
     parser.add_argument("--samples", type=int, default=4096)
     parser.add_argument("--warmup", type=int, default=64)
     parser.add_argument("--repeats", type=int, default=3)
@@ -314,13 +455,29 @@ def main():
         arguments.samples <= 0
         or arguments.warmup < 0
         or arguments.repeats <= 0
-        or len(arguments.sizes) < 2
+        or not arguments.sizes
         or any(size <= 0 or size % 2 != 0 for size in arguments.sizes)
+        or any(value <= 0 for value in arguments.nspgaussleg)
+        or any(value <= 0 for value in arguments.nmptrans)
     ):
         raise RuntimeError(
-            "sizes must be positive even integers; samples/repeats must be "
-            "positive and warmup non-negative"
+            "sizes must be positive even integers; projection counts and "
+            "samples/repeats must be positive; warmup must be non-negative"
         )
+    sizes = sorted(set(arguments.sizes))
+    nspgaussleg_values = sorted(set(arguments.nspgaussleg))
+    nmptrans_values = sorted(set(arguments.nmptrans))
+    for size in sizes:
+        for nmptrans in nmptrans_values:
+            if size % nmptrans != 0:
+                raise RuntimeError(
+                    "NMPTrans={} must divide L={}; choose a cyclic "
+                    "translation subgroup for every measured size".format(
+                        nmptrans, size
+                    )
+                )
+    if arguments.check_scaling and len(sizes) < 2:
+        raise RuntimeError("--check-scaling requires at least two sizes")
     vmc = os.path.abspath(arguments.vmc)
     vmcdry = os.path.abspath(arguments.vmcdry)
     for binary in (vmc, vmcdry):
@@ -341,31 +498,59 @@ def main():
     )
     try:
         rows = []
-        for size in sorted(arguments.sizes):
-            template, transfer_count = prepare_case(
-                workroot,
-                vmcdry,
-                size,
-                arguments.samples,
-                arguments.warmup,
-                environment,
-            )
-            measurements = measure_case(
-                workroot,
-                template,
-                vmc,
-                size,
-                arguments.repeats,
-                environment,
-            )
-            rows.append(summarize(size, transfer_count, measurements))
+        for nspgaussleg in nspgaussleg_values:
+            for nmptrans in nmptrans_values:
+                for size in sizes:
+                    template, transfer_count = prepare_case(
+                        workroot,
+                        vmcdry,
+                        size,
+                        arguments.samples,
+                        arguments.warmup,
+                        nspgaussleg,
+                        nmptrans,
+                        environment,
+                    )
+                    measurements = measure_case(
+                        workroot,
+                        template,
+                        vmc,
+                        size,
+                        arguments.repeats,
+                        nspgaussleg,
+                        nmptrans,
+                        environment,
+                    )
+                    rows.append(
+                        summarize(
+                            size,
+                            transfer_count,
+                            nspgaussleg,
+                            nmptrans,
+                            measurements,
+                        )
+                    )
         if arguments.check_scaling:
             check_scaling(rows)
         result = {
             "platform": platform.platform(),
+            "python": platform.python_version(),
+            "probe_sha256": sha256_file(os.path.abspath(__file__)),
+            "vmc_sha256": sha256_file(vmc),
+            "vmcdry_sha256": sha256_file(vmcdry),
+            "threads": {
+                "OMP_NUM_THREADS": 1,
+                "OPENBLAS_NUM_THREADS": 1,
+                "MKL_NUM_THREADS": 1,
+                "VECLIB_MAXIMUM_THREADS": 1,
+            },
+            "projection_definition": "cyclic k=0 translation subgroup",
+            "NQPOptTrans": 1,
             "samples": arguments.samples,
             "warmup": arguments.warmup,
             "repeats": arguments.repeats,
+            "nspgaussleg": nspgaussleg_values,
+            "nmptrans": nmptrans_values,
             "rows": rows,
         }
         print_markdown(result)

--- a/test/python/lanczos2_cost_probe.py
+++ b/test/python/lanczos2_cost_probe.py
@@ -1,0 +1,385 @@
+"""Manual, non-CI structural scaling probe for second power-Lanczos.
+
+The qualitative checks below verify that the expected H^3 work is exercised
+as NTransfer grows.  They are not a portable performance-regression gate:
+absolute ratios depend on the compiler, architecture, and linear-algebra
+stack.  Establish quantitative baselines on the same Linux/HPC environment.
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+
+
+TIMER_PATTERN = re.compile(r"\[(41|95)\]\s+([0-9.eE+-]+)\s*$")
+
+
+def write_standard_input(path, size, samples, warmup):
+    with open(path, "w") as destination:
+        destination.write(
+            """L = {size}
+Lsub = 2
+model = "Hubbard"
+lattice = "chain"
+U = 4
+t = 1
+ncond = {size}
+2Sz = 0
+NSROptItrStep = 1
+NVMCSample = {samples}
+NVMCWarmUp = {warmup}
+NVMCCalMode = 1
+NLanczosMode = 1
+RndSeed = 2468
+""".format(size=size, samples=samples, warmup=warmup)
+        )
+
+
+def replace_parameters(path, updates):
+    with open(path) as source:
+        lines = source.readlines()
+    remaining = dict(updates)
+    result = []
+    for line in lines:
+        columns = line.split()
+        if columns and columns[0] in remaining:
+            key = columns[0]
+            result.append("{:<16s} {}\n".format(key, remaining.pop(key)))
+        else:
+            result.append(line)
+    for key in sorted(remaining):
+        result.append("{:<16s} {}\n".format(key, remaining[key]))
+    with open(path, "w") as destination:
+        destination.writelines(result)
+
+
+def read_definition_count(path, keyword):
+    with open(path) as source:
+        for line in source:
+            columns = line.split()
+            if len(columns) >= 2 and columns[0] == keyword:
+                return int(columns[1])
+    raise RuntimeError("{} is missing from {}".format(keyword, path))
+
+
+def write_initial_parameter(path, workdir):
+    gutzwiller = read_definition_count(
+        os.path.join(workdir, "gutzwilleridx.def"), "NGutzwillerIdx"
+    )
+    jastrow = read_definition_count(
+        os.path.join(workdir, "jastrowidx.def"), "NJastrowIdx"
+    )
+    orbital = read_definition_count(
+        os.path.join(workdir, "orbitalidx.def"), "NOrbitalIdx"
+    )
+    values = [0.0] * 6
+    for index in range(gutzwiller + jastrow):
+        values.extend(
+            [
+                0.08 * math.sin(0.31 * (index + 1)),
+                0.0,
+                0.0,
+            ]
+        )
+    for index in range(orbital):
+        values.extend(
+            [
+                math.sin(0.37 * (index + 1))
+                + 0.23 * math.cos(0.19 * (index + 2)),
+                0.0,
+                0.0,
+            ]
+        )
+    with open(path, "w") as destination:
+        destination.write(
+            " ".join("{:.18e}".format(value) for value in values)
+        )
+        destination.write("\n")
+
+
+def read_transfer_count(path):
+    return read_definition_count(path, "NTransfer")
+
+
+def read_timers(path):
+    timers = {}
+    with open(path) as source:
+        for line in source:
+            match = TIMER_PATTERN.search(line)
+            if match is not None:
+                timers[int(match.group(1))] = float(match.group(2))
+    missing = sorted(set((41, 95)) - set(timers))
+    if missing:
+        raise RuntimeError(
+            "{} is missing timer(s) {}".format(path, ", ".join(map(str, missing)))
+        )
+    if timers[41] <= 0.0 or timers[95] <= 0.0:
+        raise RuntimeError("timers must be positive: {}".format(timers))
+    return timers
+
+
+def run_checked(command, workdir, environment):
+    process = subprocess.run(
+        command,
+        cwd=workdir,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            "command failed ({}):\n{}".format(
+                " ".join(command), process.stdout
+            )
+        )
+    return process.stdout
+
+
+def prepare_case(root, vmcdry, size, samples, warmup, environment):
+    case = os.path.join(root, "L{}".format(size), "template")
+    os.makedirs(case)
+    standard_input = os.path.join(case, "StdFace.def")
+    write_standard_input(standard_input, size, samples, warmup)
+    run_checked([vmcdry, standard_input], case, environment)
+    replace_parameters(
+        os.path.join(case, "modpara.def"),
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NVMCSample": str(samples),
+            "NVMCWarmUp": str(warmup),
+            "NExUpdatePath": "0",
+            "NSPGaussLeg": "1",
+            "NMPTrans": "1",
+            "NDataQtySmp": "1",
+        },
+    )
+    write_initial_parameter(os.path.join(case, "initial.dat"), case)
+    transfer_count = read_transfer_count(os.path.join(case, "trans.def"))
+    expected_transfer_count = 4 * size
+    if transfer_count != expected_transfer_count:
+        raise RuntimeError(
+            "L={} generated NTransfer={}, expected {}".format(
+                size, transfer_count, expected_transfer_count
+            )
+        )
+    return case, transfer_count
+
+
+def measure_case(root, template, vmc, size, repeats, environment):
+    measurements = []
+    for repeat in range(repeats):
+        workdir = os.path.join(
+            root, "L{}".format(size), "repeat{}".format(repeat + 1)
+        )
+        shutil.copytree(template, workdir)
+        replace_parameters(
+            os.path.join(workdir, "modpara.def"),
+            {"RndSeed": str(2468 + repeat)},
+        )
+        run_checked(
+            [vmc, "-e", "namelist.def", "initial.dat"],
+            workdir,
+            environment,
+        )
+        timers = read_timers(
+            os.path.join(workdir, "output", "zvo_CalcTimer.dat")
+        )
+        measurements.append(
+            {
+                "timer41_seconds": timers[41],
+                "timer95_seconds": timers[95],
+                "timer95_over_timer41": timers[95] / timers[41],
+            }
+        )
+    return measurements
+
+
+def summarize(size, transfer_count, measurements):
+    timer41 = statistics.median(
+        row["timer41_seconds"] for row in measurements
+    )
+    timer95 = statistics.median(
+        row["timer95_seconds"] for row in measurements
+    )
+    ratio = statistics.median(
+        row["timer95_over_timer41"] for row in measurements
+    )
+    return {
+        "L": size,
+        "NTransfer": transfer_count,
+        "timer41_seconds_median": timer41,
+        "timer95_seconds_median": timer95,
+        "timer95_over_timer41_median": ratio,
+        "ratio_per_transfer": ratio / transfer_count,
+        "measurements": measurements,
+    }
+
+
+def check_scaling(rows):
+    # Deliberately check only qualitative growth.  Cross-platform absolute
+    # timing bands belong to a separately recorded Linux/HPC baseline.
+    ratios = [row["timer95_over_timer41_median"] for row in rows]
+    for previous, current in zip(ratios, ratios[1:]):
+        if current < 0.9 * previous:
+            raise RuntimeError(
+                "Timer[95]/Timer[41] is not monotone within 10%: {}".format(
+                    ratios
+                )
+            )
+    if ratios[-1] < 1.3 * ratios[0]:
+        raise RuntimeError(
+            "endpoint Timer[95]/Timer[41] growth is below 1.3x: {}".format(
+                ratios[-1] / ratios[0]
+            )
+        )
+
+
+def print_markdown(result):
+    print("# Second-Lanczos cost probe")
+    print()
+    print(
+        "platform: `{}`; OMP/BLAS threads: 1; samples: {}; warmup: {}; "
+        "repeats: {}".format(
+            result["platform"],
+            result["samples"],
+            result["warmup"],
+            result["repeats"],
+        )
+    )
+    print()
+    print(
+        "| L | NTransfer | Timer[41] median (s) | Timer[95] median (s) "
+        "| [95]/[41] | ratio/NTransfer |"
+    )
+    print("|---:|---:|---:|---:|---:|---:|")
+    for row in result["rows"]:
+        print(
+            "| {L} | {NTransfer} | {timer41_seconds_median:.6g} "
+            "| {timer95_seconds_median:.6g} "
+            "| {timer95_over_timer41_median:.6g} "
+            "| {ratio_per_transfer:.6g} |".format(**row)
+        )
+    endpoint = (
+        result["rows"][-1]["timer95_over_timer41_median"]
+        / result["rows"][0]["timer95_over_timer41_median"]
+    )
+    print()
+    print(
+        "Endpoint growth of Timer[95]/Timer[41]: {:.6g}x.".format(endpoint)
+    )
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Manual, non-CI L=4/6/8 Timer[95]/Timer[41] scaling probe."
+        )
+    )
+    parser.add_argument("--vmc", required=True, help="path to vmc.out")
+    parser.add_argument("--vmcdry", required=True, help="path to vmcdry.out")
+    parser.add_argument("--sizes", type=int, nargs="+", default=[4, 6, 8])
+    parser.add_argument("--samples", type=int, default=4096)
+    parser.add_argument("--warmup", type=int, default=64)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--work-parent", default=None)
+    parser.add_argument("--keep-work", action="store_true")
+    parser.add_argument(
+        "--check-scaling",
+        action="store_true",
+        help=(
+            "check qualitative growth only; this is not a portable "
+            "performance-regression baseline"
+        ),
+    )
+    parser.add_argument("--json-output", default=None)
+    return parser.parse_args()
+
+
+def main():
+    arguments = parse_arguments()
+    if (
+        arguments.samples <= 0
+        or arguments.warmup < 0
+        or arguments.repeats <= 0
+        or len(arguments.sizes) < 2
+        or any(size <= 0 or size % 2 != 0 for size in arguments.sizes)
+    ):
+        raise RuntimeError(
+            "sizes must be positive even integers; samples/repeats must be "
+            "positive and warmup non-negative"
+        )
+    vmc = os.path.abspath(arguments.vmc)
+    vmcdry = os.path.abspath(arguments.vmcdry)
+    for binary in (vmc, vmcdry):
+        if not os.path.isfile(binary) or not os.access(binary, os.X_OK):
+            raise RuntimeError("executable not found: {}".format(binary))
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "OMP_NUM_THREADS": "1",
+            "OPENBLAS_NUM_THREADS": "1",
+            "MKL_NUM_THREADS": "1",
+            "VECLIB_MAXIMUM_THREADS": "1",
+        }
+    )
+    workroot = tempfile.mkdtemp(
+        prefix="lanczos2-cost-probe-", dir=arguments.work_parent
+    )
+    try:
+        rows = []
+        for size in sorted(arguments.sizes):
+            template, transfer_count = prepare_case(
+                workroot,
+                vmcdry,
+                size,
+                arguments.samples,
+                arguments.warmup,
+                environment,
+            )
+            measurements = measure_case(
+                workroot,
+                template,
+                vmc,
+                size,
+                arguments.repeats,
+                environment,
+            )
+            rows.append(summarize(size, transfer_count, measurements))
+        if arguments.check_scaling:
+            check_scaling(rows)
+        result = {
+            "platform": platform.platform(),
+            "samples": arguments.samples,
+            "warmup": arguments.warmup,
+            "repeats": arguments.repeats,
+            "rows": rows,
+        }
+        print_markdown(result)
+        if arguments.json_output is not None:
+            with open(arguments.json_output, "w") as destination:
+                json.dump(result, destination, indent=2, sort_keys=True)
+                destination.write("\n")
+    finally:
+        if arguments.keep_work:
+            print("work directory kept at {}".format(workroot), file=sys.stderr)
+        else:
+            shutil.rmtree(workroot)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/python/runtest_bf.py
+++ b/test/python/runtest_bf.py
@@ -1236,6 +1236,7 @@ def main():
     compare_energy = False
     compare_lanczos = False
     lanczos_mode = None
+    lanczos_step = None
     vmc_cal_mode = None
     compare_twobodyg = False
     compare_twobodygex = False
@@ -1281,6 +1282,9 @@ def main():
             argi += 1
         elif sys.argv[argi] == "--lanczos-mode" and argi + 1 < len(sys.argv):
             lanczos_mode = str(int(sys.argv[argi + 1]))
+            argi += 2
+        elif sys.argv[argi] == "--lanczos-step" and argi + 1 < len(sys.argv):
+            lanczos_step = str(int(sys.argv[argi + 1]))
             argi += 2
         elif sys.argv[argi] == "--vmc-cal-mode" and argi + 1 < len(sys.argv):
             vmc_cal_mode = str(int(sys.argv[argi + 1]))
@@ -1363,6 +1367,8 @@ def main():
         work_suffix += "_energy"
     if lanczos_mode is not None:
         work_suffix += "_lanczos{}".format(lanczos_mode)
+    if lanczos_step is not None:
+        work_suffix += "_lanczos_step{}".format(lanczos_step)
     if compare_twobodyg:
         work_suffix += "_twobodyg"
     if compare_twobodygex:
@@ -1423,6 +1429,8 @@ def main():
             lanczos_samples_override if lanczos_samples_override is not None
             else ("128" if expect_lanczos_warning else "32"))
         modpara_updates["NVMCWarmUp"] = "8"
+    if lanczos_step is not None:
+        modpara_updates["NLanczosStep"] = lanczos_step
     if vmc_cal_mode is not None:
         modpara_updates["NVMCCalMode"] = vmc_cal_mode
     if modpara_updates:

--- a/test/python/runtest_invalid_expert.py
+++ b/test/python/runtest_invalid_expert.py
@@ -41,6 +41,30 @@ def update_modpara(filename, updates):
         f.writelines(lines)
 
 
+def inject_spin_flip_transfer(filename):
+    with open(filename) as source:
+        lines = source.readlines()
+    for index, line in enumerate(lines):
+        words = line.split()
+        if len(words) != 6:
+            continue
+        try:
+            int(words[0])
+            source_spin = int(words[1])
+            int(words[2])
+            int(words[3])
+            float(words[4])
+            float(words[5])
+        except ValueError:
+            continue
+        words[3] = str(1 - source_spin)
+        lines[index] = " ".join(words) + "\n"
+        with open(filename, "w") as destination:
+            destination.writelines(lines)
+        return
+    raise RuntimeError("no Transfer data row was available for mutation")
+
+
 def main():
     if len(sys.argv) < 3:
         print(
@@ -52,10 +76,13 @@ def main():
     model = sys.argv[1]
     expected = sys.argv[2]
     allow_success = False
+    spin_flip_transfer = False
     modpara_updates = {}
     for arg in sys.argv[3:]:
         if arg == "allow_success":
             allow_success = True
+        elif arg == "spin_flip_transfer":
+            spin_flip_transfer = True
         elif "=" in arg:
             key, value = arg.split("=", 1)
             modpara_updates[key] = value
@@ -82,10 +109,20 @@ def main():
 
     if modpara_updates:
         update_modpara("modpara.def", modpara_updates)
+    if spin_flip_transfer:
+        try:
+            inject_spin_flip_transfer("trans.def")
+        except RuntimeError as error:
+            print("ERROR: {}".format(error))
+            return -1
 
     bin_to_test = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
+    command = [bin_to_test, "-e", "namelist.def"]
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    if mpi_procs:
+        command = ["mpirun", "-np", mpi_procs] + command
     proc = subprocess.run(
-        [bin_to_test, "-e", "namelist.def"],
+        command,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/test/python/runtest_lanczos2_complex_ed.py
+++ b/test/python/runtest_lanczos2_complex_ed.py
@@ -1,0 +1,304 @@
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+
+import numpy as np
+
+from runtest_bf_fsz import run_vmc, update_modpara
+from runtest_lanczos2_real_ed import (
+    assert_scaled_close,
+    check_solver_output,
+    DIAGONAL_TRANSFER,
+    occupation_state,
+    one_hop_states,
+    RING_HOPS,
+    read_ls2_oracle,
+    GUTZWILLER_PARAMETER,
+    write_gutzwiller,
+    write_lanczos2_namelist,
+)
+from runtest_lanczos_sector_ed import (
+    COULOMB_INTRA,
+    NSITE,
+    coulomb_intra,
+    doublon_count,
+    fixed_basis,
+    one_body,
+    operator_matrix_complex,
+    write_coulomb_intra,
+)
+
+PEIERLS_PHASE = 0.37
+FORWARD_RING_HOPS = frozenset(RING_HOPS[::2])
+
+
+def hopping_amplitude(left, right):
+    phase = PEIERLS_PHASE if (left, right) in FORWARD_RING_HOPS \
+        else -PEIERLS_PHASE
+    return np.exp(1.0j * phase)
+
+
+def write_complex_transfer(workdir):
+    rows = []
+    for left, right in RING_HOPS:
+        amplitude = hopping_amplitude(left, right)
+        for spin in (0, 1):
+            rows.append(
+                (left, spin, right, spin, amplitude.real, amplitude.imag)
+            )
+    site, spin, _, coupling = DIAGONAL_TRANSFER
+    rows.append((site, spin, site, spin, coupling, 0.0))
+    with open(os.path.join(workdir, "trans.def"), "w") as destination:
+        destination.write("========================\n")
+        destination.write("NTransfer      {}\n".format(len(rows)))
+        destination.write("========================\n")
+        destination.write("========i_j_s_tijs======\n")
+        destination.write("========================\n")
+        for row in rows:
+            destination.write(
+                "{:5d} {:5d} {:5d} {:5d} {:25.15f} {:25.15f}\n".format(
+                    *row
+                )
+            )
+
+
+def complex_orbitals():
+    orbital = np.array(
+        [
+            [
+                np.sin(0.37 * (row + 1) * (column + 2))
+                + 0.3 * np.cos(0.19 * (row + 2) * (column + 1))
+                + 0.2j * np.cos(0.23 * (row + 2) * (column + 1))
+                for column in range(NSITE)
+            ]
+            for row in range(NSITE)
+        ],
+        dtype=complex,
+    )
+    orbital[1, 1] = orbital[1, 0] * orbital[0, 1] / orbital[0, 0]
+    return orbital.reshape(NSITE * NSITE)
+
+
+def complex_ap_orbital_amplitude(state, orbital):
+    up_sites = [
+        site for site in range(NSITE) if (state >> site) & 1
+    ]
+    down_sites = [
+        site for site in range(NSITE) if (state >> (site + NSITE)) & 1
+    ]
+    matrix = np.array(
+        [[orbital[up, down] for down in down_sites] for up in up_sites],
+        dtype=complex,
+    )
+    return np.linalg.det(matrix)
+
+
+def write_complex_init(workdir):
+    values = [0.0] * 6
+    values.extend([GUTZWILLER_PARAMETER, 0.0, 0.0])
+    for value in complex_orbitals():
+        values.extend([value.real, value.imag, 0.0])
+    filename = "lanczos2_complex_init.dat"
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write(
+            " ".join("{:.18e}".format(value) for value in values)
+        )
+        destination.write("\n")
+    return filename
+
+
+def build_reference():
+    basis = fixed_basis(2, 2)
+    orbital = complex_orbitals().reshape((NSITE, NSITE))
+    psi = np.array(
+        [
+            complex_ap_orbital_amplitude(state, orbital)
+            * np.exp(GUTZWILLER_PARAMETER * doublon_count(state))
+            for state in basis
+        ],
+        dtype=complex,
+    )
+    terms = []
+    for left, right in RING_HOPS:
+        for spin in (0, 1):
+            terms.append(
+                (-hopping_amplitude(left, right),
+                 one_body(left, right, spin))
+            )
+    site, spin, _, coupling = DIAGONAL_TRANSFER
+    terms.append((-coupling, one_body(site, site, spin)))
+    terms.extend(
+        (coupling, coulomb_intra(site))
+        for site, coupling in enumerate(COULOMB_INTRA)
+    )
+    hamiltonian = operator_matrix_complex(basis, terms)
+    hermiticity_residual = np.max(
+        np.abs(hamiltonian - np.conj(hamiltonian.T))
+    )
+    if hermiticity_residual > 2.0e-13:
+        raise AssertionError(
+            "complex-hopping ED Hamiltonian is not Hermitian: {}".format(
+                hermiticity_residual
+            )
+        )
+    powers = [psi]
+    for _ in range(3):
+        powers.append(np.dot(hamiltonian, powers[-1]))
+    reference = {}
+    unconjugated_reference = {}
+    zero_overlap_states = set()
+    for index, state in enumerate(basis):
+        if abs(psi[index]) <= 1.0e-13:
+            zero_overlap_states.add(state)
+            continue
+        # mVMC evaluates the bra-oriented local estimator.
+        reference[state] = np.array(
+            [
+                np.conj(powers[order][index] / psi[index])
+                for order in range(4)
+            ],
+            dtype=complex,
+        )
+        unconjugated_reference[state] = np.array(
+            [
+                powers[order][index] / psi[index]
+                for order in range(4)
+            ],
+            dtype=complex,
+        )
+    return reference, unconjugated_reference, zero_overlap_states
+
+
+def main():
+    rootdir = os.getcwd()
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    reference_dir = os.path.join(
+        rootdir, "data", "BackFlow_Identity_Complex"
+    )
+    suffix = "_mpi" if mpi_procs else ""
+    workdir = os.path.join(rootdir, "work", "Lanczos2_Complex_ED" + suffix)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    for filename in os.listdir(reference_dir):
+        source = os.path.join(reference_dir, filename)
+        if os.path.isfile(source):
+            shutil.copy2(source, os.path.join(workdir, filename))
+
+    write_coulomb_intra(workdir)
+    write_lanczos2_namelist(workdir)
+    write_complex_transfer(workdir)
+    write_gutzwiller(workdir)
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NVMCSample": "256",
+            "NVMCWarmUp": "32",
+            "2Sz": "0",
+            "NMPTrans": "1",
+        },
+    )
+    init_path = write_complex_init(workdir)
+    dump_name = "lanczos2_complex_oracle.dat"
+    proc = run_vmc(
+        rootdir,
+        workdir,
+        mpi_procs=mpi_procs,
+        init_path=init_path,
+        extra_env={"MVMC_LANCZOS_ORACLE_DUMP": dump_name},
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            "Lanczos2 complex vmc.out failed:\n{}".format(proc.stdout)
+        )
+
+    if mpi_procs:
+        rows = []
+        for rank in range(int(mpi_procs)):
+            rows.extend(
+                read_ls2_oracle(
+                    os.path.join(
+                        workdir, dump_name + ".rank{:04d}".format(rank)
+                    )
+                )
+            )
+    else:
+        rows = read_ls2_oracle(os.path.join(workdir, dump_name))
+    reference, unconjugated_reference, zero_overlap_states = build_reference()
+    if not zero_overlap_states:
+        raise AssertionError("complex ED fixture has no zero-overlap state")
+    seen = {}
+    saw_imaginary = False
+    exercised_zero_overlap = False
+    conjugation_sensitive = False
+    for sample, occupation, power in rows:
+        state = occupation_state(occupation)
+        if state not in reference:
+            raise AssertionError(
+                "sample {} has zero or missing ED amplitude".format(sample)
+            )
+        for order in range(4):
+            assert_scaled_close(
+                "complex sample {} F{}".format(sample, order),
+                power[order],
+                reference[state][order],
+            )
+            if abs(power[order].imag) > 1.0e-8:
+                saw_imaginary = True
+            if abs(
+                reference[state][order]
+                - unconjugated_reference[state][order]
+            ) > 1.0e-6:
+                conjugation_sensitive = True
+        if occupation in seen:
+            if not np.allclose(power, seen[occupation], rtol=2.0e-12,
+                               atol=2.0e-12):
+                raise AssertionError(
+                    "complex local power changed for repeated occupation"
+                )
+        else:
+            seen[occupation] = power
+        if any(
+            neighbor in zero_overlap_states
+            for neighbor in one_hop_states(state)
+        ):
+            exercised_zero_overlap = True
+    if len(seen) < 8:
+        raise AssertionError(
+            "Lanczos2 complex ED fixture sampled only {} occupations".format(
+                len(seen)
+            )
+        )
+    if not saw_imaginary:
+        raise AssertionError("complex Lanczos2 fixture did not exercise Im(F)")
+    if not conjugation_sensitive:
+        raise AssertionError(
+            "complex-hopping fixture is insensitive to the local-power "
+            "conjugation convention"
+        )
+    if not exercised_zero_overlap:
+        raise AssertionError(
+            "complex ED fixture did not exercise a zero-overlap intermediate"
+        )
+    hankel_standard_error = check_solver_output(workdir, rows)
+    print(
+        "Lanczos2 complex ED: PASS "
+        "({} samples, {} occupations, Peierls phase={}, "
+        "max Hankel SE={:.3f})".format(
+            len(rows), len(seen), PEIERLS_PHASE, hankel_standard_error
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as error:
+        print("ERROR: {}".format(error))
+        sys.exit(1)

--- a/test/python/runtest_lanczos2_projected_ed.py
+++ b/test/python/runtest_lanczos2_projected_ed.py
@@ -1,0 +1,294 @@
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+
+import numpy as np
+
+from runtest_bf_fsz import run_vmc, update_modpara
+from runtest_lanczos2_real_ed import (
+    DIAGONAL_TRANSFER,
+    GUTZWILLER_PARAMETER,
+    RING_HOPS,
+    assert_scaled_close,
+    check_solver_output,
+    occupation_state,
+    read_ls2_oracle,
+    real_orbitals,
+    write_gutzwiller,
+    write_lanczos2_namelist,
+    write_real_init,
+    write_transfer_with_diagonal,
+)
+from runtest_lanczos_sector_ed import (
+    COULOMB_INTRA,
+    NSITE,
+    ap_orbital_amplitude,
+    coulomb_intra,
+    doublon_count,
+    fixed_basis,
+    one_body,
+    operator_matrix,
+    write_coulomb_intra,
+)
+
+
+TRANSLATIONS = tuple(
+    tuple((site + displacement) % NSITE for site in range(NSITE))
+    for displacement in range(NSITE)
+)
+MOMENTUM_PI_WEIGHTS = (1.0, -1.0, 1.0, -1.0)
+
+
+def write_translation_projection(workdir):
+    with open(os.path.join(workdir, "qptransidx.def"), "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("NQPTrans          {}\n".format(len(TRANSLATIONS)))
+        destination.write("=============================================\n")
+        destination.write(
+            "======== TrIdx_TrWeight_and_TrIdx_i_xi ======\n"
+        )
+        destination.write("=============================================\n")
+        for index, weight in enumerate(MOMENTUM_PI_WEIGHTS):
+            destination.write(
+                "{:5d} {:25.15f} {:25.15f}\n".format(index, weight, 0.0)
+            )
+        for index, translation in enumerate(TRANSLATIONS):
+            for origin, translated in enumerate(translation):
+                destination.write(
+                    "{:5d} {:5d} {:5d} {:5d}\n".format(
+                        index, origin, translated, 1
+                    )
+                )
+
+
+def translated_ap_amplitude(state, orbital, translation):
+    up_sites = [
+        site for site in range(NSITE) if (state >> site) & 1
+    ]
+    down_sites = [
+        site for site in range(NSITE)
+        if (state >> (site + NSITE)) & 1
+    ]
+    matrix = np.array(
+        [
+            [
+                orbital[translation[up], translation[down]]
+                for down in down_sites
+            ]
+            for up in up_sites
+        ],
+        dtype=float,
+    )
+    return np.linalg.det(matrix)
+
+
+def projected_amplitude(state, orbital):
+    return sum(
+        weight * translated_ap_amplitude(state, orbital, translation)
+        for weight, translation in zip(
+            MOMENTUM_PI_WEIGHTS, TRANSLATIONS
+        )
+    )
+
+
+def build_projected_reference():
+    basis = fixed_basis(2, 2)
+    orbital = real_orbitals()
+    unprojected = np.array(
+        [
+            ap_orbital_amplitude(state, orbital)
+            * np.exp(GUTZWILLER_PARAMETER * doublon_count(state))
+            for state in basis
+        ],
+        dtype=float,
+    )
+    projected = np.array(
+        [
+            projected_amplitude(state, orbital)
+            * np.exp(GUTZWILLER_PARAMETER * doublon_count(state))
+            for state in basis
+        ],
+        dtype=float,
+    )
+    if np.min(np.abs(projected)) <= 1.0e-13:
+        raise AssertionError(
+            "projected ED fixture unexpectedly has a zero-overlap state"
+        )
+
+    fidelity = (
+        abs(np.vdot(unprojected, projected)) ** 2
+        / (
+            np.vdot(unprojected, unprojected).real
+            * np.vdot(projected, projected).real
+        )
+    )
+    if fidelity >= 0.95:
+        raise AssertionError(
+            "momentum projection is too close to the identity: "
+            "fidelity={}".format(fidelity)
+        )
+
+    terms = []
+    for left, right in RING_HOPS:
+        for spin in (0, 1):
+            terms.append((-1.0, one_body(left, right, spin)))
+    site, spin, _, coupling = DIAGONAL_TRANSFER
+    terms.append((-coupling, one_body(site, site, spin)))
+    terms.extend(
+        (coupling, coulomb_intra(site))
+        for site, coupling in enumerate(COULOMB_INTRA)
+    )
+    hamiltonian = operator_matrix(basis, terms)
+    powers = [projected]
+    for _ in range(3):
+        powers.append(np.dot(hamiltonian, powers[-1]))
+
+    normalization = np.vdot(powers[0], powers[0])
+    moment = np.array(
+        [
+            [
+                np.vdot(powers[left], powers[right]) / normalization
+                for right in range(4)
+            ]
+            for left in range(4)
+        ],
+        dtype=complex,
+    )
+    scale = max(np.max(np.abs(moment)), 1.0)
+    for left in range(4):
+        for right in range(4):
+            for other_left in range(4):
+                other_right = left + right - other_left
+                if 0 <= other_right < 4 and abs(
+                    moment[left, right]
+                    - moment[other_left, other_right]
+                ) > 2.0e-12 * scale:
+                    raise AssertionError(
+                        "projected full-enumeration Hankel identity failed"
+                    )
+
+    reference = {}
+    for index, state in enumerate(basis):
+        reference[state] = np.array(
+            [
+                powers[order][index] / projected[index]
+                for order in range(4)
+            ],
+            dtype=complex,
+        )
+    return reference, fidelity
+
+
+def main():
+    rootdir = os.getcwd()
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    reference_dir = os.path.join(rootdir, "data", "BackFlow_Identity_Real")
+    suffix = "_mpi" if mpi_procs else ""
+    workdir = os.path.join(rootdir, "work", "Lanczos2_Projected_ED" + suffix)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    for filename in os.listdir(reference_dir):
+        source = os.path.join(reference_dir, filename)
+        if os.path.isfile(source):
+            shutil.copy2(source, os.path.join(workdir, filename))
+
+    write_coulomb_intra(workdir)
+    write_lanczos2_namelist(workdir)
+    write_transfer_with_diagonal(workdir)
+    write_gutzwiller(workdir)
+    write_translation_projection(workdir)
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NVMCSample": "256",
+            "NVMCWarmUp": "32",
+            "2Sz": "0",
+            "NSPGaussLeg": "1",
+            "NSPStot": "0",
+            "NMPTrans": str(len(TRANSLATIONS)),
+        },
+    )
+    init_path = write_real_init(workdir)
+    dump_name = "lanczos2_projected_oracle.dat"
+    process = run_vmc(
+        rootdir,
+        workdir,
+        mpi_procs=mpi_procs,
+        init_path=init_path,
+        extra_env={"MVMC_LANCZOS_ORACLE_DUMP": dump_name},
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "Lanczos2 projected vmc.out failed:\n{}".format(process.stdout)
+        )
+
+    if mpi_procs:
+        rows = []
+        for rank in range(int(mpi_procs)):
+            rows.extend(
+                read_ls2_oracle(
+                    os.path.join(
+                        workdir, dump_name + ".rank{:04d}".format(rank)
+                    )
+                )
+            )
+    else:
+        rows = read_ls2_oracle(os.path.join(workdir, dump_name))
+
+    reference, identity_fidelity = build_projected_reference()
+    seen = {}
+    for sample, occupation, power in rows:
+        state = occupation_state(occupation)
+        if state not in reference:
+            raise AssertionError(
+                "sample {} is outside the projected ED basis".format(sample)
+            )
+        for order in range(4):
+            assert_scaled_close(
+                "projected sample {} F{}".format(sample, order),
+                power[order],
+                reference[state][order],
+                absolute=3.0e-9,
+                relative=3.0e-9,
+            )
+        if occupation in seen and not np.allclose(
+            power, seen[occupation], rtol=3.0e-12, atol=3.0e-12
+        ):
+            raise AssertionError(
+                "projected local power changed for repeated occupation"
+            )
+        seen[occupation] = power
+    if len(seen) < 8:
+        raise AssertionError(
+            "projected ED fixture sampled only {} occupations".format(
+                len(seen)
+            )
+        )
+
+    hankel_standard_error = check_solver_output(workdir, rows)
+    print(
+        "Lanczos2 projected ED: PASS "
+        "({} samples, {} occupations, NMPTrans={}, k=pi, "
+        "identity fidelity={:.3f}, max Hankel SE={:.3f})".format(
+            len(rows),
+            len(seen),
+            len(TRANSLATIONS),
+            identity_fidelity,
+            hankel_standard_error,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as error:
+        print("ERROR: {}".format(error))
+        sys.exit(1)

--- a/test/python/runtest_lanczos2_projected_ed.py
+++ b/test/python/runtest_lanczos2_projected_ed.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+import re
 import shutil
 import sys
 
@@ -79,7 +80,7 @@ def translated_ap_amplitude(state, orbital, translation):
             ]
             for up in up_sites
         ],
-        dtype=float,
+        dtype=orbital.dtype,
     )
     return np.linalg.det(matrix)
 
@@ -93,16 +94,26 @@ def projected_amplitude(state, orbital):
     )
 
 
-def build_projected_reference():
+def build_projected_reference(complex_mode):
     basis = fixed_basis(2, 2)
-    orbital = real_orbitals()
+    if complex_mode:
+        from runtest_lanczos2_complex_ed import (
+            complex_ap_orbital_amplitude,
+            complex_orbitals,
+            hopping_amplitude,
+        )
+        orbital = complex_orbitals().reshape((NSITE, NSITE))
+        amplitude = complex_ap_orbital_amplitude
+    else:
+        orbital = real_orbitals()
+        amplitude = ap_orbital_amplitude
     unprojected = np.array(
         [
-            ap_orbital_amplitude(state, orbital)
+            amplitude(state, orbital)
             * np.exp(GUTZWILLER_PARAMETER * doublon_count(state))
             for state in basis
         ],
-        dtype=float,
+        dtype=complex if complex_mode else float,
     )
     projected = np.array(
         [
@@ -110,7 +121,7 @@ def build_projected_reference():
             * np.exp(GUTZWILLER_PARAMETER * doublon_count(state))
             for state in basis
         ],
-        dtype=float,
+        dtype=complex if complex_mode else float,
     )
     if np.min(np.abs(projected)) <= 1.0e-13:
         raise AssertionError(
@@ -133,14 +144,22 @@ def build_projected_reference():
     terms = []
     for left, right in RING_HOPS:
         for spin in (0, 1):
-            terms.append((-1.0, one_body(left, right, spin)))
+            coefficient = (
+                -hopping_amplitude(left, right)
+                if complex_mode else -1.0
+            )
+            terms.append((coefficient, one_body(left, right, spin)))
     site, spin, _, coupling = DIAGONAL_TRANSFER
     terms.append((-coupling, one_body(site, site, spin)))
     terms.extend(
         (coupling, coulomb_intra(site))
         for site, coupling in enumerate(COULOMB_INTRA)
     )
-    hamiltonian = operator_matrix(basis, terms)
+    if complex_mode:
+        from runtest_lanczos_sector_ed import operator_matrix_complex
+        hamiltonian = operator_matrix_complex(basis, terms)
+    else:
+        hamiltonian = operator_matrix(basis, terms)
     powers = [projected]
     for _ in range(3):
         powers.append(np.dot(hamiltonian, powers[-1]))
@@ -173,20 +192,87 @@ def build_projected_reference():
     for index, state in enumerate(basis):
         reference[state] = np.array(
             [
-                powers[order][index] / projected[index]
+                (
+                    np.conj(powers[order][index] / projected[index])
+                    if complex_mode
+                    else powers[order][index] / projected[index]
+                )
                 for order in range(4)
             ],
             dtype=complex,
         )
-    return reference, fidelity
+    return reference, fidelity, orbital
+
+
+def moved_state(state, left, right, spin):
+    source = right + spin * NSITE
+    target = left + spin * NSITE
+    if not ((state >> source) & 1) or ((state >> target) & 1):
+        return None
+    return state ^ (1 << source) ^ (1 << target)
+
+
+def count_zero_component_transitions(sampled_states, orbital):
+    count = 0
+    for state in sampled_states:
+        if abs(projected_amplitude(state, orbital)) <= 1.0e-12:
+            continue
+        for left, right in RING_HOPS:
+            for spin in (0, 1):
+                candidate = moved_state(state, left, right, spin)
+                if candidate is None:
+                    continue
+                components = [
+                    translated_ap_amplitude(
+                        candidate, orbital, translation
+                    )
+                    for translation in TRANSLATIONS
+                ]
+                projected = sum(
+                    weight * component
+                    for weight, component in zip(
+                        MOMENTUM_PI_WEIGHTS, components
+                    )
+                )
+                if (
+                    abs(projected) > 1.0e-12
+                    and any(
+                        abs(component) <= 1.0e-12
+                        for component in components
+                    )
+                ):
+                    count += 1
+    return count
 
 
 def main():
+    arguments = set(sys.argv[1:])
+    if arguments - {"--complex"}:
+        raise AssertionError(
+            "unknown projected ED argument: {}".format(
+                sorted(arguments - {"--complex"})
+            )
+        )
+    complex_mode = "--complex" in arguments
+    guard_audit = os.environ.get(
+        "MVMC_LANCZOS2_TEST_CALHCA_GUARD_AUDIT", "0"
+    ) not in ("", "0")
     rootdir = os.getcwd()
     mpi_procs = os.environ.get("MVMC_MPI_PROCS")
-    reference_dir = os.path.join(rootdir, "data", "BackFlow_Identity_Real")
+    reference_dir = os.path.join(
+        rootdir,
+        "data",
+        (
+            "BackFlow_Identity_Complex"
+            if complex_mode else "BackFlow_Identity_Real"
+        ),
+    )
     suffix = "_mpi" if mpi_procs else ""
-    workdir = os.path.join(rootdir, "work", "Lanczos2_Projected_ED" + suffix)
+    case_name = (
+        "Lanczos2_Projected_Complex_ED"
+        if complex_mode else "Lanczos2_Projected_ED"
+    )
+    workdir = os.path.join(rootdir, "work", case_name + suffix)
     if os.path.exists(workdir):
         shutil.rmtree(workdir)
     os.makedirs(workdir)
@@ -197,7 +283,14 @@ def main():
 
     write_coulomb_intra(workdir)
     write_lanczos2_namelist(workdir)
-    write_transfer_with_diagonal(workdir)
+    if complex_mode:
+        from runtest_lanczos2_complex_ed import (
+            write_complex_init,
+            write_complex_transfer,
+        )
+        write_complex_transfer(workdir)
+    else:
+        write_transfer_with_diagonal(workdir)
     write_gutzwiller(workdir)
     write_translation_projection(workdir)
     update_modpara(
@@ -214,19 +307,45 @@ def main():
             "NMPTrans": str(len(TRANSLATIONS)),
         },
     )
-    init_path = write_real_init(workdir)
-    dump_name = "lanczos2_projected_oracle.dat"
+    init_path = (
+        write_complex_init(workdir)
+        if complex_mode else write_real_init(workdir)
+    )
+    dump_name = (
+        "lanczos2_projected_complex_oracle.dat"
+        if complex_mode else "lanczos2_projected_oracle.dat"
+    )
     process = run_vmc(
         rootdir,
         workdir,
         mpi_procs=mpi_procs,
         init_path=init_path,
-        extra_env={"MVMC_LANCZOS_ORACLE_DUMP": dump_name},
+        extra_env={
+            "MVMC_LANCZOS_ORACLE_DUMP": dump_name,
+        },
     )
     if process.returncode != 0:
         raise AssertionError(
             "Lanczos2 projected vmc.out failed:\n{}".format(process.stdout)
         )
+    if guard_audit:
+        expected_kind = "complex" if complex_mode else "real"
+        match = re.search(
+            r"Lanczos2 calHCA guard audit: {} direct=(\d+) "
+            r"zero_component=(\d+)".format(expected_kind),
+            process.stdout,
+        )
+        if match is None:
+            raise AssertionError(
+                "Lanczos2 {} calHCA guard audit marker is missing:\n{}".format(
+                    expected_kind, process.stdout
+                )
+            )
+        if int(match.group(1)) <= 0 or int(match.group(2)) <= 0:
+            raise AssertionError(
+                "Lanczos2 {} calHCA guard audit did not exercise the "
+                "zero-component branch".format(expected_kind)
+            )
 
     if mpi_procs:
         rows = []
@@ -241,10 +360,14 @@ def main():
     else:
         rows = read_ls2_oracle(os.path.join(workdir, dump_name))
 
-    reference, identity_fidelity = build_projected_reference()
+    reference, identity_fidelity, orbital = build_projected_reference(
+        complex_mode
+    )
     seen = {}
+    sampled_states = set()
     for sample, occupation, power in rows:
         state = occupation_state(occupation)
+        sampled_states.add(state)
         if state not in reference:
             raise AssertionError(
                 "sample {} is outside the projected ED basis".format(sample)
@@ -270,16 +393,29 @@ def main():
                 len(seen)
             )
         )
+    zero_component_transitions = count_zero_component_transitions(
+        sampled_states, orbital
+    )
+    if zero_component_transitions <= 0:
+        raise AssertionError(
+            "projected {} ED fixture did not sample a nonzero-overlap "
+            "transition with a zero projection component".format(
+                "complex" if complex_mode else "real"
+            )
+        )
 
     hankel_standard_error = check_solver_output(workdir, rows)
     print(
-        "Lanczos2 projected ED: PASS "
+        "Lanczos2 projected {} ED: PASS "
         "({} samples, {} occupations, NMPTrans={}, k=pi, "
-        "identity fidelity={:.3f}, max Hankel SE={:.3f})".format(
+        "identity fidelity={:.3f}, zero-component transitions={}, "
+        "max Hankel SE={:.3f})".format(
+            "complex" if complex_mode else "real",
             len(rows),
             len(seen),
             len(TRANSLATIONS),
             identity_fidelity,
+            zero_component_transitions,
             hankel_standard_error,
         )
     )

--- a/test/python/runtest_lanczos2_projection_smoke.py
+++ b/test/python/runtest_lanczos2_projection_smoke.py
@@ -1,0 +1,192 @@
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+
+import numpy as np
+
+from runtest_bf_fsz import run_vmc, update_modpara
+from runtest_lanczos2_real_ed import stochastic_hankel_standard_error
+
+
+MODEL = "HubbardTetragonal_MomentumProjection"
+
+
+def modpara_values(path):
+    values = {}
+    with open(path) as source:
+        for line in source:
+            columns = line.split()
+            if len(columns) >= 2:
+                values[columns[0]] = columns[1]
+    return values
+
+
+def read_oracle(path, nsite):
+    rows = []
+    with open(path) as source:
+        for line in source:
+            columns = line.split()
+            marker = 3 + 2 * nsite
+            if (
+                len(columns) != marker + 1 + 8
+                or columns[0] != "sample"
+                or columns[2] != "occ"
+                or columns[marker] != "ls2power"
+            ):
+                raise AssertionError(
+                    "invalid projection oracle row: {}".format(line.rstrip())
+                )
+            occupation = tuple(
+                int(value) for value in columns[3:marker]
+            )
+            values = [float(value) for value in columns[marker + 1:]]
+            power = np.array(
+                [
+                    complex(values[2 * index], values[2 * index + 1])
+                    for index in range(4)
+                ],
+                dtype=complex,
+            )
+            if not np.all(np.isfinite(power)):
+                raise AssertionError("projection oracle has non-finite power")
+            rows.append((occupation, power))
+    if not rows:
+        raise AssertionError("projection oracle dump is empty")
+    return rows
+
+
+def read_moment(path):
+    with open(path) as source:
+        lines = source.readlines()
+    prefix = "# mVMC ls2_moment v2 basis_shift="
+    if len(lines) != 2 or not lines[0].startswith(prefix):
+        raise AssertionError("projection moment output has invalid layout")
+    shift = float(lines[0][len(prefix):].split()[0])
+    values = [float(value) for value in lines[1].split()]
+    if len(values) != 32:
+        raise AssertionError("projection moment output has invalid width")
+    moment = np.array(
+        [
+            complex(values[2 * index], values[2 * index + 1])
+            for index in range(16)
+        ],
+        dtype=complex,
+    ).reshape((4, 4))
+    return shift, moment
+
+
+def shift_local_power(power, shift):
+    return np.array(
+        [
+            power[0],
+            power[1] - shift * power[0],
+            power[2] - 2.0 * shift * power[1]
+            + shift * shift * power[0],
+            power[3] - 3.0 * shift * power[2]
+            + 3.0 * shift * shift * power[1]
+            - shift * shift * shift * power[0],
+        ],
+        dtype=complex,
+    )
+
+
+def main():
+    rootdir = os.getcwd()
+    source_workdir = os.path.join(rootdir, "work", MODEL)
+    if not os.path.isdir(source_workdir):
+        raise AssertionError(
+            "{} setup fixture did not create its work directory".format(MODEL)
+        )
+
+    workdir = os.path.join(rootdir, "work", "Lanczos2_Projection_Smoke")
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    shutil.copytree(source_workdir, workdir)
+    output_dir = os.path.join(workdir, "output")
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NDataQtySmp": "1",
+            "NVMCSample": "128",
+            "NVMCWarmUp": "32",
+            "NVMCInterval": "2",
+            "NSplitSize": "1",
+        },
+    )
+    parameters = modpara_values(os.path.join(workdir, "modpara.def"))
+    nsite = int(parameters["Nsite"])
+    if int(parameters["NMPTrans"]) <= 1:
+        raise AssertionError("projection smoke does not use momentum projection")
+    if int(parameters["NSPGaussLeg"]) <= 1:
+        raise AssertionError("projection smoke does not use spin projection")
+
+    initial_path = os.path.join(rootdir, "data", MODEL, "initial.def")
+    dump_name = "lanczos2_projection_oracle.dat"
+    process = run_vmc(
+        rootdir,
+        workdir,
+        init_path=initial_path,
+        extra_env={"MVMC_LANCZOS_ORACLE_DUMP": dump_name},
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "Lanczos2 projection vmc.out failed:\n{}".format(process.stdout)
+        )
+
+    rows = read_oracle(os.path.join(workdir, dump_name), nsite)
+    occupation_count = len(set(occupation for occupation, _ in rows))
+    if occupation_count < 8:
+        raise AssertionError("projection smoke sampled too few occupations")
+    basis_shift, observed_moment = read_moment(
+        os.path.join(output_dir, "zvo_ls2_moment_001.dat")
+    )
+    expected_moment = sum(
+        np.outer(
+            np.conj(shift_local_power(power, basis_shift)),
+            shift_local_power(power, basis_shift),
+        )
+        for _, power in rows
+    ) / float(len(rows))
+    if not np.allclose(
+        observed_moment, expected_moment, rtol=3.0e-12, atol=3.0e-12
+    ):
+        raise AssertionError(
+            "projection shifted moment does not match sample-local powers"
+        )
+    if not np.allclose(
+        observed_moment, np.conj(observed_moment.T),
+        rtol=3.0e-12, atol=3.0e-12,
+    ):
+        raise AssertionError("projection shifted moment is not Hermitian")
+    hankel_standard_error = stochastic_hankel_standard_error(
+        [power for _, power in rows], basis_shift
+    )
+
+    print(
+        "Lanczos2 projection smoke: PASS "
+        "({} samples, {} occupations, NMPTrans={}, NSPGaussLeg={}, "
+        "max Hankel SE={:.3f})".format(
+            len(rows),
+            occupation_count,
+            parameters["NMPTrans"],
+            parameters["NSPGaussLeg"],
+            hankel_standard_error,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as error:
+        print("ERROR: {}".format(error))
+        sys.exit(1)

--- a/test/python/runtest_lanczos2_real_ed.py
+++ b/test/python/runtest_lanczos2_real_ed.py
@@ -33,8 +33,9 @@ GUTZWILLER_PARAMETER = -0.43
 HANKEL_RESIDUAL_LIMIT = 0.5
 # The stochastic Hankel identities are checked with contiguous-block standard
 # errors, so the gate scales with the observed Monte Carlo uncertainty instead
-# of relying only on the absolute residual above.  Eight standard errors is a
-# conservative CI-stable outlier threshold across the ten matrix comparisons.
+# of relying only on the absolute residual above.  Consecutive blocks can
+# remain correlated, so this is an empirical outlier score, not a calibrated
+# number of sigma.  The limit of eight is deliberately CI-stable.
 HANKEL_STANDARD_ERROR_LIMIT = 8.0
 
 

--- a/test/python/runtest_lanczos2_real_ed.py
+++ b/test/python/runtest_lanczos2_real_ed.py
@@ -1,0 +1,654 @@
+from __future__ import print_function
+
+import os
+import shutil
+import sys
+
+import numpy as np
+
+from runtest_bf_fsz import (
+    run_vmc,
+    update_modpara,
+)
+from runtest_lanczos_sector_ed import (
+    COULOMB_INTRA,
+    NSITE,
+    ap_orbital_amplitude,
+    coulomb_intra,
+    doublon_count,
+    fixed_basis,
+    one_body,
+    operator_matrix,
+    write_coulomb_intra,
+)
+
+RING_HOPS = (
+    (1, 0), (0, 1), (2, 1), (1, 2),
+    (3, 2), (2, 3), (0, 3), (3, 0),
+)
+DIAGONAL_TRANSFER = (0, 0, 0, 0.17)
+GUTZWILLER_PARAMETER = -0.43
+# This is a statistical sanity gate rather than a precision target.  Keep it
+# below unity; revise it only with Linux/CI evidence, not a single local run.
+HANKEL_RESIDUAL_LIMIT = 0.5
+# The stochastic Hankel identities are checked with contiguous-block standard
+# errors, so the gate scales with the observed Monte Carlo uncertainty instead
+# of relying only on the absolute residual above.  Eight standard errors is a
+# conservative CI-stable outlier threshold across the ten matrix comparisons.
+HANKEL_STANDARD_ERROR_LIMIT = 8.0
+
+
+def real_orbitals():
+    orbital = np.array(
+        [
+            [
+                np.sin(0.37 * (row + 1) * (column + 2))
+                + 0.3 * np.cos(0.19 * (row + 2) * (column + 1))
+                for column in range(NSITE)
+            ]
+            for row in range(NSITE)
+        ],
+        dtype=float,
+    )
+    orbital[1, 1] = orbital[1, 0] * orbital[0, 1] / orbital[0, 0]
+    return orbital
+
+
+def write_real_init(workdir):
+    values = [0.0] * 6
+    values.extend([GUTZWILLER_PARAMETER, 0.0, 0.0])
+    for value in real_orbitals().reshape(NSITE * NSITE):
+        values.extend([value, 0.0, 0.0])
+    filename = "lanczos2_real_init.dat"
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write(
+            " ".join("{:.18e}".format(value) for value in values)
+        )
+        destination.write("\n")
+    return filename
+
+
+def write_transfer_with_diagonal(workdir):
+    rows = []
+    for left, right in RING_HOPS:
+        for spin in (0, 1):
+            rows.append((left, spin, right, spin, 1.0, 0.0))
+    site, spin, _, coupling = DIAGONAL_TRANSFER
+    rows.append((site, spin, site, spin, coupling, 0.0))
+    with open(os.path.join(workdir, "trans.def"), "w") as destination:
+        destination.write("========================\n")
+        destination.write("NTransfer      {}\n".format(len(rows)))
+        destination.write("========================\n")
+        destination.write("========i_j_s_tijs======\n")
+        destination.write("========================\n")
+        for row in rows:
+            destination.write(
+                "{:5d} {:5d} {:5d} {:5d} {:25.15f} {:25.15f}\n".format(
+                    *row
+                )
+            )
+
+
+def write_gutzwiller(workdir):
+    with open(os.path.join(workdir, "gutzwilleridx.def"), "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("NGutzwillerIdx          1\n")
+        destination.write("ComplexType             0\n")
+        destination.write("=============================================\n")
+        destination.write("=============================================\n")
+        for site in range(NSITE):
+            destination.write("{:5d} {:5d}\n".format(site, 0))
+        destination.write("{:5d} {:5d}\n".format(0, 0))
+
+
+def read_ls2_oracle(path):
+    rows = []
+    with open(path) as source:
+        for line in source:
+            columns = line.split()
+            if len(columns) != 4 + 2 * NSITE + 8:
+                raise AssertionError(
+                    "invalid Lanczos2 oracle width: {}".format(line.rstrip())
+                )
+            if (
+                columns[0] != "sample"
+                or columns[2] != "occ"
+                or columns[3 + 2 * NSITE] != "ls2power"
+            ):
+                raise AssertionError("invalid Lanczos2 oracle markers")
+            occupation = tuple(
+                int(value) for value in columns[3 : 3 + 2 * NSITE]
+            )
+            values = [
+                float(value) for value in columns[4 + 2 * NSITE :]
+            ]
+            power = np.array(
+                [
+                    complex(values[2 * index], values[2 * index + 1])
+                    for index in range(4)
+                ],
+                dtype=complex,
+            )
+            rows.append((int(columns[1]), occupation, power))
+    if not rows:
+        raise AssertionError("Lanczos2 oracle dump is empty")
+    return rows
+
+
+def write_lanczos2_namelist(workdir):
+    entries = [
+        ("ModPara", "modpara.def"),
+        ("LocSpin", "locspn.def"),
+        ("Trans", "trans.def"),
+        ("CoulombIntra", "coulombintra.def"),
+        ("Gutzwiller", "gutzwilleridx.def"),
+        ("Orbital", "orbitalidx.def"),
+        ("TransSym", "qptransidx.def"),
+    ]
+    with open(os.path.join(workdir, "namelist.def"), "w") as destination:
+        for keyword, filename in entries:
+            destination.write("{:>16}  {}\n".format(keyword, filename))
+
+
+def occupation_state(occupation):
+    state = 0
+    for orbital, value in enumerate(occupation):
+        if value:
+            state |= 1 << orbital
+    return state
+
+
+def one_hop_states(state):
+    for left, right in RING_HOPS:
+        for spin in (0, 1):
+            left_orbital = left + spin * NSITE
+            right_orbital = right + spin * NSITE
+            if ((state >> right_orbital) & 1) and not (
+                (state >> left_orbital) & 1
+            ):
+                yield state ^ (1 << left_orbital) ^ (1 << right_orbital)
+
+
+def read_numeric_record(path):
+    numeric = []
+    with open(path) as source:
+        lines = source.readlines()
+    if len(lines) != 2 or not lines[0].startswith("# mVMC "):
+        raise AssertionError("{} does not have the v1 two-line layout".format(path))
+    if not lines[1].endswith("\n"):
+        raise AssertionError("{} data record lacks final newline".format(path))
+    numeric.extend(float(value) for value in lines[1].split())
+    return numeric
+
+
+def read_shifted_moment(path):
+    with open(path) as source:
+        lines = source.readlines()
+    prefix = "# mVMC ls2_moment v2 basis_shift="
+    if len(lines) != 2 or not lines[0].startswith(prefix):
+        raise AssertionError(
+            "{} does not have the v2 shifted-moment layout".format(path)
+        )
+    shift = float(lines[0][len(prefix):].split()[0])
+    values = [float(value) for value in lines[1].split()]
+    if len(values) != 32:
+        raise AssertionError(
+            "ls2_moment column count is {}".format(len(values))
+        )
+    moment = np.array(
+        [
+            complex(values[2 * index], values[2 * index + 1])
+            for index in range(16)
+        ],
+        dtype=complex,
+    ).reshape((4, 4))
+    return shift, moment
+
+
+def shift_local_power(power, shift):
+    return np.array(
+        [
+            power[0],
+            power[1] - shift * power[0],
+            power[2] - 2.0 * shift * power[1]
+            + shift * shift * power[0],
+            power[3] - 3.0 * shift * power[2]
+            + 3.0 * shift * shift * power[1]
+            - shift * shift * shift * power[0],
+        ],
+        dtype=complex,
+    )
+
+
+def stochastic_hankel_standard_error(powers, shift):
+    shifted = np.array(
+        [shift_local_power(power, shift) for power in powers],
+        dtype=complex,
+    )
+    if len(shifted) < 32:
+        raise AssertionError(
+            "stochastic Hankel diagnostic needs at least 32 samples"
+        )
+
+    block_count = min(16, len(shifted) // 8)
+    maximum_score = 0.0
+    comparison_count = 0
+    epsilon = np.finfo(float).eps
+    for order in range(1, 6):
+        pairs = [
+            (left, order - left)
+            for left in range(4)
+            if 0 <= order - left < 4
+        ]
+        reference_pair = pairs[0]
+        reference = (
+            np.conj(shifted[:, reference_pair[0]])
+            * shifted[:, reference_pair[1]]
+        )
+        for pair in pairs[1:]:
+            estimate = np.conj(shifted[:, pair[0]]) * shifted[:, pair[1]]
+            difference = estimate - reference
+            sample_scale = max(
+                np.max(np.abs(estimate)),
+                np.max(np.abs(reference)),
+                1.0,
+            )
+            if np.max(np.abs(difference)) <= 128.0 * epsilon * sample_scale:
+                continue
+
+            block_means = np.array(
+                [
+                    np.mean(block)
+                    for block in np.array_split(difference, block_count)
+                ],
+                dtype=complex,
+            )
+            standard_error = np.sqrt(
+                np.sum(
+                    np.abs(block_means - np.mean(block_means)) ** 2
+                )
+                / float(block_count * (block_count - 1))
+            )
+            roundoff_floor = 128.0 * epsilon * max(
+                np.mean(np.abs(estimate)),
+                np.mean(np.abs(reference)),
+                1.0,
+            )
+            score = abs(np.mean(difference)) / max(
+                standard_error, roundoff_floor
+            )
+            if not np.isfinite(score):
+                raise AssertionError(
+                    "stochastic Hankel standard-error score is not finite"
+                )
+            maximum_score = max(maximum_score, score)
+            comparison_count += 1
+
+    if comparison_count == 0:
+        raise AssertionError(
+            "stochastic Hankel diagnostic found no nontrivial comparison"
+        )
+    if maximum_score >= HANKEL_STANDARD_ERROR_LIMIT:
+        raise AssertionError(
+            "stochastic Hankel identity exceeds its block standard error: "
+            "max score={} (limit={})".format(
+                maximum_score, HANKEL_STANDARD_ERROR_LIMIT
+            )
+        )
+    return maximum_score
+
+
+def build_reference():
+    basis = fixed_basis(2, 2)
+    orbital = real_orbitals()
+    unprojected_psi = np.array(
+        [ap_orbital_amplitude(state, orbital) for state in basis],
+        dtype=float,
+    )
+    psi = np.array(
+        [
+            amplitude * np.exp(
+                GUTZWILLER_PARAMETER * doublon_count(state)
+            )
+            for state, amplitude in zip(basis, unprojected_psi)
+        ],
+        dtype=float,
+    )
+    terms = []
+    for left, right in RING_HOPS:
+        for spin in (0, 1):
+            terms.append((-1.0, one_body(left, right, spin)))
+    site, spin, _, coupling = DIAGONAL_TRANSFER
+    terms.append((-coupling, one_body(site, site, spin)))
+    terms.extend(
+        (coupling, coulomb_intra(site))
+        for site, coupling in enumerate(COULOMB_INTRA)
+    )
+    hamiltonian = operator_matrix(basis, terms)
+    powers = [psi]
+    for _ in range(3):
+        powers.append(np.dot(hamiltonian, powers[-1]))
+    unprojected_powers = [unprojected_psi]
+    for _ in range(3):
+        unprojected_powers.append(
+            np.dot(hamiltonian, unprojected_powers[-1])
+        )
+    projection_sensitivity = 0.0
+    for index in range(len(basis)):
+        if abs(psi[index]) <= 1.0e-13 or \
+                abs(unprojected_psi[index]) <= 1.0e-13:
+            continue
+        projection_sensitivity = max(
+            projection_sensitivity,
+            abs(
+                powers[3][index] / psi[index]
+                - unprojected_powers[3][index] / unprojected_psi[index]
+            ),
+        )
+    if projection_sensitivity <= 1.0e-6:
+        raise AssertionError(
+            "real ED fixture does not exercise ProjRatio in F3"
+        )
+    validate_full_enumeration(powers)
+    reference = {}
+    zero_overlap_states = set()
+    for index, state in enumerate(basis):
+        if abs(psi[index]) <= 1.0e-13:
+            zero_overlap_states.add(state)
+            continue
+        reference[state] = np.array(
+            [powers[order][index] / psi[index] for order in range(4)],
+            dtype=complex,
+        )
+    return reference, zero_overlap_states
+
+
+def validate_full_enumeration(powers):
+    normalization = np.vdot(powers[0], powers[0])
+    moment = np.array(
+        [
+            [
+                np.vdot(powers[left], powers[right]) / normalization
+                for right in range(4)
+            ]
+            for left in range(4)
+        ],
+        dtype=complex,
+    )
+    scale = max(np.max(np.abs(moment)), 1.0)
+    for left in range(4):
+        for right in range(4):
+            for other_left in range(4):
+                other_right = left + right - other_left
+                if 0 <= other_right < 4:
+                    if (
+                        abs(
+                            moment[left, right]
+                            - moment[other_left, other_right]
+                        )
+                        > 2.0e-12 * scale
+                    ):
+                        raise AssertionError(
+                            "full-enumeration Hankel identity failed"
+                        )
+
+    energies = []
+    for dimension in (1, 2, 3):
+        overlap = moment[:dimension, :dimension]
+        reduced_hamiltonian = moment[:dimension, 1 : dimension + 1]
+        eigenvalues = np.linalg.eigvals(
+            np.linalg.solve(overlap, reduced_hamiltonian)
+        )
+        if np.max(np.abs(np.imag(eigenvalues))) > 2.0e-11:
+            raise AssertionError(
+                "full-enumeration Krylov eigenvalue is not real"
+            )
+        energies.append(np.min(np.real(eigenvalues)))
+    tolerance = 2.0e-11 * max(max(abs(value) for value in energies), 1.0)
+    if energies[2] > energies[1] + tolerance:
+        raise AssertionError("E2 is above E1 in full enumeration")
+    if energies[1] > energies[0] + tolerance:
+        raise AssertionError("E1 is above Evar in full enumeration")
+
+
+def assert_scaled_close(label, actual, expected, absolute=2.0e-10,
+                        relative=2.0e-9):
+    difference = abs(actual - expected)
+    allowed = absolute + relative * max(abs(actual), abs(expected))
+    if difference > allowed:
+        raise AssertionError(
+            "{} mismatch: actual={} expected={} difference={} allowed={}".format(
+                label, actual, expected, difference, allowed
+            )
+        )
+
+
+def check_solver_output(workdir, rows):
+    output_path = os.path.join(workdir, "output", "zvo_ls2_out_001.dat")
+    moment_path = os.path.join(workdir, "output", "zvo_ls2_moment_001.dat")
+    output = read_numeric_record(output_path)
+    basis_shift, observed_moment = read_shifted_moment(moment_path)
+    if len(output) != 17:
+        raise AssertionError("ls2_out column count is {}".format(len(output)))
+    if abs(output[15]) > 1.0e-12:
+        raise AssertionError(
+            "antihermitian_residual is unexpectedly large: {}".format(
+                output[15]
+            )
+        )
+    if not np.isfinite(output[16]) or \
+            output[16] >= HANKEL_RESIDUAL_LIMIT:
+        raise AssertionError(
+            "hankel_residual is not a finite sub-unity diagnostic: "
+            "{} (limit={})".format(
+                output[16], HANKEL_RESIDUAL_LIMIT
+            )
+        )
+    if os.path.exists(os.path.join(workdir, "output", "zvo_ls_out_001.dat")):
+        raise AssertionError("NLanczosStep=2 wrote a legacy ls_out file")
+    if os.path.exists(os.path.join(workdir, "output", "zvo_ls_qqqq_001.dat")):
+        raise AssertionError("NLanczosStep=2 wrote a legacy ls_qqqq file")
+
+    expected_raw_moment = np.zeros((4, 4), dtype=complex)
+    expected_shifted_moment = np.zeros((4, 4), dtype=complex)
+    for _, _, power in rows:
+        shifted_power = shift_local_power(power, basis_shift)
+        expected_raw_moment += np.outer(np.conj(power), power)
+        expected_shifted_moment += np.outer(
+            np.conj(shifted_power), shifted_power
+        )
+    expected_raw_moment /= float(len(rows))
+    expected_shifted_moment /= float(len(rows))
+    if not np.allclose(
+        observed_moment, expected_shifted_moment,
+        rtol=2.0e-12, atol=2.0e-12
+    ):
+        difference = np.max(
+            np.abs(observed_moment - expected_shifted_moment)
+        )
+        raise AssertionError(
+            "shifted moment does not match centered sample-local powers: "
+            "max diff={}".format(difference)
+        )
+    hankel_standard_error = stochastic_hankel_standard_error(
+        [power for _, _, power in rows], basis_shift
+    )
+
+    overlap = expected_raw_moment[:3, :3]
+    reduced_hamiltonian = 0.5 * (
+        expected_raw_moment[:3, 1:4] + expected_raw_moment[1:4, :3]
+    )
+    hamiltonian_squared = expected_raw_moment[1:4, 1:4]
+    coefficient = np.array(
+        [
+            complex(output[2], output[3]),
+            complex(output[4], output[5]),
+            complex(output[6], output[7]),
+        ],
+        dtype=complex,
+    )
+    norm = np.vdot(coefficient, np.dot(overlap, coefficient)).real
+    energy = np.vdot(
+        coefficient, np.dot(reduced_hamiltonian, coefficient)
+    ).real
+    h2 = np.vdot(
+        coefficient, np.dot(hamiltonian_squared, coefficient)
+    ).real
+    variance_ratio = (h2 - energy * energy) / (energy * energy)
+    assert_scaled_close("coefficient norm", norm, 1.0, 2.0e-11, 2.0e-11)
+    assert_scaled_close("reported energy", output[0], energy, 2.0e-11, 2.0e-11)
+    assert_scaled_close(
+        "reported variance/E2", output[1], variance_ratio, 2.0e-11, 2.0e-11
+    )
+    residual = np.linalg.norm(
+        np.dot(reduced_hamiltonian, coefficient)
+        - output[0] * np.dot(overlap, coefficient)
+    )
+    scale = max(
+        np.linalg.norm(np.dot(reduced_hamiltonian, coefficient)), 1.0
+    )
+    if residual / scale > 2.0e-10:
+        raise AssertionError(
+            "reported coefficient GEV residual={}".format(residual / scale)
+        )
+
+    timer_path = os.path.join(
+        workdir, "output", "zvo_CalcTimer.dat"
+    )
+    with open(timer_path) as source:
+        timer_rows = [line for line in source if "[95]" in line]
+    if len(timer_rows) != 1:
+        raise AssertionError("Lanczos2 timer [95] is missing or duplicated")
+    if float(timer_rows[0].split()[-1]) <= 0.0:
+        raise AssertionError("Lanczos2 timer [95] is not positive")
+    return hankel_standard_error
+
+
+def main():
+    rootdir = os.getcwd()
+    expected_error = sys.argv[1] if len(sys.argv) == 2 else None
+    if len(sys.argv) > 2:
+        raise AssertionError("usage: runtest_lanczos2_real_ed.py [expected-error]")
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    split_size = os.environ.get("MVMC_NSPLIT_SIZE", "1")
+    reference_dir = os.path.join(rootdir, "data", "BackFlow_Identity_Real")
+    suffix = "_split{}".format(split_size) if split_size != "1" else ""
+    if mpi_procs:
+        suffix += "_mpi"
+    workdir = os.path.join(rootdir, "work", "Lanczos2_Real_ED" + suffix)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    for filename in os.listdir(reference_dir):
+        source = os.path.join(reference_dir, filename)
+        if os.path.isfile(source):
+            shutil.copy2(source, os.path.join(workdir, filename))
+
+    write_coulomb_intra(workdir)
+    write_lanczos2_namelist(workdir)
+    write_transfer_with_diagonal(workdir)
+    write_gutzwiller(workdir)
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NVMCSample": "256",
+            "NVMCWarmUp": "32",
+            "2Sz": "0",
+            "NMPTrans": "1",
+            "NSplitSize": split_size,
+        },
+    )
+    init_path = write_real_init(workdir)
+    dump_name = "lanczos2_real_oracle.dat"
+    proc = run_vmc(
+        rootdir,
+        workdir,
+        mpi_procs=mpi_procs,
+        init_path=init_path,
+        extra_env={"MVMC_LANCZOS_ORACLE_DUMP": dump_name},
+    )
+    if expected_error is not None:
+        if proc.returncode == 0:
+            raise AssertionError(
+                "Lanczos2 fault injection unexpectedly succeeded"
+            )
+        if expected_error not in proc.stdout:
+            raise AssertionError(
+                "expected error {!r} was not found:\n{}".format(
+                    expected_error, proc.stdout
+                )
+            )
+        print("Lanczos2 non-finite fault injection: PASS")
+        return 0
+    if proc.returncode != 0:
+        raise AssertionError("Lanczos2 real vmc.out failed:\n{}".format(proc.stdout))
+
+    if mpi_procs:
+        rows = []
+        for rank in range(int(mpi_procs)):
+            rows.extend(
+                read_ls2_oracle(
+                    os.path.join(
+                        workdir, dump_name + ".rank{:04d}".format(rank)
+                    )
+                )
+            )
+    else:
+        rows = read_ls2_oracle(os.path.join(workdir, dump_name))
+    reference, zero_overlap_states = build_reference()
+    if not zero_overlap_states:
+        raise AssertionError("real ED fixture has no zero-overlap state")
+    seen = {}
+    exercised_zero_overlap = False
+    for sample, occupation, power in rows:
+        state = occupation_state(occupation)
+        if state not in reference:
+            raise AssertionError(
+                "sample {} has zero or missing ED amplitude".format(sample)
+            )
+        for order in range(4):
+            assert_scaled_close(
+                "sample {} F{}".format(sample, order),
+                power[order],
+                reference[state][order],
+            )
+        if occupation in seen:
+            if not np.allclose(power, seen[occupation], rtol=2.0e-12,
+                               atol=2.0e-12):
+                raise AssertionError(
+                    "local power changed for repeated occupation"
+                )
+        else:
+            seen[occupation] = power
+        if any(
+            neighbor in zero_overlap_states
+            for neighbor in one_hop_states(state)
+        ):
+            exercised_zero_overlap = True
+    if len(seen) < 8:
+        raise AssertionError(
+            "Lanczos2 ED fixture sampled only {} occupations".format(len(seen))
+        )
+    if not exercised_zero_overlap:
+        raise AssertionError(
+            "real ED fixture did not exercise a zero-overlap intermediate"
+        )
+    hankel_standard_error = check_solver_output(workdir, rows)
+    print(
+        "Lanczos2 real ED: PASS "
+        "({} samples, {} occupations, max Hankel SE={:.3f})".format(
+            len(rows), len(seen), hankel_standard_error
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as error:
+        print("ERROR: {}".format(error))
+        sys.exit(1)

--- a/test/python/runtest_lanczos2_step1_compat.py
+++ b/test/python/runtest_lanczos2_step1_compat.py
@@ -1,0 +1,139 @@
+from __future__ import print_function
+
+import filecmp
+import os
+import shutil
+import subprocess
+import sys
+
+
+def prepare_definitions(source, destination, dry_binary):
+    os.makedirs(destination)
+    for filename in os.listdir(source):
+        source_path = os.path.join(source, filename)
+        if os.path.isfile(source_path) and (
+            filename.endswith(".def") or filename.endswith(".dat")
+        ):
+            shutil.copy(
+                source_path,
+                os.path.join(destination, filename),
+            )
+    modpara = os.path.join(destination, "modpara.def")
+    if not os.path.exists(modpara):
+        standard_input = os.path.join(destination, "StdFace.def")
+        proc = subprocess.run(
+            [dry_binary, standard_input],
+            cwd=destination,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        if proc.returncode != 0:
+            print(proc.stdout)
+            raise RuntimeError("failed to generate expert definition files")
+
+
+def set_lanczos_step(filename, explicit):
+    with open(filename) as source:
+        lines = source.readlines()
+    lines = [line for line in lines if not line.split()[:1] == ["NLanczosStep"]]
+    if explicit:
+        lines.append("NLanczosStep   1\n")
+    with open(filename, "w") as destination:
+        destination.writelines(lines)
+
+
+def comparable_outputs(workdir):
+    output_dir = os.path.join(workdir, "output")
+    result = {}
+    for filename in os.listdir(output_dir):
+        if "time" in filename.lower() or "calctimer" in filename.lower():
+            continue
+        path = os.path.join(output_dir, filename)
+        if os.path.isfile(path):
+            result[filename] = path
+    return result
+
+
+def run_case(binary, workdir):
+    proc = subprocess.run(
+        [binary, "-e", "namelist.def"],
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    with open(os.path.join(workdir, "run.log"), "w") as destination:
+        destination.write(proc.stdout)
+    if proc.returncode != 0:
+        print(proc.stdout)
+    return proc.returncode
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: {} <model name>".format(sys.argv[0]))
+        return 2
+
+    model = sys.argv[1]
+    rootdir = os.getcwd()
+    source = os.path.join(rootdir, "data", model)
+    workroot = os.path.join(rootdir, "work")
+    omitted = os.path.join(workroot, model + "_lanczos_step_omitted")
+    explicit = os.path.join(workroot, model + "_lanczos_step_explicit_1")
+    binary = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
+    dry_binary = os.path.join(
+        rootdir, "..", "..", "src", "mVMC", "vmcdry.out"
+    )
+    for workdir in (omitted, explicit):
+        if os.path.exists(workdir):
+            shutil.rmtree(workdir)
+        try:
+            prepare_definitions(source, workdir, dry_binary)
+        except RuntimeError as error:
+            print("ERROR: {}".format(error))
+            return 1
+
+    set_lanczos_step(os.path.join(omitted, "modpara.def"), False)
+    set_lanczos_step(os.path.join(explicit, "modpara.def"), True)
+
+    if run_case(binary, omitted) != 0 or run_case(binary, explicit) != 0:
+        return 1
+
+    omitted_outputs = comparable_outputs(omitted)
+    explicit_outputs = comparable_outputs(explicit)
+    if not omitted_outputs:
+        print("ERROR: compatibility fixture produced no comparable output")
+        return 1
+    required_lanczos_outputs = ("_ls_out_", "_ls_qqqq_")
+    for marker in required_lanczos_outputs:
+        if not any(marker in filename for filename in omitted_outputs):
+            print(
+                "ERROR: compatibility fixture did not produce a {} file".format(
+                    marker.strip("_")
+                )
+            )
+            return 1
+    if set(omitted_outputs) != set(explicit_outputs):
+        print("ERROR: output file sets differ")
+        print("omitted:", sorted(omitted_outputs))
+        print("explicit:", sorted(explicit_outputs))
+        return 1
+
+    for filename in sorted(omitted_outputs):
+        if not filecmp.cmp(
+            omitted_outputs[filename], explicit_outputs[filename], shallow=False
+        ):
+            print("ERROR: output differs for {}".format(filename))
+            return 1
+
+    print(
+        "Lanczos2 step-1 compatibility: PASS ({} byte-identical files)".format(
+            len(omitted_outputs)
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add `NLanczosStep=2` for the second power-Lanczos state `(c0 + c1 H + c2 H^2)|psi>` while preserving valid legacy `NLanczosStep=1` results and output; negative-discriminant first-step solves now fail fast instead of continuing with invalid coefficients
- sample the local powers through `H^3`, accumulate centered moments, and solve the real or complex three-dimensional generalized eigenproblem
- add fail-fast capability checks, checked sample storage, numerical diagnostics, and versioned `ls2_out` / `ls2_moment` outputs
- support the existing non-FSZ spin and momentum projections, including a direct-contraction guard for multi-component projections
- add independent ED oracles, MPI/OpenMP variants, negative contract tests, failure injection, and English/Japanese documentation

## Motivation

mVMC's existing power-Lanczos implementation optimizes only the two-dimensional state `(c0 + c1 H)|psi>`. This change adds the next Krylov basis vector so that measurement runs can optimize `(c0 + c1 H + c2 H^2)|psi>` without changing established valid first-step results or output formats. Invalid negative-discriminant first-step solves now abort instead of continuing with undefined coefficients.

## Supported scope

The second step currently requires:

- `NVMCCalMode=1`
- `NLanczosMode=1`
- `NLanczosStep=2`
- `NExUpdatePath=0`
- real or complex non-FSZ pair orbitals
- spin-conserving `Transfer` terms and diagonal `CoulombIntra`, `CoulombInter`, and `Hund` interactions

Unsupported combinations fail before sampling. These include `OrbitalGeneral` / FSZ, BackFlow, RBM, spin-flip transfer terms, `PairHop`, `Exchange`, `InterAll`, `NBodyInterAll`, and `NBodyG`. Second-step Green's functions are outside this scope.

For `NQPFull=1`, the dominant `H^3` operator count grows as `O(NTransfer^3)`: the outer and inner `Transfer` loops call a Hamiltonian evaluation whose transfer work contributes the third factor. A nontrivial projection uses a correctness-first direct contraction with the same worst-case `O(NTransfer^3)` operator-count scaling and a larger coefficient because its `GreenFuncN` work is also proportional to `NQPFull`.

## Numerical and safety design

- retain four local powers per accepted sample and center them using the globally weighted energy before forming moments, avoiding cancellation in raw high-order moments
- form Hermitian overlap, Hamiltonian, and squared-Hamiltonian matrices and report anti-Hermitian and Hankel residual diagnostics
- equilibrate and solve the generalized eigenproblem with real or complex LAPACK, with one relative `1e-12` overlap-regularization retry
- transform the coefficients back to the unshifted polynomial basis and report energy, variance, coefficients, and alpha ratios
- validate unsupported input consistently across MPI ranks and abort collectively on invalid or non-finite states
- bypass the rank-one update for second-step multi-component projections when an individual projected Pfaffian can vanish despite a finite total overlap

## Output and documentation

- add versioned `*_ls2_out_*.dat` result files
- add centered `*_ls2_moment_*.dat` diagnostic files with the accumulation shift
- document the algorithm, input contract, output schema, validation coverage, and projection-dependent cost in both English and Japanese

## Validation

- focused local Lanczos2 suite: 36/36 passed
- fresh full local CTest suite with `OMP_NUM_THREADS=1`: 394/394 passed
- genkai GCC 13 + OpenBLAS ASan/UBSan focused suite: 33/33 passed
- genkai Intel classic + MKL focused suite: 33/33 passed
- genkai OpenMP (`OMP_NUM_THREADS=1/4`) and MPI (`1/2/4` ranks, including `NSplitSize=4`) validation passed
- independent real, complex, Gutzwiller, and nontrivial momentum-projected ED oracles passed
- 2014 archived second-Lanczos moments: 5/5 bins passed format, finite-value, Gram, Hankel, and current-solver sanity checks
- English and Japanese Sphinx HTML builds passed, with only the pre-existing `_static` warning
- branch-wide diff, local-information, debug-marker, conflict-marker, and fault-injection isolation scans passed
- final-head [push CI](https://github.com/issp-center-dev/mVMC/actions/runs/30272239422) and [pull-request CI](https://github.com/issp-center-dev/mVMC/actions/runs/30272240519) passed (4/4 each, 8/8 total)

## Review status

- [x] local focused and full regression gates passed
- [x] Linux sanitizer, MPI/OpenMP, projected-oracle, and archive gates passed
- [x] final independent review has no unresolved findings or blockers
- [x] push CI passes at `50b01ea`
- [x] pull-request CI passes at `50b01ea`
