### PR TITLE
Add singular-aware absolute Pfaffian core

### DIFF
--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories("${STDFACE_DIR}/src")
 add_definitions(-DMEXP=19937)
 
 set(SOURCES_vmcmain
-        vmcmain.c physcal_lanczos.c physcal_lanczos2.c
+        vmcmain.c absolute_pfaffian.c physcal_lanczos.c physcal_lanczos2.c
         lanczos2_contract.c splitloop.c
  )
 

--- a/src/mVMC/absolute_pfaffian.c
+++ b/src/mVMC/absolute_pfaffian.c
@@ -1,0 +1,679 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "absolute_pfaffian.h"
+
+#ifndef _BLAS_EXTERNS_H
+#ifdef _mpi_use
+#include <mpi.h>
+#else
+typedef int MPI_Comm;
+#endif
+#include "blas_externs.h"
+#endif
+
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* GCC 12 ICEs in vect_transform_reduction on this file at -O3. */
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ == 12
+/* GCC 12 ICEs while vectorizing the compensated aggregation loop at -O3. */
+#pragma GCC optimize("no-tree-loop-vectorize")
+#endif
+
+static void initialize_result(MVMCAbsolutePfaffianResult *result,
+                              uint64_t generation) {
+  result->state = MVMC_PFAFFIAN_INVALID;
+  result->inverse_valid = 0;
+  result->factor_info = 0;
+  result->inverse_info = 0;
+  result->rebuild_generation = generation;
+  result->matrix_scale = NAN;
+  result->scaled_min_pivot = NAN;
+  result->inverse_residual = NAN;
+  result->pfaffian = 0.0;
+}
+
+static int checked_square_size(int n, size_t element_size, size_t *count) {
+  size_t dimension;
+
+  if (n <= 0) return 0;
+  dimension = (size_t)n;
+  if (dimension > SIZE_MAX / dimension) return 0;
+  *count = dimension * dimension;
+  if (*count > SIZE_MAX / element_size) return 0;
+  return 1;
+}
+
+static int real_matrix_properties(const double *matrix, int n, int lda,
+                                  double *scale) {
+  int column, row;
+  double matrix_scale = 0.0;
+  double skew_error = 0.0;
+
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      const double value = matrix[row + (size_t)column * (size_t)lda];
+      if (!isfinite(value)) return -1;
+      matrix_scale = fmax(matrix_scale, fabs(value));
+    }
+  }
+  for (column = 0; column < n; ++column) {
+    skew_error = fmax(skew_error,
+                      fabs(matrix[column + (size_t)column * (size_t)lda]));
+    for (row = 0; row < column; ++row) {
+      const double pair_sum =
+          matrix[row + (size_t)column * (size_t)lda] +
+          matrix[column + (size_t)row * (size_t)lda];
+      skew_error = fmax(skew_error, fabs(pair_sum));
+    }
+  }
+  *scale = matrix_scale;
+  return skew_error <= 64.0 * DBL_EPSILON * fmax(DBL_MIN, matrix_scale);
+}
+
+static int complex_matrix_properties(const double complex *matrix, int n,
+                                     int lda, double *scale) {
+  int column, row;
+  double matrix_scale = 0.0;
+  double skew_error = 0.0;
+
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      const double complex value =
+          matrix[row + (size_t)column * (size_t)lda];
+      if (!isfinite(creal(value)) || !isfinite(cimag(value))) return -1;
+      matrix_scale = fmax(matrix_scale, cabs(value));
+    }
+  }
+  for (column = 0; column < n; ++column) {
+    skew_error = fmax(
+        skew_error,
+        cabs(matrix[column + (size_t)column * (size_t)lda]));
+    for (row = 0; row < column; ++row) {
+      const double complex pair_sum =
+          matrix[row + (size_t)column * (size_t)lda] +
+          matrix[column + (size_t)row * (size_t)lda];
+      skew_error = fmax(skew_error, cabs(pair_sum));
+    }
+  }
+  *scale = matrix_scale;
+  return skew_error <= 64.0 * DBL_EPSILON * fmax(DBL_MIN, matrix_scale);
+}
+
+static double real_inverse_residual(const double *matrix, int lda,
+                                    const double *inverse, int n) {
+  int column, inner, row;
+  double matrix_scale = 0.0;
+  double inverse_scale = 0.0;
+  double residual = 0.0;
+
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      matrix_scale = fmax(
+          matrix_scale,
+          fabs(matrix[row + (size_t)column * (size_t)lda]));
+      inverse_scale = fmax(
+          inverse_scale, fabs(inverse[row + (size_t)column * (size_t)n]));
+    }
+  }
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      double product = 0.0;
+      for (inner = 0; inner < n; ++inner) {
+        product += matrix[row + (size_t)inner * (size_t)lda] *
+                   inverse[inner + (size_t)column * (size_t)n];
+      }
+      product -= (row == column) ? 1.0 : 0.0;
+      residual = fmax(residual, fabs(product));
+    }
+  }
+  return residual /
+         fmax(1.0, (double)n * matrix_scale * inverse_scale);
+}
+
+static double complex_inverse_residual(const double complex *matrix, int lda,
+                                       const double complex *inverse, int n) {
+  int column, inner, row;
+  double matrix_scale = 0.0;
+  double inverse_scale = 0.0;
+  double residual = 0.0;
+
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      matrix_scale = fmax(
+          matrix_scale,
+          cabs(matrix[row + (size_t)column * (size_t)lda]));
+      inverse_scale = fmax(
+          inverse_scale, cabs(inverse[row + (size_t)column * (size_t)n]));
+    }
+  }
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      double complex product = 0.0;
+      for (inner = 0; inner < n; ++inner) {
+        product += matrix[row + (size_t)inner * (size_t)lda] *
+                   inverse[inner + (size_t)column * (size_t)n];
+      }
+      product -= (row == column) ? 1.0 : 0.0;
+      residual = fmax(residual, cabs(product));
+    }
+  }
+  return residual /
+         fmax(1.0, (double)n * matrix_scale * inverse_scale);
+}
+
+static double effective_pivot_tolerance(double tolerance, int n) {
+  if (tolerance > 0.0 && isfinite(tolerance)) return tolerance;
+  return 64.0 * DBL_EPSILON * (double)n;
+}
+
+static double effective_residual_tolerance(double tolerance, int n) {
+  if (tolerance > 0.0 && isfinite(tolerance)) return tolerance;
+  return 256.0 * DBL_EPSILON * (double)n;
+}
+
+int mvmc_absolute_pfaffian_strict_fp_enabled(void) {
+#ifdef __FAST_MATH__
+  return 0;
+#else
+  return 1;
+#endif
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
+    const double *matrix, int n, int lda,
+    double *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result) {
+  double *factor = NULL;
+  double *inverse_factor = NULL;
+  double *inverse_work = NULL;
+  double *factor_work = NULL;
+  int *pivots = NULL;
+  size_t matrix_count;
+  int column, row, info = 0, lwork;
+  double work_query = 0.0;
+  double pfaffian = 0.0;
+  double min_pivot = INFINITY;
+  MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_result(result, rebuild_generation);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (matrix == NULL || inverse_out == NULL || n <= 0 || (n % 2) != 0 ||
+      lda < n || inverse_lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !isfinite(residual_tolerance) ||
+      !checked_square_size(n, sizeof(*factor), &matrix_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  info = real_matrix_properties(matrix, n, lda, &result->matrix_scale);
+  if (info < 0) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+
+  factor = (double *)malloc(matrix_count * sizeof(*factor));
+  pivots = (int *)malloc((size_t)n * sizeof(*pivots));
+  if (factor == NULL || pivots == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+
+  lwork = -1;
+  M_DSKTRF("U", "P", &n, factor, &n, pivots, &work_query, &lwork, &info);
+  if (info != 0 || !isfinite(work_query) || work_query < 1.0 ||
+      work_query > (double)INT_MAX) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  lwork = (int)ceil(work_query);
+  factor_work = (double *)malloc((size_t)lwork * sizeof(*factor_work));
+  if (factor_work == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+
+  M_DSKTRF("U", "P", &n, factor, &n, pivots, factor_work, &lwork, &info);
+  result->factor_info = info;
+  if (info < 0) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_SINGULAR;
+    result->scaled_min_pivot = 0.0;
+    result->pfaffian = 0.0;
+    goto cleanup;
+  }
+
+  utu2pfa_d(n, factor, n, pivots, &pfaffian);
+  if (!isfinite(pfaffian)) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    goto cleanup;
+  }
+  result->pfaffian = pfaffian;
+  for (row = 0; row < n; row += 2) {
+    min_pivot = fmin(min_pivot,
+                     fabs(factor[row + (size_t)(row + 1) * (size_t)n]));
+  }
+  result->scaled_min_pivot =
+      min_pivot / fmax(result->matrix_scale, DBL_MIN);
+
+  if (!isfinite(result->scaled_min_pivot)) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    goto cleanup;
+  }
+  if (result->scaled_min_pivot <
+      effective_pivot_tolerance(scaled_pivot_tolerance, n)) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+
+  free(factor_work);
+  factor_work = NULL;
+  inverse_factor =
+      (double *)malloc(matrix_count * sizeof(*inverse_factor));
+  if (inverse_factor == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      inverse_factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+  M_DGETRF(&n, &n, inverse_factor, &n, pivots, &info);
+  result->inverse_info = info;
+  if (info < 0) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  lwork = -1;
+  M_DGETRI(&n, inverse_factor, &n, pivots, &work_query, &lwork, &info);
+  result->inverse_info = info;
+  if (info < 0 || !isfinite(work_query) || work_query < 1.0 ||
+      work_query > (double)INT_MAX) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  lwork = (int)ceil(work_query);
+  inverse_work = (double *)malloc((size_t)lwork * sizeof(*inverse_work));
+  if (inverse_work == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+  M_DGETRI(&n, inverse_factor, &n, pivots, inverse_work, &lwork, &info);
+  result->inverse_info = info;
+  if (info < 0) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  result->inverse_residual =
+      real_inverse_residual(matrix, lda, inverse_factor, n);
+  if (!isfinite(result->inverse_residual)) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    goto cleanup;
+  }
+  if (result->inverse_residual >
+      effective_residual_tolerance(residual_tolerance, n)) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      inverse_out[row + (size_t)column * (size_t)inverse_lda] =
+          inverse_factor[row + (size_t)column * (size_t)n];
+    }
+  }
+  result->state = MVMC_PFAFFIAN_REGULAR;
+  result->inverse_valid = 1;
+
+cleanup:
+  free(factor_work);
+  free(pivots);
+  free(inverse_work);
+  free(inverse_factor);
+  free(factor);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
+    const double complex *matrix, int n, int lda,
+    double complex *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result) {
+  double complex *factor = NULL;
+  double complex *inverse_factor = NULL;
+  double complex *inverse_work = NULL;
+  double complex *factor_work = NULL;
+  int *pivots = NULL;
+  size_t matrix_count;
+  int column, row, info = 0, lwork;
+  double complex work_query = 0.0;
+  double complex pfaffian = 0.0;
+  double min_pivot = INFINITY;
+  MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_result(result, rebuild_generation);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (matrix == NULL || inverse_out == NULL || n <= 0 || (n % 2) != 0 ||
+      lda < n || inverse_lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !isfinite(residual_tolerance) ||
+      !checked_square_size(n, sizeof(*factor), &matrix_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  info = complex_matrix_properties(matrix, n, lda, &result->matrix_scale);
+  if (info < 0) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+
+  factor = (double complex *)malloc(matrix_count * sizeof(*factor));
+  pivots = (int *)malloc((size_t)n * sizeof(*pivots));
+  if (factor == NULL || pivots == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+
+  lwork = -1;
+  M_ZSKTRF("U", "P", &n, factor, &n, pivots, &work_query, &lwork, &info);
+  if (info != 0 || !isfinite(creal(work_query)) || cimag(work_query) != 0.0 ||
+      creal(work_query) < 1.0 || creal(work_query) > (double)INT_MAX) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  lwork = (int)ceil(creal(work_query));
+  factor_work =
+      (double complex *)malloc((size_t)lwork * sizeof(*factor_work));
+  if (factor_work == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+
+  M_ZSKTRF("U", "P", &n, factor, &n, pivots, factor_work, &lwork, &info);
+  result->factor_info = info;
+  if (info < 0) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_SINGULAR;
+    result->scaled_min_pivot = 0.0;
+    result->pfaffian = 0.0;
+    goto cleanup;
+  }
+
+  utu2pfa_z(n, factor, n, pivots, &pfaffian);
+  if (!isfinite(creal(pfaffian)) || !isfinite(cimag(pfaffian))) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    goto cleanup;
+  }
+  result->pfaffian = pfaffian;
+  for (row = 0; row < n; row += 2) {
+    min_pivot = fmin(
+        min_pivot,
+        cabs(factor[row + (size_t)(row + 1) * (size_t)n]));
+  }
+  result->scaled_min_pivot =
+      min_pivot / fmax(result->matrix_scale, DBL_MIN);
+
+  if (!isfinite(result->scaled_min_pivot)) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    goto cleanup;
+  }
+  if (result->scaled_min_pivot <
+      effective_pivot_tolerance(scaled_pivot_tolerance, n)) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+
+  free(factor_work);
+  factor_work = NULL;
+  inverse_factor =
+      (double complex *)malloc(matrix_count * sizeof(*inverse_factor));
+  if (inverse_factor == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      inverse_factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+  M_ZGETRF(&n, &n, inverse_factor, &n, pivots, &info);
+  result->inverse_info = info;
+  if (info < 0) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  lwork = -1;
+  M_ZGETRI(&n, inverse_factor, &n, pivots, &work_query, &lwork, &info);
+  result->inverse_info = info;
+  if (info < 0 || !isfinite(creal(work_query)) ||
+      cimag(work_query) != 0.0 || creal(work_query) < 1.0 ||
+      creal(work_query) > (double)INT_MAX) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  lwork = (int)ceil(creal(work_query));
+  inverse_work =
+      (double complex *)malloc((size_t)lwork * sizeof(*inverse_work));
+  if (inverse_work == NULL) {
+    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    goto cleanup;
+  }
+  M_ZGETRI(&n, inverse_factor, &n, pivots, inverse_work, &lwork, &info);
+  result->inverse_info = info;
+  if (info < 0) {
+    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    goto cleanup;
+  }
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  result->inverse_residual =
+      complex_inverse_residual(matrix, lda, inverse_factor, n);
+  if (!isfinite(result->inverse_residual)) {
+    result->state = MVMC_PFAFFIAN_NONFINITE;
+    goto cleanup;
+  }
+  if (result->inverse_residual >
+      effective_residual_tolerance(residual_tolerance, n)) {
+    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      inverse_out[row + (size_t)column * (size_t)inverse_lda] =
+          inverse_factor[row + (size_t)column * (size_t)n];
+    }
+  }
+  result->state = MVMC_PFAFFIAN_REGULAR;
+  result->inverse_valid = 1;
+
+cleanup:
+  free(factor_work);
+  free(pivots);
+  free(inverse_work);
+  free(inverse_factor);
+  free(factor);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_projected_amplitude(
+    const MVMCAbsolutePfaffianResult *components,
+    const double complex *weights, size_t component_count,
+    MVMCProjectedAmplitudeResult *result) {
+  size_t index;
+  double real_sum = 0.0, real_compensation = 0.0;
+  double imag_sum = 0.0, imag_compensation = 0.0;
+  double abs_sum = 0.0, abs_compensation = 0.0;
+  MVMCProjectedAmplitudeResult accumulated;
+
+  if (result == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  memset(result, 0, sizeof(*result));
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (components == NULL || weights == NULL || component_count == 0) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  memset(&accumulated, 0, sizeof(accumulated));
+  for (index = 0; index < component_count; ++index) {
+    double complex term;
+    double value, corrected, updated;
+
+    if (!isfinite(creal(weights[index])) ||
+        !isfinite(cimag(weights[index])) ||
+        !isfinite(creal(components[index].pfaffian)) ||
+        !isfinite(cimag(components[index].pfaffian)) ||
+        components[index].state == MVMC_PFAFFIAN_NONFINITE ||
+        components[index].state == MVMC_PFAFFIAN_INVALID) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    switch (components[index].state) {
+      case MVMC_PFAFFIAN_REGULAR:
+        ++accumulated.regular_count;
+        break;
+      case MVMC_PFAFFIAN_NEAR_SINGULAR:
+        ++accumulated.near_singular_count;
+        break;
+      case MVMC_PFAFFIAN_SINGULAR:
+        if (components[index].pfaffian != 0.0) {
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+        ++accumulated.singular_count;
+        break;
+      default:
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+
+    term = weights[index] * components[index].pfaffian;
+    if (!isfinite(creal(term)) || !isfinite(cimag(term))) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    value = cabs(term);
+    corrected = value - abs_compensation;
+    updated = abs_sum + corrected;
+    abs_compensation = (updated - abs_sum) - corrected;
+    abs_sum = updated;
+
+    value = creal(term);
+    corrected = value - real_compensation;
+    updated = real_sum + corrected;
+    real_compensation = (updated - real_sum) - corrected;
+    real_sum = updated;
+
+    value = cimag(term);
+    corrected = value - imag_compensation;
+    updated = imag_sum + corrected;
+    imag_compensation = (updated - imag_sum) - corrected;
+    imag_sum = updated;
+  }
+  if (!isfinite(abs_sum)) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  accumulated.total = real_sum + I * imag_sum;
+  accumulated.sum_abs = abs_sum;
+  accumulated.cancellation_ratio =
+      accumulated.sum_abs == 0.0
+          ? 0.0
+          : fmin(1.0, cabs(accumulated.total) / accumulated.sum_abs);
+  accumulated.valid = 1;
+  *result = accumulated;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_projected_amplitude_slice(
+    const MVMCAbsolutePfaffianResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCProjectedAmplitudeResult *result) {
+  if (result != NULL) memset(result, 0, sizeof(*result));
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (qp_total <= 0 || qp_start < 0 || qp_end <= qp_start ||
+      qp_end > qp_total ||
+      (size_t)(qp_end - qp_start) != local_component_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return mvmc_projected_amplitude(
+      local_components, global_weights == NULL ? NULL : global_weights + qp_start,
+      local_component_count, result);
+}
+
+const char *mvmc_pfaffian_state_name(MVMCPfaffianState state) {
+  switch (state) {
+    case MVMC_PFAFFIAN_REGULAR:
+      return "REGULAR";
+    case MVMC_PFAFFIAN_NEAR_SINGULAR:
+      return "NEAR_SINGULAR";
+    case MVMC_PFAFFIAN_SINGULAR:
+      return "SINGULAR";
+    case MVMC_PFAFFIAN_NONFINITE:
+      return "NONFINITE";
+    case MVMC_PFAFFIAN_INVALID:
+      return "INVALID";
+  }
+  return "INVALID";
+}

--- a/src/mVMC/include/absolute_pfaffian.h
+++ b/src/mVMC/include/absolute_pfaffian.h
@@ -1,0 +1,102 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_ABSOLUTE_PFAFFIAN_H
+#define MVMC_ABSOLUTE_PFAFFIAN_H
+
+#include <complex.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+  MVMC_PFAFFIAN_REGULAR = 0,
+  MVMC_PFAFFIAN_NEAR_SINGULAR,
+  MVMC_PFAFFIAN_SINGULAR,
+  MVMC_PFAFFIAN_NONFINITE,
+  MVMC_PFAFFIAN_INVALID
+} MVMCPfaffianState;
+
+typedef enum {
+  MVMC_PFAFFIAN_STATUS_OK = 0,
+  MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+  MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE,
+  MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE,
+  MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE
+} MVMCPfaffianStatus;
+
+typedef struct {
+  MVMCPfaffianState state;
+  int inverse_valid;
+  int factor_info;
+  int inverse_info;
+  uint64_t rebuild_generation;
+  double matrix_scale;
+  double scaled_min_pivot;
+  double inverse_residual;
+  double complex pfaffian;
+} MVMCAbsolutePfaffianResult;
+
+typedef struct {
+  int valid;
+  double complex total;
+  double sum_abs;
+  double cancellation_ratio;
+  size_t regular_count;
+  size_t near_singular_count;
+  size_t singular_count;
+} MVMCProjectedAmplitudeResult;
+
+/*
+ * Evaluate an even-dimensional skew-symmetric matrix without modifying it.
+ * Matrices use LAPACK column-major layout.  A non-positive tolerance selects
+ * the scale-aware default.  inverse_out is modified only when inverse_valid
+ * is 1; singular, near-singular, nonfinite, and error paths leave it intact.
+ */
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
+    const double *matrix, int n, int lda,
+    double *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
+    const double complex *matrix, int n, int lda,
+    double complex *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result);
+
+/*
+ * Sum QPFullWeight[q] * PfM[q] without consulting inverse availability.
+ * The result is usable only when the returned status is OK and result->valid
+ * is 1.  Error paths leave a zeroed result with valid=0.
+ */
+MVMCPfaffianStatus mvmc_projected_amplitude(
+    const MVMCAbsolutePfaffianResult *components,
+    const double complex *weights, size_t component_count,
+    MVMCProjectedAmplitudeResult *result);
+
+/*
+ * Evaluate a rank-local contiguous QP slice against a replicated global
+ * weight array.  MPI reduction, if needed, is deliberately owned by the
+ * caller; this function never reads rank-0-only globals.
+ */
+MVMCPfaffianStatus mvmc_projected_amplitude_slice(
+    const MVMCAbsolutePfaffianResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCProjectedAmplitudeResult *result);
+
+/* False when this translation unit was compiled with fast-math semantics. */
+int mvmc_absolute_pfaffian_strict_fp_enabled(void);
+
+const char *mvmc_pfaffian_state_name(MVMCPfaffianState state);
+
+#endif /* MVMC_ABSOLUTE_PFAFFIAN_H */

--- a/src/mVMC/include/vmcmain.h
+++ b/src/mVMC/include/vmcmain.h
@@ -59,6 +59,7 @@ extern void omp_set_num_threads(int);
 #include "../../sfmt/SFMT.h"
 #include "version.h"
 #include "global.h"
+#include "absolute_pfaffian.h"
 #include "pfupdate_fsz.h"
 #include "blas_externs.h"
 

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -15,6 +15,7 @@ ifneq ($(BLIS_ROOT),)
 endif
 
 OBJS = \
+	absolute_pfaffian.o \
 	physcal_lanczos.o \
 	splitloop.o \
 	vmcmain.o \
@@ -22,6 +23,7 @@ OBJS = \
 	$(PFUPDATES) $(LTL2INV)
 
 SOURCES = \
+absolute_pfaffian.c \
 backflow.c \
 backflow_measure.c \
 backflow_nbody.c \
@@ -81,6 +83,7 @@ vmcmake_real.c \
 workspace.c
 
 HEADERS = \
+./include/absolute_pfaffian.h \
 ./include/backflow.h \
 ./include/backflow_nbody.h \
 ./include/average.h \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,4 +35,29 @@ if(MPI_FOUND)
 endif()
 add_test(NAME Lanczos2Solver_Unit COMMAND lanczos2_solver_unit)
 
+add_executable(absolute_pfaffian_unit
+    absolute_pfaffian_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_include_directories(absolute_pfaffian_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(absolute_pfaffian_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(absolute_pfaffian_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(absolute_pfaffian_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(absolute_pfaffian_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME AbsolutePfaffian_Unit COMMAND absolute_pfaffian_unit)
+if(MPI_FOUND)
+    add_test(NAME AbsolutePfaffian_Unit_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS} $<TARGET_FILE:absolute_pfaffian_unit>
+                ${MPIEXEC_POSTFLAGS})
+endif()
+
 add_subdirectory(python)

--- a/test/absolute_pfaffian_unit.c
+++ b/test/absolute_pfaffian_unit.c
@@ -1,0 +1,684 @@
+#include "absolute_pfaffian.h"
+
+#include <complex.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failure_count = 0;
+
+static MVMCAbsolutePfaffianResult component(MVMCPfaffianState state,
+                                            double complex pfaffian);
+
+#define CHECK(condition, message)                                      \
+  do {                                                                 \
+    if (!(condition)) {                                                \
+      fprintf(stderr, "FAIL: %s (line %d)\n", (message), __LINE__);   \
+      ++failure_count;                                                 \
+    }                                                                  \
+  } while (0)
+
+static int close_complex(double complex actual, double complex expected,
+                         double relative_tolerance) {
+  return cabs(actual - expected) <=
+         relative_tolerance * fmax(1.0, cabs(expected));
+}
+
+static void set_real_pair(double *matrix, int n, int row, int column,
+                          double value) {
+  matrix[row + column * n] = value;
+  matrix[column + row * n] = -value;
+}
+
+static void set_complex_pair(double complex *matrix, int n, int row,
+                             int column, double complex value) {
+  matrix[row + column * n] = value;
+  matrix[column + row * n] = -value;
+}
+
+/* Independent Laplace expansion, used only as a small dense oracle. */
+static double complex reference_pfaffian(const double complex *matrix, int n) {
+  double complex minor[64] = {0.0};
+  double complex value = 0.0;
+  int partner, old_column, old_row, new_column, new_row;
+
+  if (n == 0) return 1.0;
+  if (n == 2) return matrix[n];
+  for (partner = 1; partner < n; ++partner) {
+    new_column = 0;
+    for (old_column = 1; old_column < n; ++old_column) {
+      if (old_column == partner) continue;
+      new_row = 0;
+      for (old_row = 1; old_row < n; ++old_row) {
+        if (old_row == partner) continue;
+        minor[new_row + new_column * (n - 2)] =
+            matrix[old_row + old_column * n];
+        ++new_row;
+      }
+      ++new_column;
+    }
+    value += (partner % 2 == 1 ? 1.0 : -1.0) * matrix[partner * n] *
+             reference_pfaffian(minor, n - 2);
+  }
+  return value;
+}
+
+static int real_matrix_is_value(const double *matrix, int n, double value) {
+  int index;
+  for (index = 0; index < n * n; ++index) {
+    if (matrix[index] != value) return 0;
+  }
+  return 1;
+}
+
+static int complex_matrix_is_value(const double complex *matrix, int n,
+                                   double complex value) {
+  int index;
+  for (index = 0; index < n * n; ++index) {
+    if (matrix[index] != value) return 0;
+  }
+  return 1;
+}
+
+static void test_real_regular(void) {
+  const int n = 4;
+  double matrix[16] = {0.0};
+  double original[16];
+  double inverse[16];
+  double complex oracle_matrix[16];
+  MVMCAbsolutePfaffianResult result;
+  MVMCPfaffianStatus status;
+  int index;
+
+  set_real_pair(matrix, n, 0, 1, 2.0);
+  set_real_pair(matrix, n, 0, 2, -1.0);
+  set_real_pair(matrix, n, 0, 3, 0.5);
+  set_real_pair(matrix, n, 1, 2, 3.0);
+  set_real_pair(matrix, n, 1, 3, 4.0);
+  set_real_pair(matrix, n, 2, 3, -2.0);
+  memcpy(original, matrix, sizeof(matrix));
+  for (index = 0; index < 16; ++index) {
+    inverse[index] = 1234.0;
+    oracle_matrix[index] = matrix[index];
+  }
+
+  status = mvmc_absolute_pfaffian_real(matrix, n, n, inverse, n, 17, 0.0,
+                                        0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK, "real regular status");
+  CHECK(result.state == MVMC_PFAFFIAN_REGULAR, "real regular state");
+  CHECK(result.inverse_valid == 1, "real regular inverse valid");
+  CHECK(result.factor_info == 0 && result.inverse_info == 0,
+        "real regular backend info");
+  CHECK(result.rebuild_generation == 17, "real generation preserved");
+  CHECK(close_complex(result.pfaffian,
+                      reference_pfaffian(oracle_matrix, n), 1.0e-13),
+        "real Pfaffian matches independent dense oracle");
+  CHECK(result.inverse_residual < 1.0e-13, "real inverse residual");
+  CHECK(memcmp(matrix, original, sizeof(matrix)) == 0,
+        "real source matrix remains unchanged");
+}
+
+static void test_complex_regular(void) {
+  const int n = 4;
+  double complex matrix[16] = {0.0};
+  double complex original[16];
+  double complex inverse[16];
+  MVMCAbsolutePfaffianResult result;
+  MVMCPfaffianStatus status;
+  int index;
+
+  set_complex_pair(matrix, n, 0, 1, 1.0 + 0.5 * I);
+  set_complex_pair(matrix, n, 0, 2, -0.25 + 0.75 * I);
+  set_complex_pair(matrix, n, 0, 3, 2.0 - 0.5 * I);
+  set_complex_pair(matrix, n, 1, 2, 0.5 + 1.25 * I);
+  set_complex_pair(matrix, n, 1, 3, -1.0 + 0.25 * I);
+  set_complex_pair(matrix, n, 2, 3, 1.5 - 0.75 * I);
+  memcpy(original, matrix, sizeof(matrix));
+  for (index = 0; index < 16; ++index) inverse[index] = 1234.0 + I;
+
+  status = mvmc_absolute_pfaffian_complex(
+      matrix, n, n, inverse, n, 23, 0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK, "complex regular status");
+  CHECK(result.state == MVMC_PFAFFIAN_REGULAR, "complex regular state");
+  CHECK(result.inverse_valid == 1, "complex regular inverse valid");
+  CHECK(result.factor_info == 0 && result.inverse_info == 0,
+        "complex regular backend info");
+  CHECK(result.rebuild_generation == 23, "complex generation preserved");
+  CHECK(close_complex(result.pfaffian, reference_pfaffian(matrix, n),
+                      2.0e-13),
+        "complex Pfaffian matches independent dense oracle");
+  CHECK(result.inverse_residual < 1.0e-13, "complex inverse residual");
+  CHECK(memcmp(matrix, original, sizeof(matrix)) == 0,
+        "complex source matrix remains unchanged");
+}
+
+static void test_dense_six_by_six(void) {
+  const int n = 6;
+  double matrix[36] = {0.0};
+  double inverse[36];
+  double complex complex_matrix[36] = {0.0};
+  double complex complex_inverse[36];
+  MVMCAbsolutePfaffianResult result;
+  int column, row;
+
+  for (column = 1; column < n; ++column) {
+    for (row = 0; row < column; ++row) {
+      const double value = 0.17 * (double)(row + 1) +
+                           0.31 * (double)(column + 1) +
+                           0.07 * (double)(row * column + 1);
+      set_real_pair(matrix, n, row, column, value);
+      set_complex_pair(complex_matrix, n, row, column,
+                       value + I * (0.11 * (double)(column - row)));
+    }
+  }
+  CHECK(mvmc_absolute_pfaffian_real(matrix, n, n, inverse, n, 25, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "6x6 real status");
+  CHECK(result.state == MVMC_PFAFFIAN_REGULAR, "6x6 real regular");
+  for (column = 0; column < n * n; ++column) {
+    complex_inverse[column] = matrix[column];
+  }
+  CHECK(close_complex(result.pfaffian,
+                      reference_pfaffian(complex_inverse, n), 5.0e-12),
+        "6x6 real Pfaffian matches recursive oracle");
+
+  CHECK(mvmc_absolute_pfaffian_complex(
+            complex_matrix, n, n, complex_inverse, n, 26, 0.0, 0.0,
+            &result) == MVMC_PFAFFIAN_STATUS_OK,
+        "6x6 complex status");
+  CHECK(result.state == MVMC_PFAFFIAN_REGULAR, "6x6 complex regular");
+  CHECK(close_complex(result.pfaffian,
+                      reference_pfaffian(complex_matrix, n), 5.0e-12),
+        "6x6 complex Pfaffian matches recursive oracle");
+}
+
+static double deterministic_value(uint64_t *state) {
+  *state = *state * UINT64_C(6364136223846793005) +
+           UINT64_C(1442695040888963407);
+  return (double)((*state >> 11) & UINT64_C(0x1fffff)) /
+             (double)UINT64_C(0x1fffff) -
+         0.5;
+}
+
+static void test_dense_oracle_stress(void) {
+  double matrix[64];
+  double inverse[64];
+  double complex complex_matrix[64];
+  double complex complex_inverse[64];
+  MVMCAbsolutePfaffianResult result;
+  uint64_t random_state = UINT64_C(0x728f31a5c49dbe07);
+  int n, sample, column, row;
+
+  for (n = 2; n <= 8; n += 2) {
+    for (sample = 0; sample < 16; ++sample) {
+      memset(matrix, 0, sizeof(matrix));
+      memset(complex_matrix, 0, sizeof(complex_matrix));
+      for (column = 1; column < n; ++column) {
+        for (row = 0; row < column; ++row) {
+          double real_part = deterministic_value(&random_state);
+          double imag_part = 0.5 * deterministic_value(&random_state);
+          if ((row % 2) == 0 && column == row + 1) real_part += 2.0;
+          set_real_pair(matrix, n, row, column, real_part);
+          set_complex_pair(complex_matrix, n, row, column,
+                           real_part + I * imag_part);
+        }
+      }
+
+      CHECK(mvmc_absolute_pfaffian_real(
+                matrix, n, n, inverse, n, (uint64_t)sample, 0.0, 0.0,
+                &result) == MVMC_PFAFFIAN_STATUS_OK,
+            "dense real stress status");
+      CHECK(result.state == MVMC_PFAFFIAN_REGULAR,
+            "dense real stress remains regular");
+      for (column = 0; column < n * n; ++column) {
+        complex_inverse[column] = matrix[column];
+      }
+      CHECK(close_complex(result.pfaffian,
+                          reference_pfaffian(complex_inverse, n), 2.0e-11),
+            "dense real stress Pfaffian sign matches oracle");
+
+      CHECK(mvmc_absolute_pfaffian_complex(
+                complex_matrix, n, n, complex_inverse, n,
+                (uint64_t)sample, 0.0, 0.0, &result) ==
+                MVMC_PFAFFIAN_STATUS_OK,
+            "dense complex stress status");
+      CHECK(result.state == MVMC_PFAFFIAN_REGULAR,
+            "dense complex stress remains regular");
+      CHECK(close_complex(result.pfaffian,
+                          reference_pfaffian(complex_matrix, n), 3.0e-11),
+            "dense complex stress Pfaffian phase matches oracle");
+    }
+  }
+}
+
+static void test_near_singular_and_scaling(void) {
+  const int n = 4;
+  double matrix[16] = {0.0};
+  double scaled[16];
+  double inverse[16];
+  MVMCAbsolutePfaffianResult result, scaled_result;
+  int index;
+
+  set_real_pair(matrix, n, 0, 1, 1.0);
+  set_real_pair(matrix, n, 2, 3, 1.0e-15);
+  for (index = 0; index < 16; ++index) {
+    scaled[index] = matrix[index] * 1.0e100;
+    inverse[index] = 77.0;
+  }
+  CHECK(mvmc_absolute_pfaffian_real(matrix, n, n, inverse, n, 31, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "near-singular status");
+  if (result.state != MVMC_PFAFFIAN_NEAR_SINGULAR) {
+    fprintf(stderr,
+            "near diagnostic: state=%s info=%d pivot=%.17g residual=%.17g "
+            "pf=%.17g\n",
+            mvmc_pfaffian_state_name(result.state), result.factor_info,
+            result.scaled_min_pivot, result.inverse_residual,
+            creal(result.pfaffian));
+  }
+  CHECK(result.state == MVMC_PFAFFIAN_NEAR_SINGULAR,
+        "small scaled pivot is near singular");
+  CHECK(result.inverse_valid == 0, "near-singular inverse invalid");
+  CHECK(real_matrix_is_value(inverse, n, 77.0),
+        "near-singular path does not touch inverse output");
+  CHECK(close_complex(result.pfaffian, 1.0e-15, 1.0e-13),
+        "near-singular Pfaffian remains available");
+
+  for (index = 0; index < 16; ++index) inverse[index] = 88.0;
+  CHECK(mvmc_absolute_pfaffian_real(scaled, n, n, inverse, n, 32, 0.0,
+                                     0.0, &scaled_result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "scaled near-singular status");
+  if (scaled_result.state != MVMC_PFAFFIAN_NEAR_SINGULAR) {
+    fprintf(stderr,
+            "scaled near diagnostic: state=%s pivot=%.17g residual=%.17g "
+            "pf=%.17g\n",
+            mvmc_pfaffian_state_name(scaled_result.state),
+            scaled_result.scaled_min_pivot, scaled_result.inverse_residual,
+            creal(scaled_result.pfaffian));
+  }
+  CHECK(scaled_result.state == MVMC_PFAFFIAN_NEAR_SINGULAR,
+        "near-singular classification is scale aware");
+  CHECK(real_matrix_is_value(inverse, n, 88.0),
+        "scaled near-singular path does not touch inverse output");
+  CHECK(fabs(result.scaled_min_pivot - scaled_result.scaled_min_pivot) <
+            1.0e-28,
+        "scaled pivot metric is invariant under scalar rescaling");
+}
+
+static void test_singular_and_nonfinite(void) {
+  const int n = 4;
+  double matrix[16] = {0.0};
+  double complex complex_matrix[16] = {0.0};
+  double inverse[16];
+  double complex complex_inverse[16];
+  MVMCAbsolutePfaffianResult result;
+  int index;
+
+  set_real_pair(matrix, n, 0, 1, 1.0);
+  for (index = 0; index < 16; ++index) inverse[index] = 99.0;
+  CHECK(mvmc_absolute_pfaffian_real(matrix, n, n, inverse, n, 41, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "singular status");
+  CHECK(result.state == MVMC_PFAFFIAN_SINGULAR, "singular state");
+  CHECK(result.factor_info > 0, "PFAPACK singular pivot is retained");
+  CHECK(result.pfaffian == 0.0, "singular Pfaffian is exactly zero");
+  CHECK(result.inverse_valid == 0, "singular inverse invalid");
+  CHECK(real_matrix_is_value(inverse, n, 99.0),
+        "singular path performs zero inverse writes");
+
+  set_complex_pair(complex_matrix, n, 0, 1, 1.0 + I);
+  for (index = 0; index < 16; ++index) complex_inverse[index] = 6.0 + I;
+  CHECK(mvmc_absolute_pfaffian_complex(
+            complex_matrix, n, n, complex_inverse, n, 42, 0.0, 0.0,
+            &result) == MVMC_PFAFFIAN_STATUS_OK,
+        "complex singular status");
+  CHECK(result.state == MVMC_PFAFFIAN_SINGULAR,
+        "complex singular state");
+  CHECK(result.pfaffian == 0.0 && result.inverse_valid == 0,
+        "complex singular Pfaffian and inverse contract");
+  CHECK(complex_matrix_is_value(complex_inverse, n, 6.0 + I),
+        "complex singular path performs zero inverse writes");
+
+  complex_matrix[0 + 1 * n] = NAN + 0.0 * I;
+  complex_matrix[1 + 0 * n] = -NAN + 0.0 * I;
+  for (index = 0; index < 16; ++index) complex_inverse[index] = 5.0 + I;
+  CHECK(mvmc_absolute_pfaffian_complex(
+            complex_matrix, n, n, complex_inverse, n, 42, 0.0, 0.0,
+            &result) == MVMC_PFAFFIAN_STATUS_OK,
+        "nonfinite input is a numerical classification");
+  CHECK(result.state == MVMC_PFAFFIAN_NONFINITE, "nonfinite state");
+  CHECK(result.inverse_valid == 0, "nonfinite inverse invalid");
+  CHECK(complex_matrix_is_value(complex_inverse, n, 5.0 + I),
+        "nonfinite path does not touch inverse output");
+}
+
+static void test_singular_inverse_guard_page(void) {
+  const int n = 4;
+  double matrix[16] = {0.0};
+  MVMCAbsolutePfaffianResult result;
+  const long page_size = sysconf(_SC_PAGESIZE);
+  void *guard_page;
+
+  CHECK(page_size > 0, "system page size is available");
+  if (page_size <= 0) return;
+  guard_page = mmap(NULL, (size_t)page_size, PROT_NONE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  CHECK(guard_page != MAP_FAILED, "inverse guard page allocation");
+  if (guard_page == MAP_FAILED) return;
+
+  set_real_pair(matrix, n, 0, 1, 1.0);
+  CHECK(mvmc_absolute_pfaffian_real(matrix, n, n, (double *)guard_page, n,
+                                     43, 0.0, 0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "singular evaluation succeeds with inaccessible inverse output");
+  CHECK(result.state == MVMC_PFAFFIAN_SINGULAR &&
+            result.inverse_valid == 0,
+        "singular guard-page state");
+  CHECK(munmap(guard_page, (size_t)page_size) == 0,
+        "inverse guard page cleanup");
+}
+
+static void test_state_transitions(void) {
+  const int n = 4;
+  double matrix[16] = {0.0};
+  double inverse[16];
+  MVMCAbsolutePfaffianResult result;
+  const MVMCPfaffianState expected[] = {
+      MVMC_PFAFFIAN_REGULAR, MVMC_PFAFFIAN_REGULAR,
+      MVMC_PFAFFIAN_SINGULAR, MVMC_PFAFFIAN_REGULAR,
+      MVMC_PFAFFIAN_SINGULAR, MVMC_PFAFFIAN_SINGULAR};
+  const double second_pivot[] = {1.0, 0.5, 0.0, 0.25, 0.0, 0.0};
+  int step;
+
+  for (step = 0; step < 6; ++step) {
+    memset(matrix, 0, sizeof(matrix));
+    set_real_pair(matrix, n, 0, 1, 1.0);
+    if (second_pivot[step] != 0.0) {
+      set_real_pair(matrix, n, 2, 3, second_pivot[step]);
+    }
+    CHECK(mvmc_absolute_pfaffian_real(
+              matrix, n, n, inverse, n, (uint64_t)(100 + step), 0.0, 0.0,
+              &result) == MVMC_PFAFFIAN_STATUS_OK,
+          "state transition evaluation status");
+    CHECK(result.state == expected[step],
+          "R-to-R, R-to-S, S-to-R, or S-to-S transition state");
+    CHECK(result.rebuild_generation == (uint64_t)(100 + step),
+          "transition generation increments");
+  }
+}
+
+static void test_invalid_arguments(void) {
+  double matrix[16] = {0.0};
+  double inverse[16] = {0.0};
+  MVMCAbsolutePfaffianResult result;
+
+  CHECK(mvmc_absolute_pfaffian_real(matrix, 0, 0, inverse, 0, 0, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "zero dimension rejected");
+  CHECK(mvmc_absolute_pfaffian_real(matrix, -2, 1, inverse, 1, 0, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "negative dimension rejected");
+  CHECK(mvmc_absolute_pfaffian_real(matrix, 3, 3, inverse, 3, 0, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "odd dimension rejected");
+  CHECK(mvmc_absolute_pfaffian_real(matrix, 4, 3, inverse, 4, 0, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "short source leading dimension rejected");
+  CHECK(mvmc_absolute_pfaffian_real(matrix, INT_MAX, INT_MAX, inverse,
+                                     INT_MAX, 0, 0.0, 0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "allocation-size overflow rejected before dereference");
+  CHECK(mvmc_absolute_pfaffian_real(matrix, 4, 4, inverse, 4, 0, NAN, 0.0,
+                                     &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "nonfinite pivot tolerance rejected");
+
+  set_real_pair(matrix, 4, 0, 1, 1.0);
+  matrix[1 + 0 * 4] = 1.0;
+  CHECK(mvmc_absolute_pfaffian_real(matrix, 4, 4, inverse, 4, 0, 0.0,
+                                     0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "non-skew source rejected");
+
+  {
+    MVMCAbsolutePfaffianResult components[2];
+    double complex weights[2] = {1.0, 1.0};
+    MVMCProjectedAmplitudeResult projected;
+    components[0] = component(MVMC_PFAFFIAN_REGULAR, 1.0);
+    components[1] = component(MVMC_PFAFFIAN_REGULAR, 2.0);
+    CHECK(mvmc_projected_amplitude_slice(components, 2, weights, 0, 0, 2,
+                                          &projected) ==
+              MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+          "zero NQPFull rejected");
+    CHECK(mvmc_projected_amplitude_slice(components, 2, weights, 2, -1, 1,
+                                          &projected) ==
+              MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+          "negative local QP start rejected");
+    CHECK(mvmc_projected_amplitude_slice(components, 2, weights, 2, 0, 3,
+                                          &projected) ==
+              MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+          "local QP end beyond NQPFull rejected");
+    CHECK(mvmc_projected_amplitude_slice(components, 2, weights, 2, 1, 1,
+                                          &projected) ==
+              MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+          "empty local QP range rejected");
+    CHECK(mvmc_projected_amplitude_slice(components, 1, weights, 2, 0, 2,
+                                          &projected) ==
+              MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+          "inconsistent local count and QP range rejected");
+    CHECK(projected.valid == 0, "invalid slice result is marked invalid");
+  }
+}
+
+static MVMCAbsolutePfaffianResult component(MVMCPfaffianState state,
+                                            double complex pfaffian) {
+  MVMCAbsolutePfaffianResult result;
+  memset(&result, 0, sizeof(result));
+  result.state = state;
+  result.pfaffian = pfaffian;
+  return result;
+}
+
+static void test_projected_amplitude(void) {
+  MVMCAbsolutePfaffianResult components[4];
+  double complex weights[4];
+  MVMCProjectedAmplitudeResult result;
+
+  components[0] = component(MVMC_PFAFFIAN_REGULAR, 2.0 + 3.0 * I);
+  weights[0] = 0.5 - I;
+  CHECK(mvmc_projected_amplitude(components, weights, 1, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "NQP=1 aggregation status");
+  CHECK(result.valid == 1, "successful aggregation result is valid");
+  CHECK(close_complex(result.total, 4.0 - 0.5 * I, 1.0e-15),
+        "NQP=1 weighted amplitude");
+  CHECK(result.regular_count == 1 && result.singular_count == 0,
+        "NQP=1 state counters");
+
+  components[0] = component(MVMC_PFAFFIAN_REGULAR, 2.0);
+  components[1] = component(MVMC_PFAFFIAN_SINGULAR, 0.0);
+  components[2] = component(MVMC_PFAFFIAN_NEAR_SINGULAR, -1.0 + I);
+  components[3] = component(MVMC_PFAFFIAN_REGULAR, 3.0);
+  weights[0] = 1.0;
+  weights[1] = 7.0 - I;
+  weights[2] = I;
+  weights[3] = -0.5;
+  CHECK(mvmc_projected_amplitude(components, weights, 4, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "NQP=4 aggregation status");
+  CHECK(close_complex(result.total, -0.5 - I, 1.0e-15),
+        "one singular component does not zero total amplitude");
+  CHECK(result.regular_count == 2 && result.near_singular_count == 1 &&
+            result.singular_count == 1,
+        "NQP=4 state counters");
+
+  components[0] = component(MVMC_PFAFFIAN_REGULAR, 1.0);
+  components[1] = component(MVMC_PFAFFIAN_REGULAR, -1.0);
+  weights[0] = weights[1] = 1.0;
+  CHECK(mvmc_projected_amplitude(components, weights, 2, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "cancellation aggregation status");
+  CHECK(result.total == 0.0 && result.sum_abs == 2.0 &&
+            result.cancellation_ratio == 0.0,
+        "exact cancellation metrics");
+
+  components[1] =
+      component(MVMC_PFAFFIAN_REGULAR, -(1.0 - 1.0e-14));
+  CHECK(mvmc_projected_amplitude(components, weights, 2, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "near-cancellation aggregation status");
+  CHECK(cabs(result.total) < 1.1e-14 &&
+            result.cancellation_ratio < 6.0e-15,
+        "near-zero cancellation metric remains resolved");
+
+  components[0] = component(MVMC_PFAFFIAN_SINGULAR, 0.0);
+  components[1] = component(MVMC_PFAFFIAN_SINGULAR, 0.0);
+  CHECK(mvmc_projected_amplitude(components, weights, 2, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "all-zero aggregation status");
+  CHECK(result.total == 0.0 && result.sum_abs == 0.0 &&
+            result.singular_count == 2,
+        "all-singular total amplitude is zero");
+
+  {
+    MVMCAbsolutePfaffianResult compensated_components[6];
+    double complex compensated_weights[6];
+    const double values[6] = {1.0e16, 1.0, 1.0, 1.0, 1.0, -1.0e16};
+    int index;
+
+    for (index = 0; index < 6; ++index) {
+      compensated_components[index] =
+          component(MVMC_PFAFFIAN_REGULAR, values[index]);
+      compensated_weights[index] = 1.0;
+    }
+    CHECK(mvmc_projected_amplitude(compensated_components,
+                                   compensated_weights, 6, &result) ==
+              MVMC_PFAFFIAN_STATUS_OK,
+          "compensated aggregation status");
+    CHECK(result.valid == 1 && result.total == 4.0,
+          "compensated sum recovers terms lost by plain summation");
+  }
+
+  components[0] = component(MVMC_PFAFFIAN_REGULAR, 1.0);
+  components[1] = component(MVMC_PFAFFIAN_INVALID, 2.0);
+  weights[0] = weights[1] = 1.0;
+  CHECK(mvmc_projected_amplitude(components, weights, 2, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "invalid component rejects aggregation");
+  CHECK(result.valid == 0 && result.total == 0.0 &&
+            result.regular_count == 0,
+        "failed aggregation does not expose a partial result");
+}
+
+static void test_rank_local_projected_amplitude(void) {
+  MVMCAbsolutePfaffianResult components[4];
+  double complex weights[4] = {1.0, 2.0, -I, 0.5 + 0.25 * I};
+  MVMCProjectedAmplitudeResult local, expected;
+  double complex reduced_total;
+  double reduced_sum_abs;
+  unsigned long long local_counts[3], reduced_counts[3];
+  int rank = 0, size = 1;
+  int qp_start, qp_end;
+
+#ifdef _mpi_use
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+#endif
+  if (size != 1 && size != 2) return;
+
+  components[0] = component(MVMC_PFAFFIAN_REGULAR, 2.0);
+  components[1] = component(MVMC_PFAFFIAN_SINGULAR, 0.0);
+  components[2] = component(MVMC_PFAFFIAN_NEAR_SINGULAR, -1.0 + I);
+  components[3] = component(MVMC_PFAFFIAN_REGULAR, 3.0 - 0.5 * I);
+  qp_start = 4 * rank / size;
+  qp_end = 4 * (rank + 1) / size;
+  CHECK(mvmc_projected_amplitude_slice(
+            components + qp_start, (size_t)(qp_end - qp_start), weights, 4,
+            qp_start, qp_end, &local) == MVMC_PFAFFIAN_STATUS_OK,
+        "rank-local projected amplitude status");
+  CHECK(mvmc_projected_amplitude(components, weights, 4, &expected) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "full projected amplitude reference status");
+
+  reduced_total = local.total;
+  reduced_sum_abs = local.sum_abs;
+  local_counts[0] = (unsigned long long)local.regular_count;
+  local_counts[1] = (unsigned long long)local.near_singular_count;
+  local_counts[2] = (unsigned long long)local.singular_count;
+  memcpy(reduced_counts, local_counts, sizeof(local_counts));
+#ifdef _mpi_use
+  if (size > 1) {
+    MPI_Allreduce(&local.total, &reduced_total, 1, MPI_C_DOUBLE_COMPLEX, MPI_SUM,
+                  MPI_COMM_WORLD);
+    MPI_Allreduce(&local.sum_abs, &reduced_sum_abs, 1, MPI_DOUBLE, MPI_SUM,
+                  MPI_COMM_WORLD);
+    MPI_Allreduce(local_counts, reduced_counts, 3, MPI_UNSIGNED_LONG_LONG,
+                  MPI_SUM, MPI_COMM_WORLD);
+  }
+#endif
+  CHECK(close_complex(reduced_total, expected.total, 1.0e-15),
+        "rank-local totals reduce to full amplitude");
+  CHECK(fabs(reduced_sum_abs - expected.sum_abs) < 1.0e-14,
+        "rank-local absolute sums reduce to full metric");
+  CHECK(reduced_counts[0] == expected.regular_count &&
+            reduced_counts[1] == expected.near_singular_count &&
+            reduced_counts[2] == expected.singular_count,
+        "rank-local state counters reduce to full counters");
+}
+
+int main(int argc, char **argv) {
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    fputs("FAIL: absolute Pfaffian core requires strict floating-point "
+          "semantics\n",
+          stderr);
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+  test_real_regular();
+  test_complex_regular();
+  test_dense_six_by_six();
+  test_dense_oracle_stress();
+  test_near_singular_and_scaling();
+  test_singular_and_nonfinite();
+  test_singular_inverse_guard_page();
+  test_state_transitions();
+  test_invalid_arguments();
+  test_projected_amplitude();
+  test_rank_local_projected_amplitude();
+
+  if (failure_count != 0) {
+    fprintf(stderr, "%d absolute Pfaffian checks failed\n", failure_count);
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+  if (failure_count == 0) puts("absolute Pfaffian unit checks passed");
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add out-of-place real and complex absolute Pfaffian evaluators using PFAPACK partial factorization
- separate component Pfaffian availability from inverse-cache validity with explicit regular, near-singular, singular, and nonfinite states
- add transactional multi-QP amplitude aggregation, rank-local slice validation, compensated summation, and permanent serial/MPI tests
- compile the core as an independent translation unit and reject fast-math builds that cannot satisfy the finite-value and compensated-sum contract

## Scope

This PR provides the Phase 1 correctness core only. It does not connect the new evaluator to the production sampler or change accepted-state cache transitions. Classic sampler integration, periodic rebuild auditing, and the strictly configured Fugaku build gate remain follow-up work.

## Verification

- macOS Clang full CTest: 416/416 passed with `OMP_NUM_THREADS=1`
- macOS Clang ASan/UBSan: serial and MPI rank 2 passed
- Debian 12 arm64, GCC/GFortran 12.2, OpenMPI 4.1.4, OpenBLAS 0.3.21: Release serial/MPI unit tests and `vmc.out` build passed
- same Linux environment: no-MPI leak gate and MPI ASan/UBSan passed
- Ubuntu 24.04 amd64, GCC 13.3, OpenMPI 4.1.6, OpenBLAS 0.3.26: default `USE_GEMMT=ON` serial/MPI unit tests passed
- explicit `-ffast-math` mutation build: rejected as expected by the strict floating-point capability gate

