### PR TITLE
Support the second power-Lanczos step for pure-spin models

### DIFF
--- a/doc/en/source/algorithm.rst
+++ b/doc/en/source/algorithm.rst
@@ -657,12 +657,15 @@ which
 :math:`F_3(x)=\langle x|\hat H^3|\psi\rangle/\langle x|\psi\rangle`
 dominates.
 
-In the current second-step implementation, the Hamiltonian is limited to
-spin-conserving ``Transfer`` terms and number-operator-type diagonal
-interactions. The
-evaluation of :math:`F_3` runs nested outer and inner loops over the
-off-diagonal ``Transfer`` terms. Since the product of two ``Transfer``
-terms combines into the two-body operator
+The current second-step implementation has two Hamiltonian classes.
+The electronic class contains spin-conserving ``Transfer`` terms and
+number-operator-type diagonal interactions. The pure spin-1/2 class
+contains diagonal interactions and ``Exchange`` terms, preserves one
+electron per site, and is currently limited to ``NQPFull=1``.
+
+For the electronic class, the evaluation of :math:`F_3` runs nested
+outer and inner loops over the off-diagonal ``Transfer`` terms. Since
+the product of two ``Transfer`` terms combines into the two-body operator
 
 .. math::
 
@@ -703,6 +706,26 @@ function, so the dominant operator count of this path grows as
 proportional to ``NQPFull``. Wall-clock cost therefore depends strongly
 on the projection as well as the wave function and execution
 environment.
+
+For the pure-spin class, write each exchange bond as the sum of two
+oriented operators :math:`X_a`. Direct contraction gives
+
+.. math::
+
+   \begin{aligned}
+   F_3(x)={}&V_0^3
+   +\sum_a j_a(V_0^2+V_0V_a+V_a^2)G_a\\
+   &+\sum_{a,b}j_bj_a(V_0+V_a+V_{ba})G_{ba}
+   +\sum_{a,b,c}j_cj_bj_aG_{cba},
+   \end{aligned}
+
+where :math:`V_a` and :math:`V_{ba}` are the diagonal energies after
+the indicated exchanges, and :math:`G_a`, :math:`G_{ba}`, and
+:math:`G_{cba}` are evaluated from the original sampled configuration
+with ``GreenFuncN`` orders 2, 4, and 6. This avoids division by an
+intermediate wave-function amplitude and remains valid when that
+amplitude is zero. For :math:`A` active oriented exchanges, the
+depth-three call count is bounded by :math:`A^3`.
 
 Calculation of physical quantities after the first power-Lanczos step
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/en/source/expert.rst
+++ b/doc/en/source/expert.rst
@@ -540,16 +540,28 @@ Keywords and parameters
    :math:`(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle` in the
    three-dimensional Krylov subspace.
 
-   The initial second-step implementation requires
-   ``NVMCCalMode=1``, ``NLanczosMode=1``, and ``NExUpdatePath=0``.
-   It supports real or complex non-FSZ pair orbitals, including the
-   existing spin and momentum projections. Its Hamiltonian is limited
-   to spin-conserving ``Transfer`` terms
-   (:math:`\sigma_1=\sigma_2`) and diagonal number-operator interactions
-   (``CoulombIntra``, ``CoulombInter``, and ``Hund``).
-   ``OrbitalGeneral`` / FSZ, BackFlow, RBM, ``PairHop``, ``Exchange``,
-   ``InterAll``, ``NBodyInterAll``, and ``NBodyG`` are rejected before
-   sampling. Second-step Green's functions are not calculated.
+   The second step requires ``NVMCCalMode=1`` and ``NLanczosMode=1``.
+   It supports two model classes with real or complex non-FSZ pair
+   orbitals:
+
+   * The electronic class uses ``NExUpdatePath=0`` and supports
+     spin-conserving ``Transfer`` terms
+     (:math:`\sigma_1=\sigma_2`) and diagonal number-operator
+     interactions (``CoulombIntra``, ``CoulombInter``, and ``Hund``).
+     Existing spin and momentum projections are supported.
+   * The pure spin-1/2 class uses ``NExUpdatePath=2`` and requires
+     ``NLocalSpin=Nsite=2*Ne``, ``NTransfer=0``, and ``NQPFull=1``.
+     Its Hamiltonian may contain diagonal number-operator interactions
+     and ``Exchange`` terms. This covers Heisenberg/XXZ, nonuniform,
+     and Ising-limit inputs in the fixed ``2Sz=0`` sector.
+
+   ``OrbitalGeneral`` / FSZ, BackFlow, RBM, ``PairHop``, ``InterAll``,
+   ``NBodyInterAll``, and ``NBodyG`` are rejected before sampling.
+   ``Exchange`` remains unsupported in the electronic class, and
+   ``Transfer`` remains unsupported in the pure-spin class. Mixed
+   localized/itinerant models and pure-spin quantum projection with
+   ``NQPFull>1`` are also outside the current scope. Second-step Green's
+   functions are not calculated.
    The Gutzwiller ``ProjRatio`` path is checked against an independent
    ED oracle. A nontrivial :math:`k=\pi` momentum projection is checked
    against independent real and complex projected-ED value oracles.
@@ -558,7 +570,8 @@ Keywords and parameters
    has runtime and structural smoke coverage, but not an independent
    projected-ED value oracle.
 
-   With ``NQPFull=1``, the :math:`H^3` local power is evaluated by nested
+   In the electronic class with ``NQPFull=1``, the :math:`H^3` local
+   power is evaluated by nested
    outer and inner loops over ``Transfer`` terms, so its dominant operator
    count grows as :math:`O(N_{\mathrm{Transfer}}^2)`.  With a nontrivial
    quantum projection (``NQPFull>1``), the direct-contraction path for
@@ -566,6 +579,14 @@ Keywords and parameters
    loop.  Its dominant operator count is therefore
    :math:`O(N_{\mathrm{Transfer}}^3)`, and its ``GreenFuncN`` work is
    proportional to ``NQPFull``.
+
+   In the pure-spin class, each ``Exchange`` bond is expanded into its
+   two oriented spin-exchange operators. The direct :math:`H^3`
+   contraction evaluates active paths of depth one, two, and three with
+   ``GreenFuncN`` orders 2, 4, and 6. If :math:`A` oriented exchanges
+   are active for a sample, the corresponding call-count bounds are
+   :math:`A`, :math:`A^2`, and :math:`A^3`; the depth-three term
+   dominates. Only ``NQPFull=1`` is currently supported for this class.
 
    Projection can consequently increase second-step measurement time
    substantially. Benchmark a small instance with the same

--- a/doc/ja/source/algorithm.rst
+++ b/doc/ja/source/algorithm.rst
@@ -633,9 +633,13 @@ Hamiltonian行列、Hamiltonian二乗行列を
 :math:`F_3(x)=\langle x|\hat H^3|\psi\rangle/\langle x|\psi\rangle`
 が計算量を支配します。
 
-現在の2nd step実装では、Hamiltonianはspinを保存する ``Transfer`` 項と
-number-operator型の対角相互作用に限定されています。
-:math:`F_3` の評価では、非対角な ``Transfer`` 項に対する
+現在の2nd step実装には2種類のHamiltonian classがあります。
+electronic classはspinを保存する ``Transfer`` 項とnumber-operator型の
+対角相互作用を含みます。pure spin-1/2 classは対角相互作用と
+``Exchange`` 項を含み、全siteの1電子占有を保存し、現時点では
+``NQPFull=1`` に限定されます。
+
+electronic classの :math:`F_3` 評価では、非対角な ``Transfer`` 項に対する
 outer/innerの二重loopを回します。2つの ``Transfer`` 項の積は二体演算子
 
 .. math::
@@ -675,6 +679,25 @@ estimatorとrank-two updateを利用でき、``NQPFull`` に比例する
 となり、``GreenFuncN`` の計算量は ``NQPFull`` にも比例します。
 したがって実時間は波動関数と計算環境だけでなく、
 射影設定にも強く依存します。
+
+pure-spin classでは各exchange bondを2つの向き付き演算子
+:math:`X_a` の和として表します。直接縮約により
+
+.. math::
+
+   \begin{aligned}
+   F_3(x)={}&V_0^3
+   +\sum_a j_a(V_0^2+V_0V_a+V_a^2)G_a\\
+   &+\sum_{a,b}j_bj_a(V_0+V_a+V_{ba})G_{ba}
+   +\sum_{a,b,c}j_cj_bj_aG_{cba}
+   \end{aligned}
+
+を評価します。ここで :math:`V_a` と :math:`V_{ba}` は各exchange作用後の
+対角energy、:math:`G_a`、:math:`G_{ba}`、:math:`G_{cba}` は元のsample配置から
+それぞれ2、4、6次の ``GreenFuncN`` で求める行列要素です。
+途中配置の波動関数振幅で割らないため、その振幅が0でも有効です。
+向き付きexchangeが :math:`A` 個activeなら、深さ3のcall数は
+:math:`A^3` 以下です。
 
 1st power-Lanczos stepでの物理量の計算
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/ja/source/expert.rst
+++ b/doc/ja/source/expert.rst
@@ -537,15 +537,26 @@ ModParaファイル (modpara.def)
    :math:`(c_0+c_1\hat{H}+c_2\hat{H}^2)|\psi\rangle`
    を最適化します。
 
-   初期実装の2nd stepには ``NVMCCalMode=1``、``NLanczosMode=1``、
-   ``NExUpdatePath=0`` が必要です。実数または複素数のnon-FSZペア軌道に
-   対応し、既存のスピン射影・運動量射影を使用できます。Hamiltonianは
-   spinを保存する ``Transfer`` 項（:math:`\sigma_1=\sigma_2`）と
-   number-operator型の対角相互作用
-   （``CoulombIntra``, ``CoulombInter``, ``Hund``）に限定されます。
+   2nd stepには ``NVMCCalMode=1`` と ``NLanczosMode=1`` が必要です。
+   実数または複素数のnon-FSZペア軌道について、次の2つのmodel classに
+   対応します。
+
+   * electronic classは ``NExUpdatePath=0`` を使用し、spinを保存する
+     ``Transfer`` 項（:math:`\sigma_1=\sigma_2`）とnumber-operator型の
+     対角相互作用（``CoulombIntra``, ``CoulombInter``, ``Hund``）に
+     対応します。既存のスピン射影・運動量射影を使用できます。
+   * pure spin-1/2 classは ``NExUpdatePath=2`` を使用し、
+     ``NLocalSpin=Nsite=2*Ne``、``NTransfer=0``、``NQPFull=1`` を
+     必須とします。Hamiltonianにはnumber-operator型の対角相互作用と
+     ``Exchange`` 項を指定できます。固定 ``2Sz=0`` sectorの
+     Heisenberg/XXZ、非一様結合、Ising極限を含みます。
+
    ``OrbitalGeneral`` / FSZ、BackFlow、RBM、``PairHop``、
-   ``Exchange``、``InterAll``、``NBodyInterAll``、``NBodyG`` は
-   sampling開始前にエラー終了します。2nd stepのGreen関数は計算しません。
+   ``InterAll``、``NBodyInterAll``、``NBodyG`` はsampling開始前に
+   エラー終了します。``Exchange`` はelectronic classでは未対応、
+   ``Transfer`` はpure-spin classでは未対応です。局在spinと遍歴電子の
+   mixed系、および ``NQPFull>1`` のpure-spin量子射影も現scope外です。
+   2nd stepのGreen関数は計算しません。
    Gutzwillerの ``ProjRatio`` 経路は独立ED oracleで値を検証しています。
    非自明な :math:`k=\pi` 運動量射影は、real/complexの独立projected ED
    value oracleで検証しています。real oracleはserial、MPI、OpenMP経路を
@@ -553,13 +564,21 @@ ModParaファイル (modpara.def)
    非自明なスピン射影はruntimeおよび構造のsmoke testまでで、
    projected EDによる独立な値oracleは現時点ではありません。
 
-   ``NQPFull=1`` の場合、:math:`H^3` のlocal powerは ``Transfer`` 項に対する
+   electronic classで ``NQPFull=1`` の場合、:math:`H^3` のlocal powerは
+   ``Transfer`` 項に対する
    outer/inner二重loopで評価するため、支配的なoperator数は
    :math:`O(N_{\mathrm{Transfer}}^2)` で増加します。非自明な量子射影
    （``NQPFull>1``）では、射影された :math:`H\,CACA` 行列要素の直接縮約経路に
    もう1段の ``Transfer`` loopが加わります。そのため支配的なoperator数は
    :math:`O(N_{\mathrm{Transfer}}^3)` となり、``GreenFuncN`` の縮約量は
    ``NQPFull`` にも比例します。
+
+   pure-spin classでは、各 ``Exchange`` bondを2つの向き付きspin-exchange
+   演算子へ展開します。:math:`H^3` の直接縮約は、深さ1、2、3のactive pathを
+   それぞれ2、4、6次の ``GreenFuncN`` で評価します。sampleあたり
+   :math:`A` 個の向き付きexchangeがactiveなら、各深さのcall数上限は
+   :math:`A`、:math:`A^2`、:math:`A^3` で、深さ3が支配します。
+   このclassは現時点で ``NQPFull=1`` のみ対応します。
 
    したがって、射影により2nd stepの測定時間が大幅に増える場合があります。
    実サイズの計算前に、実計算と同じ ``NSPGaussLeg`` と ``NMPTrans`` を使った

--- a/src/mVMC/include/lanczos2_contract.h
+++ b/src/mVMC/include/lanczos2_contract.h
@@ -15,7 +15,18 @@ typedef struct {
   int nNBodyInterAll;
   int nNBodyG;
   int nSpinFlipTransfer;
+  int nLocSpn;
+  int nsite;
+  int ne;
+  int nTransfer;
+  int nQPFull;
 } Lanczos2Contract;
+
+typedef enum {
+  LANCZOS2_MODEL_INVALID = 0,
+  LANCZOS2_MODEL_ELECTRONIC_VK,
+  LANCZOS2_MODEL_LOCAL_SPIN_EXCHANGE
+} Lanczos2ModelClass;
 
 typedef enum {
   LANCZOS2_CONTRACT_OK = 0,
@@ -31,8 +42,14 @@ typedef enum {
   LANCZOS2_CONTRACT_UNSUPPORTED_INTER_ALL,
   LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_INTER_ALL,
   LANCZOS2_CONTRACT_UNSUPPORTED_NBODY_G,
-  LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER
+  LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER,
+  LANCZOS2_CONTRACT_REQUIRES_PURE_LOCALIZED_SPIN,
+  LANCZOS2_CONTRACT_UNSUPPORTED_TRANSFER,
+  LANCZOS2_CONTRACT_UNSUPPORTED_QUANTUM_PROJECTION
 } Lanczos2ContractStatus;
+
+Lanczos2ModelClass ClassifyLanczos2Model(
+    const Lanczos2Contract *contract);
 
 Lanczos2ContractStatus ValidateLanczos2Contract(
     const Lanczos2Contract *contract);

--- a/src/mVMC/include/lslocgrn_heisenberg.h
+++ b/src/mVMC/include/lslocgrn_heisenberg.h
@@ -1,0 +1,69 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models based on many-variable Variational Monte Carlo method
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is developed based on the mVMC-mini program
+(https://github.com/fiber-miniapp/mVMC-mini)
+which follows "The BSD 3-Clause License".
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see http://www.gnu.org/licenses/.
+*/
+#ifndef _LSLOCGRN_HEISENBERG
+#define _LSLOCGRN_HEISENBERG
+
+#include <complex.h>
+#include <stddef.h>
+
+typedef struct {
+  int initialized;
+  int complexMode;
+  int nsize;
+  int nsite2;
+  int nproj;
+  int nqpFull;
+  int lapackLWork;
+  int *pathEleNumA;
+  int *pathEleNumBA;
+  int *workEleIdx;
+  int *workEleNum;
+  int *projCntNew;
+  double *realBuffer;
+  double complex *complexBuffer;
+  double *complexRWork;
+  long long greenCalls[3];
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  int auditEnabled;
+  long long auditedSamples;
+#endif
+} Lanczos2HeisenbergScratch;
+
+/* The caller must zero-initialize scratch before its first initialization. */
+int Lanczos2HeisenbergScratchInit(
+    Lanczos2HeisenbergScratch *scratch, int complexMode);
+
+void Lanczos2HeisenbergScratchFree(
+    Lanczos2HeisenbergScratch *scratch);
+
+int CalculateLS2HeisenbergLocalPowerReal(
+    const double h1, const double ip, const int *eleIdx, const int *eleCfg,
+    const int *eleNum, const int *eleProjCnt,
+    Lanczos2HeisenbergScratch *scratch, double *localPower);
+
+int CalculateLS2HeisenbergLocalPowerComplex(
+    const double complex h1, const double complex ip, const int *eleIdx,
+    const int *eleCfg, const int *eleNum, const int *eleProjCnt,
+    const double complex *rbmCnt, Lanczos2HeisenbergScratch *scratch,
+    double complex *localPower);
+
+#endif

--- a/src/mVMC/lanczos2_contract.c
+++ b/src/mVMC/lanczos2_contract.c
@@ -1,9 +1,29 @@
+#include <limits.h>
 #include <stddef.h>
 
 #include "lanczos2_contract.h"
 
+Lanczos2ModelClass ClassifyLanczos2Model(
+    const Lanczos2Contract *contract) {
+  if (contract == NULL) return LANCZOS2_MODEL_INVALID;
+  if (contract->exUpdatePath == 0) {
+    return LANCZOS2_MODEL_ELECTRONIC_VK;
+  }
+  if (contract->exUpdatePath == 2 &&
+      contract->nsite > 0 &&
+      contract->ne > 0 &&
+      contract->ne <= INT_MAX / 2 &&
+      contract->nLocSpn == contract->nsite &&
+      contract->nLocSpn == 2 * contract->ne) {
+    return LANCZOS2_MODEL_LOCAL_SPIN_EXCHANGE;
+  }
+  return LANCZOS2_MODEL_INVALID;
+}
+
 Lanczos2ContractStatus ValidateLanczos2Contract(
     const Lanczos2Contract *contract) {
+  Lanczos2ModelClass model;
+
   if (contract == NULL || (contract->step != 1 && contract->step != 2)) {
     return LANCZOS2_CONTRACT_INVALID_STEP;
   }
@@ -24,13 +44,23 @@ Lanczos2ContractStatus ValidateLanczos2Contract(
   if (contract->flagRBM != 0) {
     return LANCZOS2_CONTRACT_UNSUPPORTED_RBM;
   }
-  if (contract->exUpdatePath != 0) {
+  if (contract->exUpdatePath != 0 && contract->exUpdatePath != 2) {
     return LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH;
+  }
+  model = ClassifyLanczos2Model(contract);
+  if (contract->exUpdatePath == 2 &&
+      model != LANCZOS2_MODEL_LOCAL_SPIN_EXCHANGE) {
+    return LANCZOS2_CONTRACT_REQUIRES_PURE_LOCALIZED_SPIN;
+  }
+  if (model == LANCZOS2_MODEL_LOCAL_SPIN_EXCHANGE &&
+      contract->nTransfer != 0) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_TRANSFER;
   }
   if (contract->nPairHopping != 0) {
     return LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING;
   }
-  if (contract->nExchangeCoupling != 0) {
+  if (model == LANCZOS2_MODEL_ELECTRONIC_VK &&
+      contract->nExchangeCoupling != 0) {
     return LANCZOS2_CONTRACT_UNSUPPORTED_EXCHANGE;
   }
   if (contract->nInterAll != 0) {
@@ -44,6 +74,10 @@ Lanczos2ContractStatus ValidateLanczos2Contract(
   }
   if (contract->nSpinFlipTransfer != 0) {
     return LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER;
+  }
+  if (model == LANCZOS2_MODEL_LOCAL_SPIN_EXCHANGE &&
+      contract->nQPFull != 1) {
+    return LANCZOS2_CONTRACT_UNSUPPORTED_QUANTUM_PROJECTION;
   }
   return LANCZOS2_CONTRACT_OK;
 }
@@ -65,7 +99,8 @@ const char *Lanczos2ContractError(Lanczos2ContractStatus status) {
     case LANCZOS2_CONTRACT_UNSUPPORTED_RBM:
       return "NLanczosStep=2 does not support RBM";
     case LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH:
-      return "NLanczosStep=2 requires NExUpdatePath=0";
+      return "NLanczosStep=2 supports NExUpdatePath=0, or "
+             "NExUpdatePath=2 for pure-spin mode";
     case LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING:
       return "NLanczosStep=2 does not support PairHopping";
     case LANCZOS2_CONTRACT_UNSUPPORTED_EXCHANGE:
@@ -78,6 +113,13 @@ const char *Lanczos2ContractError(Lanczos2ContractStatus status) {
       return "NLanczosStep=2 does not support NBodyG";
     case LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER:
       return "NLanczosStep=2 supports only spin-conserving Transfer terms";
+    case LANCZOS2_CONTRACT_REQUIRES_PURE_LOCALIZED_SPIN:
+      return "NLanczosStep=2 with NExUpdatePath=2 requires "
+             "NLocalSpin=Nsite=2*Ne";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_TRANSFER:
+      return "NLanczosStep=2 pure-spin mode requires NTransfer=0";
+    case LANCZOS2_CONTRACT_UNSUPPORTED_QUANTUM_PROJECTION:
+      return "NLanczosStep=2 pure-spin mode currently requires NQPFull=1";
   }
   return "unknown NLanczosStep contract error";
 }

--- a/src/mVMC/lslocgrn.c
+++ b/src/mVMC/lslocgrn.c
@@ -44,6 +44,8 @@ static int Lanczos2CalHCAGuardAuditComplexEnabled = 0;
 static long long Lanczos2CalHCAGuardAuditComplexDirectCount = 0;
 static long long Lanczos2CalHCAGuardAuditComplexZeroComponentCount = 0;
 static int Lanczos2CalHCAGuardAuditComplexLastMovedHasZeroComponent = 0;
+static int Lanczos2HeisenbergZeroOverlapAuditComplexEnabled = 0;
+static long long Lanczos2HeisenbergZeroOverlapAuditComplexCount = 0;
 #endif
 
 double complex calculateHK(const double complex h1, const double complex ip, int *eleIdx, int *eleCfg,
@@ -610,6 +612,12 @@ double complex calHCACA(const int ri, const int rj, const int rk, const int rl,
   if(cabs(g)>1.0e-12 && (NLanczosStep != 2 || NQPFull == 1)) {
     val = calHCACA1(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt);
   } else {
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+    if(Lanczos2HeisenbergZeroOverlapAuditComplexEnabled &&
+       cabs(g)<=1.0e-12 && NLanczosStep == 2 && NQPFull == 1) {
+      Lanczos2HeisenbergZeroOverlapAuditComplexCount++;
+    }
+#endif
     val = calHCACA2(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt);
   }
 

--- a/src/mVMC/lslocgrn_heisenberg.c
+++ b/src/mVMC/lslocgrn_heisenberg.c
@@ -1,0 +1,484 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models based on many-variable Variational Monte Carlo method
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is developed based on the mVMC-mini program
+(https://github.com/fiber-miniapp/mVMC-mini)
+which follows "The BSD 3-Clause License".
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see http://www.gnu.org/licenses/.
+*/
+#include "lslocgrn_heisenberg.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "global.h"
+
+static void *Lanczos2HeisenbergCheckedCalloc(size_t count, size_t size) {
+  if (count == 0) count = 1;
+  if (size == 0 || count > SIZE_MAX / size) return NULL;
+  return calloc(count, size);
+}
+
+void Lanczos2HeisenbergScratchFree(
+    Lanczos2HeisenbergScratch *scratch) {
+  if (scratch == NULL) return;
+  free(scratch->pathEleNumA);
+  free(scratch->pathEleNumBA);
+  free(scratch->workEleIdx);
+  free(scratch->workEleNum);
+  free(scratch->projCntNew);
+  free(scratch->realBuffer);
+  free(scratch->complexBuffer);
+  free(scratch->complexRWork);
+  memset(scratch, 0, sizeof(*scratch));
+}
+
+int Lanczos2HeisenbergScratchInit(
+    Lanczos2HeisenbergScratch *scratch, int complexMode) {
+  size_t bufferCount;
+
+  if (scratch == NULL || (complexMode != 0 && complexMode != 1) ||
+      Nsize <= 0 || Nsite2 <= 0 || NProj < 0 || NQPFull != 1 ||
+      LapackLWork <= 0 ||
+      (size_t)Nsize > (SIZE_MAX - (size_t)NQPFull) / 6) {
+    return -1;
+  }
+  if (scratch->initialized != 0) return -1;
+  memset(scratch, 0, sizeof(*scratch));
+  scratch->complexMode = complexMode;
+  scratch->nsize = Nsize;
+  scratch->nsite2 = Nsite2;
+  scratch->nproj = NProj;
+  scratch->nqpFull = NQPFull;
+  scratch->lapackLWork = LapackLWork;
+  bufferCount = (size_t)NQPFull + 6 * (size_t)Nsize;
+
+  scratch->pathEleNumA = Lanczos2HeisenbergCheckedCalloc(
+      (size_t)Nsite2, sizeof(*scratch->pathEleNumA));
+  scratch->pathEleNumBA = Lanczos2HeisenbergCheckedCalloc(
+      (size_t)Nsite2, sizeof(*scratch->pathEleNumBA));
+  scratch->workEleIdx = Lanczos2HeisenbergCheckedCalloc(
+      (size_t)Nsize, sizeof(*scratch->workEleIdx));
+  scratch->workEleNum = Lanczos2HeisenbergCheckedCalloc(
+      (size_t)Nsite2, sizeof(*scratch->workEleNum));
+  scratch->projCntNew = Lanczos2HeisenbergCheckedCalloc(
+      (size_t)(NProj > 0 ? NProj : 1), sizeof(*scratch->projCntNew));
+  if (complexMode == 0) {
+    scratch->realBuffer = Lanczos2HeisenbergCheckedCalloc(
+        bufferCount, sizeof(*scratch->realBuffer));
+  } else {
+    scratch->complexBuffer = Lanczos2HeisenbergCheckedCalloc(
+        bufferCount, sizeof(*scratch->complexBuffer));
+    scratch->complexRWork = Lanczos2HeisenbergCheckedCalloc(
+        (size_t)LapackLWork, sizeof(*scratch->complexRWork));
+  }
+
+  if (scratch->pathEleNumA == NULL || scratch->pathEleNumBA == NULL ||
+      scratch->workEleIdx == NULL || scratch->workEleNum == NULL ||
+      scratch->projCntNew == NULL ||
+      (complexMode == 0 && scratch->realBuffer == NULL) ||
+      (complexMode != 0 &&
+       (scratch->complexBuffer == NULL || scratch->complexRWork == NULL))) {
+    Lanczos2HeisenbergScratchFree(scratch);
+    return -1;
+  }
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  {
+    const char *auditValue = getenv("MVMC_LANCZOS2_HEISENBERG_AUDIT");
+    scratch->auditEnabled =
+        auditValue != NULL && auditValue[0] != '\0' &&
+        strcmp(auditValue, "0") != 0;
+  }
+#endif
+  scratch->initialized = 1;
+  return 0;
+}
+
+static int Lanczos2HeisenbergScratchMatches(
+    const Lanczos2HeisenbergScratch *scratch, int complexMode) {
+  return scratch != NULL && scratch->initialized != 0 &&
+         scratch->complexMode == complexMode &&
+         scratch->nsize == Nsize && scratch->nsite2 == Nsite2 &&
+         scratch->nproj == NProj && scratch->nqpFull == NQPFull &&
+         scratch->lapackLWork == LapackLWork;
+}
+
+/*
+ * Build one oriented Exchange operator and its resulting occupation.
+ * orientation=0 is c^+_{i up} c_{j up} c^+_{j down} c_{i down};
+ * orientation=1 is its spin-reversed partner.
+ */
+static int Lanczos2BuildExchangeOperator(
+    int bond, int orientation, const int *sourceEleNum, int *targetEleNum,
+    int *rsi, int *rsj) {
+  int ri;
+  int rj;
+  int riUp;
+  int rjUp;
+  int riDown;
+  int rjDown;
+  int source0;
+  int target0;
+  int source1;
+  int target1;
+
+  if (bond < 0 || bond >= NExchangeCoupling ||
+      (orientation != 0 && orientation != 1) ||
+      sourceEleNum == NULL || rsi == NULL || rsj == NULL) {
+    return 0;
+  }
+  ri = ExchangeCoupling[bond][0];
+  rj = ExchangeCoupling[bond][1];
+  if (ri < 0 || ri >= Nsite || rj < 0 || rj >= Nsite) return 0;
+  riUp = ri;
+  rjUp = rj;
+  riDown = ri + Nsite;
+  rjDown = rj + Nsite;
+  if (orientation == 0) {
+    source0 = rjUp;
+    target0 = riUp;
+    source1 = riDown;
+    target1 = rjDown;
+  } else {
+    source0 = rjDown;
+    target0 = riDown;
+    source1 = riUp;
+    target1 = rjUp;
+  }
+  if (sourceEleNum[source0] == 0 || sourceEleNum[target0] != 0 ||
+      sourceEleNum[source1] == 0 || sourceEleNum[target1] != 0) {
+    return 0;
+  }
+
+  if (targetEleNum != NULL) {
+    memcpy(targetEleNum, sourceEleNum, (size_t)Nsite2 * sizeof(int));
+    targetEleNum[source0] = 0;
+    targetEleNum[target0] = 1;
+    targetEleNum[source1] = 0;
+    targetEleNum[target1] = 1;
+  }
+  rsi[0] = target0;
+  rsj[0] = source0;
+  rsi[1] = target1;
+  rsj[1] = source1;
+  return 1;
+}
+
+static void Lanczos2ComposeOperators(
+    int depth, const int *leftRsi, const int *leftRsj,
+    const int *middleRsi, const int *middleRsj,
+    const int *rightRsi, const int *rightRsj,
+    int *rsi, int *rsj) {
+  int offset = 0;
+  int index;
+  const int *sourcesRsi[3] = {leftRsi, middleRsi, rightRsi};
+  const int *sourcesRsj[3] = {leftRsj, middleRsj, rightRsj};
+  for (index = 0; index < depth; index++) {
+    rsi[offset] = sourcesRsi[index][0];
+    rsj[offset++] = sourcesRsj[index][0];
+    rsi[offset] = sourcesRsi[index][1];
+    rsj[offset++] = sourcesRsj[index][1];
+  }
+}
+
+static double Lanczos2HeisenbergGreenReal(
+    int n, const int *rsi, const int *rsj, double ip, const int *eleIdx,
+    const int *eleCfg, const int *eleNum, const int *eleProjCnt,
+    Lanczos2HeisenbergScratch *scratch) {
+  int callRsi[6];
+  int callRsj[6];
+  memcpy(callRsi, rsi, (size_t)n * sizeof(int));
+  memcpy(callRsj, rsj, (size_t)n * sizeof(int));
+  memcpy(scratch->workEleIdx, eleIdx, (size_t)Nsize * sizeof(int));
+  memcpy(scratch->workEleNum, eleNum, (size_t)Nsite2 * sizeof(int));
+  scratch->greenCalls[n / 2 - 1]++;
+  return GreenFuncN_real(
+      n, callRsi, callRsj, ip, scratch->workEleIdx, eleCfg,
+      scratch->workEleNum, eleProjCnt, scratch->realBuffer,
+      scratch->projCntNew);
+}
+
+static double complex Lanczos2HeisenbergGreenComplex(
+    int n, const int *rsi, const int *rsj, double complex ip,
+    const int *eleIdx, const int *eleCfg, const int *eleNum,
+    const int *eleProjCnt, const double complex *rbmCnt,
+    Lanczos2HeisenbergScratch *scratch) {
+  int callRsi[6];
+  int callRsj[6];
+  memcpy(callRsi, rsi, (size_t)n * sizeof(int));
+  memcpy(callRsj, rsj, (size_t)n * sizeof(int));
+  memcpy(scratch->workEleIdx, eleIdx, (size_t)Nsize * sizeof(int));
+  memcpy(scratch->workEleNum, eleNum, (size_t)Nsite2 * sizeof(int));
+  scratch->greenCalls[n / 2 - 1]++;
+  return GreenFuncN(
+      n, callRsi, callRsj, ip, scratch->workEleIdx, eleCfg,
+      scratch->workEleNum, eleProjCnt, rbmCnt, NULL,
+      scratch->complexBuffer, scratch->projCntNew, scratch->complexRWork);
+}
+
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+static int Lanczos2ScaledCloseReal(double left, double right) {
+  const double scale = fmax(fmax(fabs(left), fabs(right)), 1.0);
+  return fabs(left - right) <= 2.0e-10 + 2.0e-9 * scale;
+}
+
+static int Lanczos2ScaledCloseComplex(
+    double complex left, double complex right) {
+  const double scale = fmax(fmax(cabs(left), cabs(right)), 1.0);
+  return cabs(left - right) <= 2.0e-10 + 2.0e-9 * scale;
+}
+#endif
+
+int CalculateLS2HeisenbergLocalPowerReal(
+    const double h1, const double ip, const int *eleIdx, const int *eleCfg,
+    const int *eleNum, const int *eleProjCnt,
+    Lanczos2HeisenbergScratch *scratch, double *localPower) {
+  double legacyLocalPower[4];
+  double directF1;
+  double directF2;
+  double directF3;
+  double v0;
+  int aBond;
+  int aOrientation;
+
+  if (!Lanczos2HeisenbergScratchMatches(scratch, 0) ||
+      eleIdx == NULL || eleCfg == NULL || eleNum == NULL ||
+      localPower == NULL || !isfinite(ip) || fabs(ip) == 0.0) {
+    return -1;
+  }
+  v0 = CalculateHamiltonian0_real(eleNum);
+  LSLocalQ_real(h1, ip, (int *)eleIdx, (int *)eleCfg, (int *)eleNum,
+                (int *)eleProjCnt, legacyLocalPower);
+  localPower[0] = 1.0;
+  localPower[1] = h1;
+  localPower[2] = legacyLocalPower[3];
+  directF1 = v0;
+  directF2 = v0 * v0;
+  directF3 = v0 * v0 * v0;
+
+  for (aBond = 0; aBond < NExchangeCoupling; aBond++) {
+    for (aOrientation = 0; aOrientation < 2; aOrientation++) {
+      int aRsi[2];
+      int aRsj[2];
+      int composedRsi[6];
+      int composedRsj[6];
+      const double ja = ParaExchangeCoupling[aBond];
+      double ga;
+      double va;
+      int bBond;
+      int bOrientation;
+
+      if (!Lanczos2BuildExchangeOperator(
+              aBond, aOrientation, eleNum, scratch->pathEleNumA,
+              aRsi, aRsj)) {
+        continue;
+      }
+      va = CalculateHamiltonian0_real(scratch->pathEleNumA);
+      Lanczos2ComposeOperators(
+          1, aRsi, aRsj, NULL, NULL, NULL, NULL,
+          composedRsi, composedRsj);
+      ga = Lanczos2HeisenbergGreenReal(
+          2, composedRsi, composedRsj, ip, eleIdx, eleCfg, eleNum,
+          eleProjCnt, scratch);
+      directF1 += ja * ga;
+      directF2 += ja * (v0 + va) * ga;
+      directF3 += ja * (v0 * v0 + v0 * va + va * va) * ga;
+
+      for (bBond = 0; bBond < NExchangeCoupling; bBond++) {
+        for (bOrientation = 0; bOrientation < 2; bOrientation++) {
+          int bRsi[2];
+          int bRsj[2];
+          const double jb = ParaExchangeCoupling[bBond];
+          double gba;
+          double vba;
+          int cBond;
+          int cOrientation;
+
+          if (!Lanczos2BuildExchangeOperator(
+                  bBond, bOrientation, scratch->pathEleNumA,
+                  scratch->pathEleNumBA, bRsi, bRsj)) {
+            continue;
+          }
+          vba = CalculateHamiltonian0_real(scratch->pathEleNumBA);
+          Lanczos2ComposeOperators(
+              2, bRsi, bRsj, aRsi, aRsj, NULL, NULL,
+              composedRsi, composedRsj);
+          gba = Lanczos2HeisenbergGreenReal(
+              4, composedRsi, composedRsj, ip, eleIdx, eleCfg, eleNum,
+              eleProjCnt, scratch);
+          directF2 += jb * ja * gba;
+          directF3 += jb * ja * (v0 + va + vba) * gba;
+
+          for (cBond = 0; cBond < NExchangeCoupling; cBond++) {
+            for (cOrientation = 0; cOrientation < 2; cOrientation++) {
+              int cRsi[2];
+              int cRsj[2];
+              const double jc = ParaExchangeCoupling[cBond];
+              double gcba;
+
+              if (!Lanczos2BuildExchangeOperator(
+                      cBond, cOrientation, scratch->pathEleNumBA,
+                      NULL, cRsi, cRsj)) {
+                continue;
+              }
+              Lanczos2ComposeOperators(
+                  3, cRsi, cRsj, bRsi, bRsj, aRsi, aRsj,
+                  composedRsi, composedRsj);
+              gcba = Lanczos2HeisenbergGreenReal(
+                  6, composedRsi, composedRsj, ip, eleIdx, eleCfg,
+                  eleNum, eleProjCnt, scratch);
+              directF3 += jc * jb * ja * gcba;
+            }
+          }
+        }
+      }
+    }
+  }
+  localPower[3] = directF3;
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if (scratch->auditEnabled) {
+    if (!Lanczos2ScaledCloseReal(h1, directF1) ||
+        !Lanczos2ScaledCloseReal(localPower[2], directF2)) {
+      return -1;
+    }
+    scratch->auditedSamples++;
+  }
+#endif
+  return 0;
+}
+
+int CalculateLS2HeisenbergLocalPowerComplex(
+    const double complex h1, const double complex ip, const int *eleIdx,
+    const int *eleCfg, const int *eleNum, const int *eleProjCnt,
+    const double complex *rbmCnt, Lanczos2HeisenbergScratch *scratch,
+    double complex *localPower) {
+  double complex legacyLocalPower[4];
+  double complex directF1;
+  double complex directF2;
+  double complex directF3;
+  double complex v0;
+  int aBond;
+  int aOrientation;
+
+  if (!Lanczos2HeisenbergScratchMatches(scratch, 1) ||
+      eleIdx == NULL || eleCfg == NULL || eleNum == NULL ||
+      localPower == NULL ||
+      !isfinite(creal(ip)) || !isfinite(cimag(ip)) || cabs(ip) == 0.0) {
+    return -1;
+  }
+  v0 = CalculateHamiltonian0(eleNum);
+  LSLocalQ(h1, ip, (int *)eleIdx, (int *)eleCfg, (int *)eleNum,
+           (int *)eleProjCnt, (double complex *)rbmCnt, legacyLocalPower);
+  localPower[0] = 1.0;
+  localPower[1] = h1;
+  localPower[2] = legacyLocalPower[3];
+  directF1 = v0;
+  directF2 = v0 * v0;
+  directF3 = v0 * v0 * v0;
+
+  for (aBond = 0; aBond < NExchangeCoupling; aBond++) {
+    for (aOrientation = 0; aOrientation < 2; aOrientation++) {
+      int aRsi[2];
+      int aRsj[2];
+      int composedRsi[6];
+      int composedRsj[6];
+      const double ja = ParaExchangeCoupling[aBond];
+      double complex ga;
+      double complex va;
+      int bBond;
+      int bOrientation;
+
+      if (!Lanczos2BuildExchangeOperator(
+              aBond, aOrientation, eleNum, scratch->pathEleNumA,
+              aRsi, aRsj)) {
+        continue;
+      }
+      va = CalculateHamiltonian0(scratch->pathEleNumA);
+      Lanczos2ComposeOperators(
+          1, aRsi, aRsj, NULL, NULL, NULL, NULL,
+          composedRsi, composedRsj);
+      ga = Lanczos2HeisenbergGreenComplex(
+          2, composedRsi, composedRsj, ip, eleIdx, eleCfg, eleNum,
+          eleProjCnt, rbmCnt, scratch);
+      directF1 += ja * ga;
+      directF2 += ja * (v0 + va) * ga;
+      directF3 += ja * (v0 * v0 + v0 * va + va * va) * ga;
+
+      for (bBond = 0; bBond < NExchangeCoupling; bBond++) {
+        for (bOrientation = 0; bOrientation < 2; bOrientation++) {
+          int bRsi[2];
+          int bRsj[2];
+          const double jb = ParaExchangeCoupling[bBond];
+          double complex gba;
+          double complex vba;
+          int cBond;
+          int cOrientation;
+
+          if (!Lanczos2BuildExchangeOperator(
+                  bBond, bOrientation, scratch->pathEleNumA,
+                  scratch->pathEleNumBA, bRsi, bRsj)) {
+            continue;
+          }
+          vba = CalculateHamiltonian0(scratch->pathEleNumBA);
+          Lanczos2ComposeOperators(
+              2, bRsi, bRsj, aRsi, aRsj, NULL, NULL,
+              composedRsi, composedRsj);
+          gba = Lanczos2HeisenbergGreenComplex(
+              4, composedRsi, composedRsj, ip, eleIdx, eleCfg, eleNum,
+              eleProjCnt, rbmCnt, scratch);
+          directF2 += jb * ja * gba;
+          directF3 += jb * ja * (v0 + va + vba) * gba;
+
+          for (cBond = 0; cBond < NExchangeCoupling; cBond++) {
+            for (cOrientation = 0; cOrientation < 2; cOrientation++) {
+              int cRsi[2];
+              int cRsj[2];
+              const double jc = ParaExchangeCoupling[cBond];
+              double complex gcba;
+
+              if (!Lanczos2BuildExchangeOperator(
+                      cBond, cOrientation, scratch->pathEleNumBA,
+                      NULL, cRsi, cRsj)) {
+                continue;
+              }
+              Lanczos2ComposeOperators(
+                  3, cRsi, cRsj, bRsi, bRsj, aRsi, aRsj,
+                  composedRsi, composedRsj);
+              gcba = Lanczos2HeisenbergGreenComplex(
+                  6, composedRsi, composedRsj, ip, eleIdx, eleCfg,
+                  eleNum, eleProjCnt, rbmCnt, scratch);
+              directF3 += jc * jb * ja * gcba;
+            }
+          }
+        }
+      }
+    }
+  }
+  localPower[3] = directF3;
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if (scratch->auditEnabled) {
+    if (!Lanczos2ScaledCloseComplex(h1, directF1) ||
+        !Lanczos2ScaledCloseComplex(localPower[2], directF2)) {
+      return -1;
+    }
+    scratch->auditedSamples++;
+  }
+#endif
+  return 0;
+}

--- a/src/mVMC/lslocgrn_real.c
+++ b/src/mVMC/lslocgrn_real.c
@@ -46,6 +46,8 @@ static int Lanczos2CalHCAGuardAuditRealEnabled = 0;
 static long long Lanczos2CalHCAGuardAuditRealDirectCount = 0;
 static long long Lanczos2CalHCAGuardAuditRealZeroComponentCount = 0;
 static int Lanczos2CalHCAGuardAuditRealLastMovedHasZeroComponent = 0;
+static int Lanczos2HeisenbergZeroOverlapAuditRealEnabled = 0;
+static long long Lanczos2HeisenbergZeroOverlapAuditRealCount = 0;
 #endif
 
 /* Calculate <psi|QQ|x>/<psi|x> */
@@ -592,6 +594,12 @@ double calHCACA_real(const int ri, const int rj, const int rk, const int rl,
   if(fabs(g)>1.0e-12 && (NLanczosStep != 2 || NQPFull == 1)) {
     val = calHCACA1_real(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt);
   } else {
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+    if(Lanczos2HeisenbergZeroOverlapAuditRealEnabled &&
+       fabs(g)<=1.0e-12 && NLanczosStep == 2 && NQPFull == 1) {
+      Lanczos2HeisenbergZeroOverlapAuditRealCount++;
+    }
+#endif
     val = calHCACA2_real(ri,rj,rk,rl,si,sk,ip,eleIdx,eleCfg,eleNum,eleProjCnt);
   }
 

--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -54,7 +54,8 @@ int CheckQuadSite(const int iSite1, const int iSite2, const int iSite3, const in
 
 int GetTransferInfo(FILE *fp, int **ArrayIdx, double complex *ArrayValue, int Nsite, int NArray, char *defname);
 
-int GetLocSpinInfo(FILE *fp, int *ArrayIdx, int Nsite, char *defname);
+int GetLocSpinInfo(FILE *fp, int *ArrayIdx, int Nsite, int NLocalSpin,
+                   char *defname);
 
 int GetInfoCoulombIntra(FILE *fp, int *ArrayIdx, double *ArrayValue, int Nsite, int NArray, char *defname);
 
@@ -1282,20 +1283,36 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
   }
 
   {
+    int lanczos2NQPFull = 0;
+    const long long lanczos2MPTrans =
+        NMPTrans < 0 ? -(long long)NMPTrans : (long long)NMPTrans;
+    if (NSPGaussLeg > 0 && lanczos2MPTrans > 0 &&
+        lanczos2MPTrans <= INT_MAX && NQPOptTrans > 0 &&
+        NSPGaussLeg <= INT_MAX / (int)lanczos2MPTrans &&
+        NSPGaussLeg * (int)lanczos2MPTrans <=
+            INT_MAX / NQPOptTrans) {
+      lanczos2NQPFull =
+          NSPGaussLeg * (int)lanczos2MPTrans * NQPOptTrans;
+    }
     const Lanczos2Contract lanczos2Contract = {
-        NLanczosStep,
-        NLanczosMode,
-        NVMCCalMode,
-        iFlgOrbitalGeneral,
-        NProjBF,
-        FlagRBM,
-        NExUpdatePath,
-        NPairHopping,
-        NExchangeCoupling,
-        NInterAll,
-        NNBodyInterAll,
-        NNBodyG,
-        0 /* Transfer contents are validated after ReadDefFileIdxPara. */};
+        .step = NLanczosStep,
+        .lanczosMode = NLanczosMode,
+        .vmcCalMode = NVMCCalMode,
+        .orbitalGeneral = iFlgOrbitalGeneral,
+        .nProjBF = NProjBF,
+        .flagRBM = FlagRBM,
+        .exUpdatePath = NExUpdatePath,
+        .nPairHopping = NPairHopping,
+        .nExchangeCoupling = NExchangeCoupling,
+        .nInterAll = NInterAll,
+        .nNBodyInterAll = NNBodyInterAll,
+        .nNBodyG = NNBodyG,
+        .nSpinFlipTransfer = 0,
+        .nLocSpn = NLocSpn,
+        .nsite = Nsite,
+        .ne = Ne,
+        .nTransfer = NTransfer,
+        .nQPFull = lanczos2NQPFull};
     int lanczos2StatusCode = LANCZOS2_CONTRACT_OK;
     Lanczos2ContractStatus lanczos2Status;
     if (rank == 0) {
@@ -1423,7 +1440,7 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
       for (i = 0; i < IgnoreLinesInDef; i++) fgets(ctmp, sizeof(ctmp) / sizeof(char), fp);
       switch (iKWidx) {
         case KWLocSpin: /* Read locspn.def----------------------------------------*/
-          if (GetLocSpinInfo(fp, LocSpn, Nsite, defname) != 0) info = 1;
+          if (GetLocSpinInfo(fp, LocSpn, Nsite, NLocSpn, defname) != 0) info = 1;
           break;//locspn
 
         case KWTrans: /* transfer.def--------------------------------------*/
@@ -1708,6 +1725,15 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
     fprintf(stdout, "finish reading parameters.\n");
   } /* if(rank==0) */
 
+  /*
+   * Definition arrays are read only on rank 0.  Broadcast the verdict before
+   * any rank consumes them so malformed input reaches the same abort path on
+   * every rank.
+   */
+#ifdef _mpi_use
+  MPI_Bcast(&info, 1, MPI_INT, 0, comm);
+#endif
+
   if (FlagOptTrans <= 0) { // initialization of QPOptTrans
     ParaQPOptTrans[0] = 1.0;
     for (i = 0; i < Nsite; ++i) {
@@ -1759,6 +1785,11 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
     lanczos2Contract.nNBodyInterAll = NNBodyInterAll;
     lanczos2Contract.nNBodyG = NNBodyG;
     lanczos2Contract.nSpinFlipTransfer = nSpinFlipTransfer;
+    lanczos2Contract.nLocSpn = NLocSpn;
+    lanczos2Contract.nsite = Nsite;
+    lanczos2Contract.ne = Ne;
+    lanczos2Contract.nTransfer = NTransfer;
+    lanczos2Contract.nQPFull = NQPFull;
     lanczos2Status = ValidateLanczos2Contract(&lanczos2Contract);
     if (lanczos2Status != LANCZOS2_CONTRACT_OK) {
       if (rank == 0) {
@@ -2682,21 +2713,62 @@ int GetTransferInfo(FILE *fp, int **ArrayIdx, double complex *ArrayValue, int Ns
   return info;
 }
 
-int GetLocSpinInfo(FILE *fp, int *ArrayIdx, int Nsite, char *defname) {
+int GetLocSpinInfo(FILE *fp, int *ArrayIdx, int Nsite, int NLocalSpin,
+                   char *defname) {
   char ctmp2[256];
-  int idx = 0, info = 0;
+  int idx = 0, info = 0, localSpinCount = 0;
+  int site;
   int x0 = 0, x1 = 0;
+  if (fp == NULL || ArrayIdx == NULL || Nsite <= 0 ||
+      NLocalSpin < 0 || NLocalSpin > Nsite) {
+    fprintf(stderr, "Error: Invalid LocSpin dimensions.\n");
+    return 1;
+  }
+  for (site = 0; site < Nsite; site++) ArrayIdx[site] = -1;
   while (fgets(ctmp2, sizeof(ctmp2) / sizeof(char), fp) != NULL) {
-    sscanf(ctmp2, "%d %d \n", &x0, &x1);
-    ArrayIdx[x0] = x1;
+    if (sscanf(ctmp2, "%d %d", &x0, &x1) != 2) {
+      fprintf(stderr, "Error: Malformed LocSpin definition.\n");
+      info = 1;
+      break;
+    }
     if (CheckSite(x0, Nsite) != 0) {
       fprintf(stderr, "Error: Site index is incorrect.\n");
       info = 1;
       break;
     }
+    if (x1 != 0 && x1 != 1) {
+      fprintf(stderr,
+              "Error: LocSpin flag must be 0 or 1 (site=%d, value=%d).\n",
+              x0, x1);
+      info = 1;
+      break;
+    }
+    if (ArrayIdx[x0] != -1) {
+      fprintf(stderr, "Error: Duplicate LocSpin site index: %d.\n", x0);
+      info = 1;
+      break;
+    }
+    ArrayIdx[x0] = x1;
+    localSpinCount += x1;
     idx++;
   }
-  if (idx != Nsite) info = ReadDefFileError(defname);
+  if (info == 0) {
+    for (site = 0; site < Nsite; site++) {
+      if (ArrayIdx[site] == -1) {
+        fprintf(stderr, "Error: Missing LocSpin site index: %d.\n", site);
+        info = 1;
+        break;
+      }
+    }
+  }
+  if (info == 0 && idx != Nsite) info = ReadDefFileError(defname);
+  if (info == 0 && localSpinCount != NLocalSpin) {
+    fprintf(stderr,
+            "Error: NLocalSpin header (%d) does not match LocSpin flag "
+            "count (%d).\n",
+            NLocalSpin, localSpinCount);
+    info = 1;
+  }
   return info;
 }
 

--- a/src/mVMC/vmccal.c
+++ b/src/mVMC/vmccal.c
@@ -41,6 +41,7 @@ along with this program. If not, see http://www.gnu.org/licenses/.
 #include "calham.h"
 #include "lslocgrn_real.c"
 #include "lslocgrn.c"
+#include "lslocgrn_heisenberg.c"
 #include "calgrn.c"
 #include "physcal_lanczos2.h"
 
@@ -244,6 +245,7 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
   int rank,size,parentRank,parentSize,int_i;
   FILE *lanczosOracleDump = NULL;
   Lanczos2StateSnapshot lanczos2StateSnapshot;
+  Lanczos2HeisenbergScratch lanczos2HeisenbergScratch;
 #ifdef MVMC_ENABLE_FAULT_INJECTION
   int lanczos2InjectNonfinite = 0;
   int lanczos2CalHCAGuardAudit = 0;
@@ -263,6 +265,7 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
   StopTimer(24);
 
   memset(&lanczos2StateSnapshot, 0, sizeof(lanczos2StateSnapshot));
+  memset(&lanczos2HeisenbergScratch, 0, sizeof(lanczos2HeisenbergScratch));
 #ifdef MVMC_ENABLE_FAULT_INJECTION
   /*
    * Test-only hook for exercising the collective non-finite failure path.
@@ -304,6 +307,34 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
             parentRank);
     MPI_Abort(comm_parent, EXIT_FAILURE);
   }
+  if(NVMCCalMode == 1 && NLanczosMode > 0 && NLanczosStep == 2 &&
+     NExUpdatePath == 2 &&
+     Lanczos2HeisenbergScratchInit(
+         &lanczos2HeisenbergScratch, AllComplexFlag != 0) != 0) {
+    fprintf(stderr,
+            "Error: failed to allocate Lanczos2 Heisenberg scratch "
+            "on rank %d.\n",
+            parentRank);
+    MPI_Abort(comm_parent, EXIT_FAILURE);
+  }
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if(lanczos2HeisenbergScratch.auditEnabled) {
+    if(parentSize != 1 || NVMCCalMode != 1 || NLanczosMode != 1 ||
+       NLanczosStep != 2 || NExUpdatePath != 2 || NQPFull != 1 ||
+       NExchangeCoupling <= 0) {
+      fprintf(stderr,
+              "Error: Lanczos2 Heisenberg audit requires a single-rank "
+              "pure-spin Exchange calculation with NQPFull=1.\n");
+      MPI_Abort(comm_parent, EXIT_FAILURE);
+    }
+    Lanczos2HeisenbergZeroOverlapAuditRealCount = 0;
+    Lanczos2HeisenbergZeroOverlapAuditComplexCount = 0;
+    Lanczos2HeisenbergZeroOverlapAuditRealEnabled =
+        AllComplexFlag == 0;
+    Lanczos2HeisenbergZeroOverlapAuditComplexEnabled =
+        AllComplexFlag != 0;
+  }
+#endif
 
   if(NVMCCalMode == 1 && NLanczosMode > 0) {
     const char *dumpValue = getenv("MVMC_LANCZOS_ORACLE_DUMP");
@@ -560,17 +591,29 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
           Lanczos2StateSnapshotCapture(
               &lanczos2StateSnapshot,eleIdx,eleCfg,eleNum,eleProjCnt);
           if(AllComplexFlag==0) {
-            CalculateLS2LocalPower_real(
-                creal(e),creal(ip),eleIdx,eleCfg,eleNum,eleProjCnt,
-                LS2LocalPower_real);
+            if(NExUpdatePath == 2) {
+              lanczos2Status =
+                  CalculateLS2HeisenbergLocalPowerReal(
+                      creal(e),creal(ip),eleIdx,eleCfg,eleNum,eleProjCnt,
+                      &lanczos2HeisenbergScratch,LS2LocalPower_real) == 0
+                      ? LANCZOS2_SOLVE_OK
+                      : LANCZOS2_SOLVE_INVALID_ARGUMENT;
+            }else{
+              CalculateLS2LocalPower_real(
+                  creal(e),creal(ip),eleIdx,eleCfg,eleNum,eleProjCnt,
+                  LS2LocalPower_real);
+              lanczos2Status = LANCZOS2_SOLVE_OK;
+            }
 #ifdef MVMC_ENABLE_FAULT_INJECTION
             if(lanczos2InjectNonfinite && parentRank == 0 &&
                sample == sampleStart) {
               LS2LocalPower_real[LANCZOS2_POWER_COUNT-1] = NAN;
             }
 #endif
-            lanczos2Status = LANCZOS2_SOLVE_OK;
-            for(i=0; i<LANCZOS2_POWER_COUNT; i++) {
+            for(i=0;
+                lanczos2Status == LANCZOS2_SOLVE_OK &&
+                i<LANCZOS2_POWER_COUNT;
+                i++) {
               if(!isfinite(LS2LocalPower_real[i])) {
                 lanczos2Status = LANCZOS2_SOLVE_NONFINITE_MOMENT;
                 break;
@@ -583,16 +626,29 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
                      LANCZOS2_POWER_COUNT * sizeof(double));
             }
           }else{
-            CalculateLS2LocalPower(
-                e,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt,LS2LocalPower);
+            if(NExUpdatePath == 2) {
+              lanczos2Status =
+                  CalculateLS2HeisenbergLocalPowerComplex(
+                      e,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt,
+                      &lanczos2HeisenbergScratch,LS2LocalPower) == 0
+                      ? LANCZOS2_SOLVE_OK
+                      : LANCZOS2_SOLVE_INVALID_ARGUMENT;
+            }else{
+              CalculateLS2LocalPower(
+                  e,ip,eleIdx,eleCfg,eleNum,eleProjCnt,rbmCnt,
+                  LS2LocalPower);
+              lanczos2Status = LANCZOS2_SOLVE_OK;
+            }
 #ifdef MVMC_ENABLE_FAULT_INJECTION
             if(lanczos2InjectNonfinite && parentRank == 0 &&
                sample == sampleStart) {
               LS2LocalPower[LANCZOS2_POWER_COUNT-1] = NAN + 0.0*I;
             }
 #endif
-            lanczos2Status = LANCZOS2_SOLVE_OK;
-            for(i=0; i<LANCZOS2_POWER_COUNT; i++) {
+            for(i=0;
+                lanczos2Status == LANCZOS2_SOLVE_OK &&
+                i<LANCZOS2_POWER_COUNT;
+                i++) {
               if(!isfinite(creal(LS2LocalPower[i])) ||
                  !isfinite(cimag(LS2LocalPower[i]))) {
                 lanczos2Status = LANCZOS2_SOLVE_NONFINITE_MOMENT;
@@ -673,8 +729,33 @@ void VMCMainCal(MPI_Comm comm_parent, MPI_Comm comm) {
   }
 #endif
 
+#ifdef MVMC_ENABLE_FAULT_INJECTION
+  if(lanczos2HeisenbergScratch.auditEnabled) {
+    const long long zeroOverlapCount =
+        AllComplexFlag == 0
+            ? Lanczos2HeisenbergZeroOverlapAuditRealCount
+            : Lanczos2HeisenbergZeroOverlapAuditComplexCount;
+    if(lanczos2HeisenbergScratch.auditedSamples <= 0 ||
+       zeroOverlapCount <= 0) {
+      fprintf(stderr,
+              "Error: Lanczos2 Heisenberg audit did not exercise all "
+              "required paths (samples=%lld, zero_overlap=%lld).\n",
+              lanczos2HeisenbergScratch.auditedSamples,zeroOverlapCount);
+      MPI_Abort(comm_parent, EXIT_FAILURE);
+    }
+    printf("Lanczos2 Heisenberg audit: %s samples=%lld "
+           "zero_overlap=%lld green2=%lld green4=%lld green6=%lld\n",
+           AllComplexFlag == 0 ? "real" : "complex",
+           lanczos2HeisenbergScratch.auditedSamples,zeroOverlapCount,
+           lanczos2HeisenbergScratch.greenCalls[0],
+           lanczos2HeisenbergScratch.greenCalls[1],
+           lanczos2HeisenbergScratch.greenCalls[2]);
+  }
+#endif
+
   if(lanczosOracleDump != NULL) fclose(lanczosOracleDump);
   Lanczos2StateSnapshotFree(&lanczos2StateSnapshot);
+  Lanczos2HeisenbergScratchFree(&lanczos2HeisenbergScratch);
 
 // calculate OO and HO at NVMCCalMode==0
   if(NVMCCalMode==0){

--- a/test/lanczos2_contract_unit.c
+++ b/test/lanczos2_contract_unit.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -16,21 +17,22 @@ static int failures = 0;
   } while (0)
 
 static Lanczos2Contract SupportedContract(void) {
-  Lanczos2Contract contract = {
-      2, /* step */
-      1, /* lanczosMode */
-      1, /* vmcCalMode */
-      0, /* orbitalGeneral */
-      0, /* nProjBF */
-      0, /* flagRBM */
-      0, /* exUpdatePath */
-      0, /* nPairHopping */
-      0, /* nExchangeCoupling */
-      0, /* nInterAll */
-      0, /* nNBodyInterAll */
-      0, /* nNBodyG */
-      0  /* nSpinFlipTransfer */
-  };
+  Lanczos2Contract contract;
+  memset(&contract, 0, sizeof(contract));
+  contract.step = 2;
+  contract.lanczosMode = 1;
+  contract.vmcCalMode = 1;
+  contract.nsite = 4;
+  contract.ne = 2;
+  contract.nQPFull = 1;
+  return contract;
+}
+
+static Lanczos2Contract SupportedHeisenbergContract(void) {
+  Lanczos2Contract contract = SupportedContract();
+  contract.exUpdatePath = 2;
+  contract.nExchangeCoupling = 4;
+  contract.nLocSpn = 4;
   return contract;
 }
 
@@ -49,6 +51,21 @@ static void CheckStatus(const Lanczos2Contract *contract,
 static void TestAllowedInputs(void) {
   Lanczos2Contract contract = SupportedContract();
   CheckStatus(&contract, LANCZOS2_CONTRACT_OK, "supported step 2");
+
+  contract = SupportedHeisenbergContract();
+  CheckStatus(&contract, LANCZOS2_CONTRACT_OK,
+              "supported pure-spin Heisenberg step 2");
+  CHECK(ClassifyLanczos2Model(&contract) ==
+            LANCZOS2_MODEL_LOCAL_SPIN_EXCHANGE,
+        "pure-spin model classification");
+
+  contract.nExchangeCoupling = 0;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_OK,
+              "supported pure-spin Ising step 2");
+
+  contract = SupportedContract();
+  CHECK(ClassifyLanczos2Model(&contract) == LANCZOS2_MODEL_ELECTRONIC_VK,
+        "electronic model classification");
 
   /*
    * Step 1 is the compatibility path: the new step-2 capability gate must not
@@ -102,6 +119,34 @@ static void TestEachUnsupportedCapability(void) {
   CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH,
               "update path");
 
+  contract = SupportedHeisenbergContract();
+  contract.nLocSpn = 3;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_PURE_LOCALIZED_SPIN,
+              "mixed localized and itinerant model");
+
+  contract = SupportedHeisenbergContract();
+  contract.nsite = 5;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_PURE_LOCALIZED_SPIN,
+              "localized spin does not cover every site");
+
+  contract = SupportedHeisenbergContract();
+  contract.nTransfer = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_TRANSFER,
+              "pure-spin Transfer");
+
+  contract = SupportedHeisenbergContract();
+  contract.nQPFull = 2;
+  CheckStatus(&contract,
+              LANCZOS2_CONTRACT_UNSUPPORTED_QUANTUM_PROJECTION,
+              "pure-spin multi-QP");
+
+  contract = SupportedHeisenbergContract();
+  contract.ne = INT_MAX;
+  contract.nsite = INT_MAX;
+  contract.nLocSpn = INT_MAX;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_PURE_LOCALIZED_SPIN,
+              "pure-spin electron-count overflow");
+
   contract = SupportedContract();
   contract.nPairHopping = 2;
   CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_PAIR_HOPPING,
@@ -129,6 +174,18 @@ static void TestEachUnsupportedCapability(void) {
   CheckStatus(
       &contract, LANCZOS2_CONTRACT_UNSUPPORTED_SPIN_FLIP_TRANSFER,
       "spin-flip Transfer");
+
+  {
+    const int unsupportedPaths[] = {1, 3, 4, 5, 6};
+    size_t i;
+    for (i = 0;
+         i < sizeof(unsupportedPaths) / sizeof(unsupportedPaths[0]); i++) {
+      contract = SupportedHeisenbergContract();
+      contract.exUpdatePath = unsupportedPaths[i];
+      CheckStatus(&contract, LANCZOS2_CONTRACT_UNSUPPORTED_UPDATE_PATH,
+                  "pure-spin unsupported update path");
+    }
+  }
 }
 
 static void TestFirstFailureIsStable(void) {
@@ -137,6 +194,12 @@ static void TestFirstFailureIsStable(void) {
   contract.nNBodyG = 1;
   CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1,
               "first-failure order");
+
+  contract = SupportedHeisenbergContract();
+  contract.lanczosMode = 2;
+  contract.nTransfer = 1;
+  CheckStatus(&contract, LANCZOS2_CONTRACT_REQUIRES_LANCZOS_MODE_1,
+              "pure-spin first-failure order");
 }
 
 int main(void) {

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -20,6 +20,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos_sector_ed.py DESTINATION $
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_step1_compat.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_real_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_complex_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_heisenberg_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projected_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projection_smoke.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nbodyg.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
@@ -556,7 +557,7 @@ add_python_vmc_test_invalid_expert_with_updates(
     NLanczosStep=2 NLanczosMode=1 NVMCCalMode=0)
 add_python_vmc_test_invalid_expert_with_updates(
     Lanczos2_InvalidUpdatePath HubbardChain_SpinJastrow
-    "NLanczosStep=2 requires NExUpdatePath=0"
+    "NLanczosStep=2 supports NExUpdatePath=0"
     NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1 NExUpdatePath=1)
 add_python_vmc_test_invalid_expert_with_updates(
     Lanczos2_InvalidFSZ HubbardChain_fsz_SpinJastrow
@@ -599,6 +600,14 @@ add_python_vmc_test_invalid_expert_with_updates(
     NLanczosStep=2 NLanczosMode=0 NVMCCalMode=1)
 set_tests_properties(Lanczos2_InvalidLanczosMode_mpi PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;MVMC_MPI_PROCS=2")
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_Heisenberg_InvalidLanczosMode HeisenbergChain_SpinJastrow
+    "NLanczosStep=2 requires NLanczosMode=1"
+    NLanczosStep=2 NLanczosMode=2 NVMCCalMode=1 NMPTrans=1)
+add_python_vmc_test_invalid_expert_with_updates(
+    Lanczos2_Heisenberg_InvalidMultiQP HeisenbergChain_SpinJastrow
+    "pure-spin mode currently requires NQPFull=1"
+    NLanczosStep=2 NLanczosMode=1 NVMCCalMode=1 NMPTrans=2)
 add_test(NAME Lanczos2_ContractPositive_TwoSz0_NonFSZ
     COMMAND ${PYTHON_EXECUTABLE} runtest_invalid_expert.py
     HubbardChain_SpinJastrow "Finish calculation." allow_success
@@ -652,6 +661,66 @@ add_test(NAME Lanczos2_Complex_ED_omp
 set_tests_properties(Lanczos2_Complex_ED_omp PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
     RESOURCE_LOCK "lanczos2_complex_ed_workdir")
+add_test(NAME Lanczos2_Heisenberg_Real_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py)
+set_tests_properties(Lanczos2_Heisenberg_Real_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_real_ed_workdir")
+add_test(NAME Lanczos2_Heisenberg_Complex_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --complex)
+set_tests_properties(Lanczos2_Heisenberg_Complex_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_complex_ed_workdir")
+add_test(NAME Lanczos2_Heisenberg_Ising_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --ising)
+set_tests_properties(Lanczos2_Heisenberg_Ising_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_ising_ed_workdir")
+add_test(NAME Lanczos2_Heisenberg_Standard_Smoke
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --standard-smoke)
+set_tests_properties(Lanczos2_Heisenberg_Standard_Smoke PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_standard_smoke_workdir")
+add_test(NAME Lanczos2_Heisenberg_InvalidLocSpin
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --invalid-locspin)
+set_tests_properties(Lanczos2_Heisenberg_InvalidLocSpin PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_invalid_locspin_workdir")
+add_test(NAME Lanczos2_Heisenberg_InvalidLocSpin_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --invalid-locspin)
+set_tests_properties(Lanczos2_Heisenberg_InvalidLocSpin_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2"
+    RESOURCE_LOCK "lanczos2_heisenberg_invalid_locspin_mpi_workdir")
+add_test(NAME Lanczos2_Heisenberg_Real_ED_omp
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py)
+set_tests_properties(Lanczos2_Heisenberg_Real_ED_omp PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_real_ed_workdir")
+add_test(NAME Lanczos2_Heisenberg_Complex_ED_omp
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --complex)
+set_tests_properties(Lanczos2_Heisenberg_Complex_ED_omp PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_complex_ed_workdir")
+add_test(NAME Lanczos2_Heisenberg_Real_ED_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py)
+set_tests_properties(Lanczos2_Heisenberg_Real_ED_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_real_ed_mpi_workdir")
+add_test(NAME Lanczos2_Heisenberg_Complex_ED_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py --complex)
+set_tests_properties(Lanczos2_Heisenberg_Complex_ED_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_complex_ed_mpi_workdir")
+add_test(NAME Lanczos2_Heisenberg_Real_ED_Split2_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py)
+set_tests_properties(Lanczos2_Heisenberg_Real_ED_Split2_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_NSPLIT_SIZE=2;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_real_ed_split2_mpi_workdir")
+add_test(NAME Lanczos2_Heisenberg_Real_ED_Rank4_mpi
+    COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_heisenberg_ed.py)
+set_tests_properties(Lanczos2_Heisenberg_Real_ED_Rank4_mpi PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=4;MVMC_LANCZOS2_STATE_CHECK=1"
+    RESOURCE_LOCK "lanczos2_heisenberg_real_ed_mpi_workdir")
 add_test(NAME Lanczos2_Projected_ED
     COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_projected_ed.py)
 set_tests_properties(Lanczos2_Projected_ED PROPERTIES

--- a/test/python/runtest_lanczos2_heisenberg_ed.py
+++ b/test/python/runtest_lanczos2_heisenberg_ed.py
@@ -1,0 +1,741 @@
+from __future__ import print_function
+
+import argparse
+import math
+import os
+import shutil
+import subprocess
+import sys
+
+import numpy as np
+
+from runtest_bf_fsz import run_vmc, update_modpara
+from runtest_lanczos2_real_ed import (
+    assert_scaled_close,
+    check_solver_output,
+    occupation_state,
+    read_ls2_oracle,
+    validate_full_enumeration,
+)
+from runtest_lanczos_sector_ed import (
+    NSITE,
+    ap_orbital_amplitude,
+    fixed_basis,
+    occupied,
+    operator_matrix_complex,
+    tj_allowed,
+)
+
+
+HUND_BONDS = (
+    (0, 1, 0.31),
+    (1, 2, -0.27),
+    (2, 3, 0.43),
+    (3, 0, 0.19),
+    (0, 2, -0.11),
+)
+EXCHANGE_BONDS = (
+    (0, 1, -0.47),
+    (1, 2, -0.63),
+    (2, 3, -0.38),
+    (3, 0, -0.56),
+    (0, 2, 0.17),
+)
+HEISENBERG_HANKEL_RESIDUAL_LIMIT = 0.8
+HEISENBERG_HANKEL_STANDARD_ERROR_LIMIT = 12.0
+ZERO_AMPLITUDE_UPS = (0, 1)
+ZERO_AMPLITUDE_DOWNS = (2, 3)
+
+
+def write_standard_input(path):
+    with open(path, "w") as destination:
+        destination.write(
+            """L = 4
+Lsub = 2
+model = "Spin"
+lattice = "chain"
+J = 1.0
+NSROptItrStep = 1
+NVMCSample = 128
+NVMCWarmUp = 16
+2Sz = 0
+RndSeed = 2468
+"""
+        )
+
+
+def read_definition_count(path, keyword):
+    with open(path) as source:
+        for line in source:
+            columns = line.split()
+            if len(columns) >= 2 and columns[0] == keyword:
+                return int(columns[1])
+    raise AssertionError("{} is missing from {}".format(keyword, path))
+
+
+def write_standard_initial(path, workdir):
+    projector_count = sum(
+        read_definition_count(
+            os.path.join(workdir, filename), keyword
+        )
+        for filename, keyword in (
+            ("gutzwilleridx.def", "NGutzwillerIdx"),
+            ("jastrowidx.def", "NJastrowIdx"),
+        )
+    )
+    orbital_count = read_definition_count(
+        os.path.join(workdir, "orbitalidx.def"), "NOrbitalIdx"
+    )
+    values = [0.0] * 6
+    for index in range(projector_count):
+        values.extend(
+            [0.07 * math.sin(0.31 * (index + 1)), 0.0, 0.0]
+        )
+    for index in range(orbital_count):
+        values.extend(
+            [
+                math.sin(0.37 * (index + 1))
+                + 0.23 * math.cos(0.19 * (index + 2)),
+                0.0,
+                0.0,
+            ]
+        )
+    with open(path, "w") as destination:
+        destination.write(
+            " ".join("{:.18e}".format(value) for value in values)
+        )
+        destination.write("\n")
+
+
+def run_standard_smoke(rootdir):
+    workdir = os.path.join(
+        rootdir, "work", "Lanczos2_Heisenberg_Standard_Smoke"
+    )
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    write_standard_input(os.path.join(workdir, "StdFace.def"))
+
+    dry_binary = os.path.join(
+        rootdir, "..", "..", "src", "mVMC", "vmcdry.out"
+    )
+    dry_process = subprocess.run(
+        [dry_binary, "StdFace.def"],
+        cwd=workdir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if dry_process.returncode != 0:
+        raise AssertionError(
+            "standard-mode generation failed:\n{}".format(
+                dry_process.stdout
+            )
+        )
+    if read_definition_count(
+        os.path.join(workdir, "locspn.def"), "NlocalSpin"
+    ) != NSITE:
+        raise AssertionError(
+            "standard-mode input did not generate a pure-spin model"
+        )
+    if read_definition_count(
+        os.path.join(workdir, "trans.def"), "NTransfer"
+    ) != 0:
+        raise AssertionError(
+            "standard-mode pure-spin input generated Transfer terms"
+        )
+    if read_definition_count(
+        os.path.join(workdir, "exchange.def"), "NExchange"
+    ) <= 0:
+        raise AssertionError(
+            "standard-mode pure-spin input generated no Exchange terms"
+        )
+
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NVMCSample": "128",
+            "NVMCWarmUp": "16",
+            "NMPTrans": "1",
+            "NSPGaussLeg": "1",
+            "NExUpdatePath": "2",
+        },
+    )
+    initial_name = "lanczos2_heisenberg_standard_init.dat"
+    write_standard_initial(
+        os.path.join(workdir, initial_name), workdir
+    )
+    process = run_vmc(
+        rootdir,
+        workdir,
+        init_path=initial_name,
+        extra_env={
+            "MVMC_LANCZOS_ORACLE_DUMP":
+                "lanczos2_heisenberg_standard_oracle.dat"
+        },
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "standard-generated Heisenberg step=2 run failed:\n{}".format(
+                process.stdout
+            )
+        )
+    required_outputs = (
+        "zvo_ls2_out_001.dat",
+        "zvo_ls2_moment_001.dat",
+    )
+    for filename in required_outputs:
+        path = os.path.join(workdir, "output", filename)
+        if not os.path.exists(path):
+            raise AssertionError(
+                "standard-generated run did not write {}".format(filename)
+            )
+        values = np.loadtxt(path)
+        if not np.all(np.isfinite(values)):
+            raise AssertionError(
+                "standard-generated {} contains non-finite data".format(
+                    filename
+                )
+            )
+    if os.path.exists(
+        os.path.join(workdir, "output", "zvo_ls_out_001.dat")
+    ):
+        raise AssertionError(
+            "standard-generated step=2 run wrote a legacy ls_out file"
+        )
+    print("Lanczos2 Heisenberg standard-mode smoke: PASS")
+    return 0
+
+
+def pure_spin_basis():
+    return [state for state in fixed_basis(2, 2) if tj_allowed(state)]
+
+
+def pair_orbitals(complex_mode):
+    orbital = np.array(
+        [
+            [
+                np.sin(0.37 * (row + 1) * (column + 2))
+                + 0.3 * np.cos(0.19 * (row + 2) * (column + 1))
+                + (
+                    0.2j * np.cos(0.23 * (row + 2) * (column + 1))
+                    if complex_mode
+                    else 0.0
+                )
+                for column in range(NSITE)
+            ]
+            for row in range(NSITE)
+        ],
+        dtype=complex if complex_mode else float,
+    )
+    # det(F[ups=(0,1), downs=(2,3)]) = 0.  The corresponding spin
+    # configuration is an intermediate state for several Exchange paths.
+    orbital[1, 3] = (
+        orbital[0, 3] * orbital[1, 2] / orbital[0, 2]
+    )
+    return orbital
+
+
+def pair_amplitude(state, orbital):
+    if not np.iscomplexobj(orbital):
+        return ap_orbital_amplitude(state, orbital)
+    ups = [site for site in range(NSITE) if occupied(state, site)]
+    downs = [
+        site for site in range(NSITE)
+        if occupied(state, site + NSITE)
+    ]
+    matrix = np.array(
+        [[orbital[up, down] for down in downs] for up in ups],
+        dtype=complex,
+    )
+    return np.linalg.det(matrix)
+
+
+def exchange_operators(left, right):
+    return (
+        [
+            ("c", left),
+            ("a", right),
+            ("c", right + NSITE),
+            ("a", left + NSITE),
+        ],
+        [
+            ("c", left + NSITE),
+            ("a", right + NSITE),
+            ("c", right),
+            ("a", left),
+        ],
+    )
+
+
+def diagonal_energy(state):
+    value = 0.0
+    for left, right, coupling in HUND_BONDS:
+        parallel = (
+            occupied(state, left) * occupied(state, right)
+            + occupied(state, left + NSITE)
+            * occupied(state, right + NSITE)
+        )
+        value -= coupling * parallel
+    return value
+
+
+def build_hamiltonian(basis, ising):
+    terms = []
+    if not ising:
+        for left, right, coupling in EXCHANGE_BONDS:
+            for operators in exchange_operators(left, right):
+                terms.append((coupling, operators))
+    hamiltonian = operator_matrix_complex(basis, terms)
+    for index, state in enumerate(basis):
+        hamiltonian[index, index] += diagonal_energy(state)
+    residual = np.max(np.abs(hamiltonian - np.conj(hamiltonian.T)))
+    if residual > 2.0e-13:
+        raise AssertionError(
+            "Heisenberg ED Hamiltonian is not Hermitian: {}".format(
+                residual
+            )
+        )
+    return hamiltonian
+
+
+def zero_amplitude_state():
+    state = 0
+    for site in ZERO_AMPLITUDE_UPS:
+        state |= 1 << site
+    for site in ZERO_AMPLITUDE_DOWNS:
+        state |= 1 << (site + NSITE)
+    return state
+
+
+def build_reference(complex_mode, ising):
+    basis = pure_spin_basis()
+    orbital = pair_orbitals(complex_mode)
+    psi = np.array(
+        [pair_amplitude(state, orbital) for state in basis],
+        dtype=complex,
+    )
+    target = zero_amplitude_state()
+    target_index = basis.index(target)
+    if abs(psi[target_index]) > 1.0e-13:
+        raise AssertionError(
+            "zero-overlap fixture amplitude is {}".format(
+                psi[target_index]
+            )
+        )
+    psi[target_index] = 0.0
+
+    hamiltonian = build_hamiltonian(basis, ising)
+    powers = [psi]
+    for _ in range(3):
+        powers.append(np.dot(hamiltonian, powers[-1]))
+    validate_full_enumeration(powers)
+
+    reference = {}
+    unconjugated = {}
+    zero_states = set()
+    for index, state in enumerate(basis):
+        if abs(psi[index]) <= 1.0e-13:
+            zero_states.add(state)
+            continue
+        values = np.array(
+            [powers[order][index] / psi[index] for order in range(4)],
+            dtype=complex,
+        )
+        unconjugated[state] = values
+        reference[state] = np.conj(values) if complex_mode else values
+
+    bridge_sources = set()
+    if not ising:
+        first_power = powers[1]
+        for source_index, source in enumerate(basis):
+            if source not in reference:
+                continue
+            coupling_to_zero = hamiltonian[target_index, source_index]
+            bridge = coupling_to_zero * first_power[target_index]
+            if abs(coupling_to_zero) > 1.0e-13 and abs(bridge) > 1.0e-10:
+                bridge_sources.add(source)
+        if not bridge_sources:
+            raise AssertionError(
+                "fixture has no nonzero bridge through its zero-overlap state"
+            )
+
+    if ising:
+        for state, values in reference.items():
+            diagonal = diagonal_energy(state)
+            expected = np.array(
+                [1.0, diagonal, diagonal ** 2, diagonal ** 3],
+                dtype=complex,
+            )
+            if not np.allclose(values, expected, rtol=2.0e-13, atol=2.0e-13):
+                raise AssertionError(
+                    "Ising local-power reduction failed for state {}".format(
+                        state
+                    )
+                )
+
+    return reference, unconjugated, zero_states, bridge_sources
+
+
+def write_locspin_rows(workdir, rows, header_count=NSITE):
+    with open(os.path.join(workdir, "locspn.def"), "w") as destination:
+        destination.write("================================\n")
+        destination.write("NlocalSpin     {}\n".format(header_count))
+        destination.write("================================\n")
+        destination.write("========i_1LocSpn_0IteElc ======\n")
+        destination.write("================================\n")
+        for site, flag in rows:
+            if flag is None:
+                destination.write("{}\n".format(site))
+            else:
+                destination.write("{:5d} {:5d}\n".format(site, flag))
+
+
+def write_locspin(workdir):
+    write_locspin_rows(
+        workdir, tuple((site, 1) for site in range(NSITE))
+    )
+
+
+def write_zero_transfer(workdir):
+    with open(os.path.join(workdir, "trans.def"), "w") as destination:
+        destination.write("========================\n")
+        destination.write("NTransfer       0\n")
+        destination.write("========================\n")
+        destination.write("========i_j_s_tijs======\n")
+        destination.write("========================\n")
+
+
+def write_bond_definition(workdir, filename, count_name, rows):
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("{}          {}\n".format(count_name, len(rows)))
+        destination.write("=============================================\n")
+        destination.write("============ i j coupling ===================\n")
+        destination.write("=============================================\n")
+        for left, right, coupling in rows:
+            destination.write(
+                "{:5d} {:5d} {:25.15f}\n".format(
+                    left, right, coupling
+                )
+            )
+
+
+def write_namelist(workdir):
+    entries = [
+        ("ModPara", "modpara.def"),
+        ("LocSpin", "locspn.def"),
+        ("Trans", "trans.def"),
+        ("Hund", "hund.def"),
+        ("Exchange", "exchange.def"),
+        ("Orbital", "orbitalidx.def"),
+        ("TransSym", "qptransidx.def"),
+    ]
+    with open(os.path.join(workdir, "namelist.def"), "w") as destination:
+        for keyword, filename in entries:
+            destination.write(
+                "{:>16}  {}\n".format(keyword, filename)
+            )
+
+
+def write_init(workdir, complex_mode):
+    values = [0.0] * 6
+    for value in pair_orbitals(complex_mode).reshape(NSITE * NSITE):
+        values.extend([value.real, value.imag, 0.0])
+    filename = (
+        "lanczos2_heisenberg_complex_init.dat"
+        if complex_mode
+        else "lanczos2_heisenberg_real_init.dat"
+    )
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write(
+            " ".join("{:.18e}".format(value) for value in values)
+        )
+        destination.write("\n")
+    return filename
+
+
+def prepare_case(rootdir, complex_mode, ising, workdir_stem=None):
+    reference_name = (
+        "BackFlow_Identity_Complex"
+        if complex_mode
+        else "BackFlow_Identity_Real"
+    )
+    reference_dir = os.path.join(rootdir, "data", reference_name)
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    split_size = os.environ.get("MVMC_NSPLIT_SIZE", "1")
+    suffix = "_Complex" if complex_mode else "_Real"
+    if ising:
+        suffix += "_Ising"
+    if split_size != "1":
+        suffix += "_Split{}".format(split_size)
+    if mpi_procs:
+        suffix += "_mpi"
+    if workdir_stem is None:
+        workdir_name = "Lanczos2_Heisenberg_ED" + suffix
+    else:
+        workdir_name = workdir_stem
+        if mpi_procs:
+            workdir_name += "_mpi"
+    workdir = os.path.join(rootdir, "work", workdir_name)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    for filename in ("modpara.def", "orbitalidx.def", "qptransidx.def"):
+        shutil.copy2(
+            os.path.join(reference_dir, filename),
+            os.path.join(workdir, filename),
+        )
+
+    write_locspin(workdir)
+    write_zero_transfer(workdir)
+    write_bond_definition(workdir, "hund.def", "NHund", HUND_BONDS)
+    write_bond_definition(
+        workdir,
+        "exchange.def",
+        "NExchange",
+        () if ising else EXCHANGE_BONDS,
+    )
+    write_namelist(workdir)
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NVMCCalMode": "1",
+            "NVMCSample": "512",
+            "NVMCWarmUp": "32",
+            "NVMCInterval": "1",
+            "Ncond": "0",
+            "2Sz": "0",
+            "NMPTrans": "1",
+            "NExUpdatePath": "2",
+            "NSplitSize": split_size,
+        },
+    )
+    return workdir, write_init(workdir, complex_mode)
+
+
+def collect_oracle_rows(workdir, dump_name, mpi_procs):
+    if not mpi_procs:
+        return read_ls2_oracle(os.path.join(workdir, dump_name))
+    rows = []
+    for rank in range(int(mpi_procs)):
+        rows.extend(
+            read_ls2_oracle(
+                os.path.join(
+                    workdir,
+                    dump_name + ".rank{:04d}".format(rank),
+                )
+            )
+        )
+    return rows
+
+
+def run_invalid_locspin(rootdir):
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    cases = (
+        (
+            "count_mismatch",
+            ((0, 1), (1, 1), (2, 0), (3, 0)),
+            "NLocalSpin header (4) does not match LocSpin flag count (2)",
+        ),
+        (
+            "invalid_site",
+            ((0, 1), (1, 1), (2, 1), (NSITE, 1)),
+            "Site index is incorrect",
+        ),
+        (
+            "invalid_flag",
+            ((0, 1), (1, 1), (2, 1), (3, 2)),
+            "LocSpin flag must be 0 or 1",
+        ),
+        (
+            "duplicate_site",
+            ((0, 1), (1, 1), (2, 1), (2, 1)),
+            "Duplicate LocSpin site index",
+        ),
+        (
+            "missing_site",
+            ((0, 1), (1, 1), (2, 1)),
+            "Missing LocSpin site index",
+        ),
+        (
+            "malformed_row",
+            ((0, 1), (1, 1), (2, 1), ("not-an-index", None)),
+            "Malformed LocSpin definition",
+        ),
+    )
+    for name, rows, expected in cases:
+        workdir, init_path = prepare_case(
+            rootdir,
+            False,
+            False,
+            workdir_stem="Lanczos2_Heisenberg_InvalidLocSpin",
+        )
+        write_locspin_rows(workdir, rows)
+        process = run_vmc(
+            rootdir,
+            workdir,
+            mpi_procs=mpi_procs,
+            init_path=init_path,
+        )
+        if process.returncode == 0:
+            raise AssertionError(
+                "invalid LocSpin case {} unexpectedly succeeded".format(name)
+            )
+        if expected not in process.stdout:
+            raise AssertionError(
+                "invalid LocSpin case {} missed diagnostic {!r}:\n{}".format(
+                    name, expected, process.stdout
+                )
+            )
+    print(
+        "Lanczos2 Heisenberg invalid LocSpin{}: PASS ({} cases)".format(
+            " MPI" if mpi_procs else "", len(cases)
+        )
+    )
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--complex", action="store_true")
+    parser.add_argument("--ising", action="store_true")
+    parser.add_argument("--standard-smoke", action="store_true")
+    parser.add_argument("--invalid-locspin", action="store_true")
+    args = parser.parse_args()
+
+    rootdir = os.getcwd()
+    if args.invalid_locspin:
+        if args.complex or args.ising or args.standard_smoke:
+            raise AssertionError(
+                "--invalid-locspin cannot be combined with other modes"
+            )
+        return run_invalid_locspin(rootdir)
+    if args.standard_smoke:
+        if args.complex or args.ising:
+            raise AssertionError(
+                "--standard-smoke cannot be combined with other modes"
+            )
+        return run_standard_smoke(rootdir)
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    workdir, init_path = prepare_case(
+        rootdir, args.complex, args.ising
+    )
+    dump_name = "lanczos2_heisenberg_oracle.dat"
+    extra_env = {"MVMC_LANCZOS_ORACLE_DUMP": dump_name}
+    if not args.ising and not mpi_procs:
+        extra_env["MVMC_LANCZOS2_HEISENBERG_AUDIT"] = "1"
+    process = run_vmc(
+        rootdir,
+        workdir,
+        mpi_procs=mpi_procs,
+        init_path=init_path,
+        extra_env=extra_env,
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "Lanczos2 Heisenberg vmc.out failed:\n{}".format(
+                process.stdout
+            )
+        )
+    if not args.ising and not mpi_procs and \
+            "Lanczos2 Heisenberg audit:" not in process.stdout:
+        raise AssertionError("Heisenberg audit completion marker is missing")
+
+    rows = collect_oracle_rows(workdir, dump_name, mpi_procs)
+    reference, unconjugated, zero_states, bridge_sources = build_reference(
+        args.complex, args.ising
+    )
+    if len(zero_states) != 1:
+        raise AssertionError(
+            "expected one zero-overlap state, got {}".format(
+                len(zero_states)
+            )
+        )
+
+    seen = {}
+    saw_imaginary = False
+    conjugation_sensitive = False
+    bridge_exercised = args.ising
+    for sample, occupation, power in rows:
+        state = occupation_state(occupation)
+        if state not in reference:
+            raise AssertionError(
+                "sample {} has zero or missing ED amplitude".format(sample)
+            )
+        for order in range(4):
+            assert_scaled_close(
+                "Heisenberg sample {} F{}".format(sample, order),
+                power[order],
+                reference[state][order],
+            )
+            if abs(power[order].imag) > 1.0e-8:
+                saw_imaginary = True
+            if abs(
+                reference[state][order] - unconjugated[state][order]
+            ) > 1.0e-6:
+                conjugation_sensitive = True
+        if occupation in seen and not np.allclose(
+            power, seen[occupation], rtol=2.0e-12, atol=2.0e-12
+        ):
+            raise AssertionError(
+                "Heisenberg local power changed for repeated occupation"
+            )
+        seen[occupation] = power
+        if state in bridge_sources:
+            bridge_exercised = True
+
+    if len(seen) != len(reference):
+        raise AssertionError(
+            "Heisenberg fixture sampled {}/{} nonzero occupations".format(
+                len(seen), len(reference)
+            )
+        )
+    if not bridge_exercised:
+        raise AssertionError(
+            "Heisenberg sampling did not exercise a nonzero zero-overlap "
+            "bridge source"
+        )
+    if args.complex and not args.ising:
+        if not saw_imaginary:
+            raise AssertionError(
+                "complex Heisenberg fixture did not exercise Im(F)"
+            )
+        if not conjugation_sensitive:
+            raise AssertionError(
+                "complex Heisenberg fixture is insensitive to conjugation"
+            )
+
+    hankel_standard_error = check_solver_output(
+        workdir,
+        rows,
+        HEISENBERG_HANKEL_RESIDUAL_LIMIT,
+        require_nontrivial_hankel=not args.ising,
+        hankel_standard_error_limit=(
+            HEISENBERG_HANKEL_STANDARD_ERROR_LIMIT
+        ),
+    )
+    print(
+        "Lanczos2 Heisenberg {}{} ED: PASS "
+        "({} samples, {} occupations, max Hankel SE={:.3f})".format(
+            "complex" if args.complex else "real",
+            " Ising" if args.ising else "",
+            len(rows),
+            len(seen),
+            hankel_standard_error,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AssertionError as error:
+        print("ERROR: {}".format(error))
+        sys.exit(1)

--- a/test/python/runtest_lanczos2_real_ed.py
+++ b/test/python/runtest_lanczos2_real_ed.py
@@ -221,7 +221,9 @@ def shift_local_power(power, shift):
     )
 
 
-def stochastic_hankel_standard_error(powers, shift):
+def stochastic_hankel_standard_error(
+        powers, shift,
+        standard_error_limit=HANKEL_STANDARD_ERROR_LIMIT):
     shifted = np.array(
         [shift_local_power(power, shift) for power in powers],
         dtype=complex,
@@ -289,11 +291,11 @@ def stochastic_hankel_standard_error(powers, shift):
         raise AssertionError(
             "stochastic Hankel diagnostic found no nontrivial comparison"
         )
-    if maximum_score >= HANKEL_STANDARD_ERROR_LIMIT:
+    if maximum_score >= standard_error_limit:
         raise AssertionError(
             "stochastic Hankel identity exceeds its block standard error: "
             "max score={} (limit={})".format(
-                maximum_score, HANKEL_STANDARD_ERROR_LIMIT
+                maximum_score, standard_error_limit
             )
         )
     return maximum_score
@@ -424,7 +426,10 @@ def assert_scaled_close(label, actual, expected, absolute=2.0e-10,
         )
 
 
-def check_solver_output(workdir, rows):
+def check_solver_output(
+        workdir, rows, hankel_residual_limit=HANKEL_RESIDUAL_LIMIT,
+        require_nontrivial_hankel=True,
+        hankel_standard_error_limit=HANKEL_STANDARD_ERROR_LIMIT):
     output_path = os.path.join(workdir, "output", "zvo_ls2_out_001.dat")
     moment_path = os.path.join(workdir, "output", "zvo_ls2_moment_001.dat")
     output = read_numeric_record(output_path)
@@ -438,11 +443,11 @@ def check_solver_output(workdir, rows):
             )
         )
     if not np.isfinite(output[16]) or \
-            output[16] >= HANKEL_RESIDUAL_LIMIT:
+            output[16] >= hankel_residual_limit:
         raise AssertionError(
             "hankel_residual is not a finite sub-unity diagnostic: "
             "{} (limit={})".format(
-                output[16], HANKEL_RESIDUAL_LIMIT
+                output[16], hankel_residual_limit
             )
         )
     if os.path.exists(os.path.join(workdir, "output", "zvo_ls_out_001.dat")):
@@ -471,8 +476,14 @@ def check_solver_output(workdir, rows):
             "shifted moment does not match centered sample-local powers: "
             "max diff={}".format(difference)
         )
-    hankel_standard_error = stochastic_hankel_standard_error(
-        [power for _, _, power in rows], basis_shift
+    hankel_standard_error = (
+        stochastic_hankel_standard_error(
+            [power for _, _, power in rows],
+            basis_shift,
+            hankel_standard_error_limit,
+        )
+        if require_nontrivial_hankel
+        else 0.0
     )
 
     overlap = expected_raw_moment[:3, :3]


### PR DESCRIPTION
## Summary

- extend `NLanczosStep=2` from the electronic `Transfer` model class added in #134 to pure localized spin-1/2 models with `NExUpdatePath=2`
- support real and complex Heisenberg/XXZ Hamiltonians represented by diagonal interactions and `Exchange`, including nonuniform couplings and the Ising limit
- add a model-aware input contract, rank-safe localized-spin validation, and a dedicated direct-contraction kernel for the local powers through `H^3`
- add independent ED oracles, zero-overlap coverage, MPI/OpenMP variants, malformed-input tests, and synchronized English/Japanese documentation

## Motivation

PR #134 added the second power-Lanczos state
`(c0 + c1 H + c2 H^2)|psi>` for electronic models with spin-conserving
`Transfer` terms. Pure localized-spin Heisenberg inputs use `Exchange` and
`NExUpdatePath=2`, so they were intentionally rejected by that initial contract.

This follow-up adds a correctness-first path for the pure-spin sector without changing the existing electronic second-Lanczos implementation or valid first-step behavior.

## Supported scope

The new model class requires:

- spin-1/2 pure localized spins with one electron per site
- `NLocalSpin=Nsite=2*Ne`
- fixed `2Sz=0`, non-FSZ pair orbitals
- `NExUpdatePath=2`
- `NTransfer=0`
- `NQPFull=1`
- `NVMCCalMode=1`, `NLanczosMode=1`, and `NLanczosStep=2`
- diagonal `CoulombIntra`, `CoulombInter`, and `Hund` terms plus `Exchange`

Mixed localized/itinerant models, pure-spin `Transfer`, `PairHop`, `InterAll`, `NBodyInterAll`, `NBodyG`, FSZ, BackFlow, RBM, grand-canonical calculations, higher spins, nonzero-magnetization sectors, and nontrivial pure-spin quantum projection remain outside this scope and fail before sampling.

## Numerical and safety design

- classify the electronic and pure-spin model classes explicitly in the second-Lanczos contract
- validate every `locspn.def` site, flag, duplicate, omission, and declared localized-spin count on rank 0, then broadcast the verdict before collective abort
- expand each exchange bond into oriented spin-exchange operators and evaluate the `H^3` local power with direct `GreenFuncN` contractions of orders 2, 4, and 6
- avoid division by intermediate wave-function amplitudes, preserving nonzero bridge contributions when an intermediate overlap vanishes
- keep dedicated real/complex scratch storage and restore sampled state across all contraction paths
- preserve the existing electronic `LSLocalQ` path and compare its `F1/F2` values with independent direct contractions in test-only audits

## Validation

- independent full-enumeration real and genuinely complex ED oracles for per-configuration `F0` through `F3`
- independent centered moments, generalized Krylov solve, energy, variance, and coefficient checks
- nonuniform XXZ, Ising-limit, repeated-bond, and intermediate zero-overlap fixtures
- Linux `OMP_NUM_THREADS=1/4`, MPI ranks 2/4, and `NSplitSize=2` checks
- malformed `locspn.def` serial/MPI coverage for count mismatch, invalid site, invalid flag, duplicate, missing site, and malformed rows
- ASan/UBSan focused suite: 6/6 passed
- focused second-Lanczos regression: 52/52 passed
- fresh full local CTest suite: 408/408 passed
- final local Heisenberg and contract suite: 15/15 passed
- final local CI-equivalent non-MPI suite: 325/325 passed
- targeted mutation checks: 7/7 expected failures detected
- English and Japanese documentation checks passed

## HPC baseline

A single-process, single-thread Intel classic 2021.10 + Intel MPI 2021.10 + MKL baseline used 4096 samples, 64 warmup samples, and three performance repetitions:

| 1D chain | `Timer[95]` median [s] | Max RSS [KiB] | `GreenFuncN(6)` calls |
|---:|---:|---:|---:|
| L=4 | 0.067400 | 136260 | 90464 |
| L=6 | 0.249720 | 136724 | 261600 |
| L=8 | 1.070800 | 136956 | 970176 |

Memory remained effectively flat. The depth-six direct contraction is the dominant future optimization target; optimization and scaling work are intentionally separated from this correctness PR.

## Review status

- [x] independent code review has no unresolved High or Medium findings
- [x] local correctness, sanitizer, MPI/OpenMP, and HPC baseline gates passed
- [x] final-head [push CI](https://github.com/issp-center-dev/mVMC/actions/runs/30419130372) passed (4/4)
- [x] final-head [pull-request CI](https://github.com/issp-center-dev/mVMC/actions/runs/30420712685) passed (4/4)
