### PR TITLE
Add configurable path-2 update weights

### DIFF
--- a/doc/en/source/expert.rst
+++ b/doc/en/source/expert.rst
@@ -266,6 +266,7 @@ example of the file format is shown as follows.
     OneBodyG zcisajs.def
     TwoBodyG	zcisajscktaltdc.def
     NBodyG nbodyg.def
+    InUpdateWeight updateweight.def
 
 File format
 ^^^^^^^^^^^
@@ -361,6 +362,8 @@ User rules
      - Pair orbital factors :math:`f_{i\sigma_1 j\sigma_2}`.
    * - TransSym :math:`^*`
      - Translational and lattice symmetry operation.
+   * - InUpdateWeight
+     - Optional relative weights for local-update kernels.
    * - InGutzwiller
      - Initial values of Gutzwiller factors.
    * - InJastrow
@@ -797,6 +800,12 @@ Keywords and parameters
    ``Orbital`` input. It currently does not support ``LocSpin``,
    ``BackFlow``, RBM, or ``OrbitalGeneral``/FSZ inputs.
 
+   If ``InUpdateWeight`` is absent, ``NExUpdatePath=2`` uses its legacy
+   selector unchanged: exchange only for fixed-:math:`S_z` or non-FSZ
+   calculations, and equal-probability exchange/local-spin-flip for
+   ``OrbitalGeneral`` with ``2Sz=-1``. See ``updateweight.def`` below for
+   the optional weighted selector and pair-spin-flip kernel.
+
 -  ``RndSeed``
 
    **Type :** int-type
@@ -915,6 +924,55 @@ Keywords and parameters
    **Type :** int-type (default value: 0)
 
    **Description :** The number of neurons :math:`N_{\rm General RBM}` in the hidden layer of RBM.
+
+UpdateWeight file (updateweight.def)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This optional file sets relative, unnormalized probabilities for the
+local-update kernels of ``NExUpdatePath=2``. It is enabled by adding
+``InUpdateWeight updateweight.def`` to ``namelist.def``. Omitting the file
+preserves the legacy selector, random-number consumption, and ``zvo_time``
+column layout.
+
+::
+
+    ================================
+    NUpdateWeight 3
+    ================================
+    ========UpdateType Weight=======
+    ================================
+    Exchange          1.0
+    LocalSpinFlip     1.0
+    PairSpinFlip      1.0
+
+The second header line gives the number of data rows. Each following data
+row contains a supported kernel name and a finite, non-negative weight.
+Rows may appear in any order; omitted supported kernels have weight zero.
+Duplicate and unknown names, extra tokens, a non-positive total, or use with
+an update path other than 2 terminate the calculation. The weights are
+normalized internally and printed at input time.
+
+``LocalSpinFlip`` requires ``OrbitalGeneral`` and ``2Sz=-1``.
+Setting its weight to zero deliberately conserves the parity of the number
+of up spins. This is appropriate when sampling a declared fixed-parity
+sector. If the target distribution has nonzero weight in both parity
+sectors, a positive ``LocalSpinFlip`` weight is necessary, and accepted
+local-spin-flip moves must be observed; a positive proposal weight alone
+does not guarantee ergodicity.
+
+Enabling this file consumes one random number for every kernel selection,
+even when only one kernel has positive weight. Consequently, a weighted run
+does not preserve the legacy random-number stream merely because it selects
+the same kernel sequence. Random-number-stream compatibility is guaranteed
+only when ``InUpdateWeight`` is omitted.
+
+``PairSpinFlip`` flips two distinct local spins with the same initial spin.
+It additionally requires ``Ncond=0``, ``NLocalSpin=Nsite``, and ``LocSpin=1``
+at every site. A pair with opposite initial spins is counted as a rejected
+proposal; the weights are not renormalized according to the current state.
+This keeps the proposal probabilities state independent and symmetric under
+the reverse move. When this file is active, pair-spin-flip proposal and
+acceptance counters are appended to ``zvo_time``.
 
 LocSpin file (locspn.def)
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/ja/source/expert.rst
+++ b/doc/ja/source/expert.rst
@@ -262,6 +262,7 @@
     OneBodyG zcisajs.def
     TwoBodyG	zcisajscktaltdc.def
     NBodyG nbodyg.def
+    InUpdateWeight updateweight.def
 
 ファイル形式
 ^^^^^^^^^^^^
@@ -358,6 +359,8 @@
      - ペア軌道因子を指定します。
    * - TransSym :math:`^*`
      - 並進・格子対称演算子を設定します。
+   * - InUpdateWeight
+     - ローカル更新kernelの相対重みを任意指定します。
    * - InGutzwiller
      - Gutzwiller因子の初期値を設定します。
    * - InJastrow
@@ -772,6 +775,12 @@ ModParaファイル (modpara.def)
    反平行スピンの ``Orbital`` 入力が必要です。現状では ``LocSpin``、
    ``BackFlow``、RBM、``OrbitalGeneral``/FSZ入力には対応していません。
 
+   ``InUpdateWeight``を指定しない場合、``NExUpdatePath=2``の従来selectorは
+   変更されません。固定 :math:`S_z` または非FSZ計算ではEXCHANGEのみ、
+   ``OrbitalGeneral``かつ``2Sz=-1``ではEXCHANGEとLOCALSPINFLIPを等確率で
+   選びます。重み付きselectorとPAIRSPINFLIPについては後述の
+   ``updateweight.def``を参照してください。
+
 -  ``RndSeed``
 
    **形式 :** int型
@@ -879,6 +888,48 @@ ModParaファイル (modpara.def)
    **形式 :** int型 (デフォルト値=0)
 
    **説明 :** RBMの隠れ層にあるニューロン数 :math:`N_{\rm General RBM}` を指定する整数。
+
+UpdateWeight指定ファイル(updateweight.def)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``NExUpdatePath=2``で用いるローカル更新kernelの相対重みを指定する任意入力です。
+``namelist.def``へ``InUpdateWeight updateweight.def``を追加すると有効になります。
+ファイルを指定しない場合、従来のselector、乱数消費順、``zvo_time``の列構成を
+そのまま維持します。
+
+::
+
+    ================================
+    NUpdateWeight 3
+    ================================
+    ========UpdateType Weight=======
+    ================================
+    Exchange          1.0
+    LocalSpinFlip     1.0
+    PairSpinFlip      1.0
+
+2行目にdata行数を書き、6行目以降にkernel名と有限・非負の重みを指定します。
+行順は任意で、省略した対応済みkernelの重みは0です。重複名、未知の名前、余分な列、
+正でない重み合計、またはpath 2以外での使用はエラー終了します。重みは内部で正規化し、
+入力読込時に表示します。
+
+``LocalSpinFlip``には``OrbitalGeneral``と``2Sz=-1``が必要です。
+この重みを0にすると、up-spin数のparityを意図的に保存します。宣言した固定parity
+sectorだけをsampleする場合には正しい設定です。target分布が両parity sectorに
+nonzero weightを持つ場合、``LocalSpinFlip``の正の重みは必要条件であり、実際に
+acceptされたlocal-spin-flipも確認する必要があります。proposal重みが正であること
+だけではergodicityを保証しません。
+
+このファイルを有効にすると、正の重みを持つkernelが1個だけでもkernel選択ごとに
+乱数を1個消費します。したがって、選ばれるkernel列が同じでもweighted runの乱数列は
+legacy runと一致しません。乱数消費順の互換性を保証するのは``InUpdateWeight``を
+省略した場合だけです。
+
+``PairSpinFlip``は、初期spinが同じ2個の異なる局在spinを同時に反転します。さらに
+``Ncond=0``、``NLocalSpin=Nsite``、全siteで``LocSpin=1``を要求します。初期spinが
+逆向きのpairは棄却proposalとして数え、現在stateに応じた重みの再正規化は行いません。
+これによりproposal確率をstate非依存かつ逆更新と対称に保ちます。このファイルが
+有効な場合、PAIRSPINFLIPのproposal数とacceptanceを``zvo_time``末尾へ追記します。
 
 LocSpin指定ファイル(locspn.def)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/mVMC/include/global.h
+++ b/src/mVMC/include/global.h
@@ -83,6 +83,8 @@ int NVMCInterval; /* sampling interval [MCS] */
 int NVMCSample; /* the number of samples */
 int NExUpdatePath; /* update path  0: hopping, 1: hopping+exchange, 2: exchange(spin), 3: KondoGC, 6: pair hopping(doublon-only) */
 int NBlockUpdateSize; /* {DEFINED: _pf_block_update} size of block Pfaffian update */
+int FlagUpdateWeight = 0; /* optional InUpdateWeight file is active */
+double UpdateWeights[3] = {0.0, 0.0, 0.0};
 
 int RndSeed; /* seed for pseudorandom number generator */
 int NSplitSize; /* the number of inner MPI processes */
@@ -406,10 +408,11 @@ int NThread;
 int LapackLWork;
 
 /***** counter for vmcMake *****/
-int Counter[6] = {0,0,0,0,0,0};
+int Counter[8] = {0,0,0,0,0,0,0,0};
 int Counter_max = 6;
 /* 0: hopping, 1: hopping accept, 2: exchange try, 3: exchange accept */
-/* 4: local spin flip try, 5 local spin flip accept*/
+/* 4: local spin flip try, 5: local spin flip accept */
+/* 6: pair spin flip try, 7: pair spin flip accept */
 
 /***** optional BackFlow profiling counters *****/
 #define NBFProfileCounter 48

--- a/src/mVMC/include/pfupdate_two_fsz_real.h
+++ b/src/mVMC/include/pfupdate_two_fsz_real.h
@@ -12,10 +12,10 @@ void calculateNewPfMTwo_child_fsz_real(const int ma, const int s, const int mb, 
                               const int qpStart, const int qpEnd, const int qpidx,
                               double *vec_a, double *vec_b);
 void UpdateMAllTwo_fsz_real(const int ma, const int s, const int mb, const int t,
-                   const int raOld, const int rbOld,
+                   const int raOld, const int sOld, const int rbOld, const int tOld,
                    const int *eleIdx,const int*eleSpn, const int qpStart, const int qpEnd);
 void updateMAllTwo_child_fsz_real(const int ma, const int s, const int mb, const int t,
-                         const int raOld, const int rbOld,
+                         const int raOld, const int sOld, const int rbOld, const int tOld,
                          const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd, const int qpidx,
                          double *vecP, double *vecQ, double *vecS, double *vecT);
 

--- a/src/mVMC/include/readdef.h
+++ b/src/mVMC/include/readdef.h
@@ -43,7 +43,7 @@ static char cKWListOfFileNameList[][D_CharTmpReadDef]={
   //RBM
   "Orbital", "OrbitalAntiParallel",
   "OrbitalParallel", "OrbitalGeneral",
-  "TransSym", "InGutzwiller", "InJastrow", "InSpinJastrow",
+  "TransSym", "InUpdateWeight", "InGutzwiller", "InJastrow", "InSpinJastrow",
   "InDH2", "InDH4",
   //RBM
   "InChargeRBM_HiddenLayer","InChargeRBM_PhysLayer", "InChargeRBM_PhysHidden",
@@ -74,7 +74,7 @@ enum KWIdxInt{
   //RBM
   KWOrbital, KWOrbitalAntiParallel,
 	KWOrbitalParallel, KWOrbitalGeneral,
-  KWTransSym, KWInGutzwiller, KWInJastrow, KWInSpinJastrow,
+  KWTransSym, KWInUpdateWeight, KWInGutzwiller, KWInJastrow, KWInSpinJastrow,
   KWInDH2, KWInDH4,
   //RBM
   KWInChargeRBM_HiddenLayer,KWInChargeRBM_PhysLayer,KWInChargeRBM_PhysHidden,

--- a/src/mVMC/include/update_weight.h
+++ b/src/mVMC/include/update_weight.h
@@ -1,0 +1,32 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models based on many-variable Variational Monte Carlo method
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+#pragma once
+
+#include <stddef.h>
+#include <stdio.h>
+
+enum UpdateWeightIndex {
+  UpdateWeightExchange = 0,
+  UpdateWeightLocalSpinFlip,
+  UpdateWeightPairSpinFlip,
+  UpdateWeightCount
+};
+
+int ReadUpdateWeight(FILE *fp, const char *source,
+                     double weights[UpdateWeightCount],
+                     char *error, size_t errorSize);
+int ValidateUpdateWeightContract(
+    int enabled, int updatePath, int twoSz, int nsite, int nLocSpn, int ne,
+    int orbitalGeneral, const double weights[UpdateWeightCount],
+    char *error, size_t errorSize);
+int ValidateUpdateWeightLocSpin(
+    int enabled, int nsite, int nLocSpn, const int *locSpn,
+    const double weights[UpdateWeightCount], char *error, size_t errorSize);
+int SelectUpdateWeight(const double weights[UpdateWeightCount], double draw);

--- a/src/mVMC/include/vmcmain.h
+++ b/src/mVMC/include/vmcmain.h
@@ -60,6 +60,7 @@ extern void omp_set_num_threads(int);
 #include "version.h"
 #include "global.h"
 #include "absolute_pfaffian.h"
+#include "update_weight.h"
 #include "pfupdate_fsz.h"
 #include "blas_externs.h"
 
@@ -118,6 +119,7 @@ extern void omp_set_num_threads(int);
 #include "../calgrn_fsz.c"
 #include "../backflow.c"
 #include "../setmemory.c"
+#include "../update_weight.c"
 #include "../readdef.c"
 #include "../initfile.c"
 

--- a/src/mVMC/include/vmcmake.h
+++ b/src/mVMC/include/vmcmake.h
@@ -37,7 +37,7 @@ void saveEleConfigBF(const int sample, const double logIp,
                      const int *eleIdx, const int *eleCfg, const int *eleNum, const int *eleProjCnt, const int *eleProjBFCnt);
 /*[e] BackFlow */
 
-typedef enum {HOPPING,HOPPING_FSZ,EXCHANGE,LOCALSPINFLIP,SPINHOPPING,PAIRHOPPING,NONE} UpdateType;
+typedef enum {HOPPING,HOPPING_FSZ,EXCHANGE,LOCALSPINFLIP,PAIRSPINFLIP,SPINHOPPING,PAIRHOPPING,NONE} UpdateType;
 UpdateType getUpdateType(int path);
 
 #endif

--- a/src/mVMC/include/vmcmake_fsz.h
+++ b/src/mVMC/include/vmcmake_fsz.h
@@ -44,9 +44,10 @@ void CheckEleConfig_fsz(int *eleIdx, int *eleCfg, int *eleNum,int *eleSpn,MPI_Co
 int CheckEleNum_fsz(int *eleIdx, int *eleCfg, int *eleNum,int *eleSpn,MPI_Comm comm);
 void makeCandidate_LocalSpinFlip_localspin(int *mi_, int *ri_, int *rj_, int *s_,int *t_, int *rejectFlag_,
                            const int *eleIdx, const int *eleCfg,const int *eleNum,const int *eleSpn);
+void makeCandidate_PairSpinFlip_localspin(int *mi_, int *mj_, int *ri_, int *rj_, int *s_,int *t_, int *rejectFlag_,
+                           const int *eleIdx, const int *eleCfg,const int *eleNum,const int *eleSpn);
 void makeCandidate_LocalSpinFlip_conduction(int *mi_, int *ri_, int *rj_, int *s_,int *t_, int *rejectFlag_,
                            const int *eleIdx, const int *eleCfg,const int *eleNum,const int *eleSpn);
 
 
 #endif
-

--- a/src/mVMC/pfupdate_two_fsz.c
+++ b/src/mVMC/pfupdate_two_fsz.c
@@ -36,10 +36,10 @@ void calculateNewPfMTwo_child_fsz(const int ma, const int s, const int mb, const
                               const int qpStart, const int qpEnd, const int qpidx,
                               double complex *vec_a, double complex *vec_b);
 void UpdateMAllTwo_fsz(const int ma, const int s, const int mb, const int t,
-                   const int raOld, const int rbOld,
+                   const int raOld, const int sOld, const int rbOld, const int tOld,
                    const int *eleIdx,const int*eleSpn, const int qpStart, const int qpEnd);
 void updateMAllTwo_child_fsz(const int ma, const int s, const int mb, const int t,
-                         const int raOld, const int rbOld,
+                         const int raOld, const int sOld, const int rbOld, const int tOld,
                          const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd, const int qpidx,
                          double complex *vecP, double complex *vecQ, double complex *vecS, double complex *vecT);
 
@@ -192,10 +192,11 @@ void calculateNewPfMTwo_child_fsz(const int ma, const int s, const int mb, const
 }
 
 // s comp
-/* Update PfM and InvM. The ma-th electron with spin s hops from raOld to site ra=eleIdx[msa],
-   and then the mb-th electron with spin t hops from rbOld to site rb=eleIdx[msb] */
+/* Update PfM and InvM. The ma-th electron changes from (raOld,sOld) to
+   (eleIdx[ma],s), and the mb-th electron changes from (rbOld,tOld) to
+   (eleIdx[mb],t). */
 void UpdateMAllTwo_fsz(const int ma, const int s, const int mb, const int t,
-                   const int raOld, const int rbOld,
+                   const int raOld, const int sOld, const int rbOld, const int tOld,
                    const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd) {
   const int qpNum = qpEnd-qpStart;
   int qpidx;
@@ -213,7 +214,7 @@ void UpdateMAllTwo_fsz(const int ma, const int s, const int mb, const int t,
     #pragma omp for
     #pragma loop nounroll
     for(qpidx=0;qpidx<qpNum;qpidx++) {
-      updateMAllTwo_child_fsz(ma, s, mb, t, raOld, rbOld, eleIdx,eleSpn, qpStart, qpEnd, qpidx,
+      updateMAllTwo_child_fsz(ma, s, mb, t, raOld, sOld, rbOld, tOld, eleIdx,eleSpn, qpStart, qpEnd, qpidx,
                           vec1, vec2, vec3, vec4);
     }
   }
@@ -223,7 +224,7 @@ void UpdateMAllTwo_fsz(const int ma, const int s, const int mb, const int t,
 }
 
 void updateMAllTwo_child_fsz(const int ma, const int s, const int mb, const int t,
-                         const int raOld, const int rbOld,
+                         const int raOld, const int sOld, const int rbOld, const int tOld,
                          const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd, const int qpidx,
                          double complex *vecP, double complex *vecQ, double complex *vecS, double complex *vecT) {
   #pragma procedure serial
@@ -231,8 +232,8 @@ void updateMAllTwo_child_fsz(const int ma, const int s, const int mb, const int 
   const int msb = mb;//+t*Ne; fsz
   const int rsa = eleIdx[msa] + s*Nsite;
   const int rsb = eleIdx[msb] + t*Nsite;
-  const int rsaOld = raOld + s*Nsite;
-  const int rsbOld = rbOld + t*Nsite;
+  const int rsaOld = raOld + sOld*Nsite;
+  const int rsbOld = rbOld + tOld*Nsite;
   const int nsize = Nsize;
 
   const double complex *sltE = SlaterElm + (qpidx+qpStart)*Nsite2*Nsite2;;

--- a/src/mVMC/pfupdate_two_fsz_real.c
+++ b/src/mVMC/pfupdate_two_fsz_real.c
@@ -178,10 +178,11 @@ void calculateNewPfMTwo_child_fsz_real(const int ma, const int s, const int mb, 
 }
 
 // s comp
-/* Update PfM and InvM. The ma-th electron with spin s hops from raOld to site ra=eleIdx[msa],
-   and then the mb-th electron with spin t hops from rbOld to site rb=eleIdx[msb] */
+/* Update PfM and InvM. The ma-th electron changes from (raOld,sOld) to
+   (eleIdx[ma],s), and the mb-th electron changes from (rbOld,tOld) to
+   (eleIdx[mb],t). */
 void UpdateMAllTwo_fsz_real(const int ma, const int s, const int mb, const int t,
-                   const int raOld, const int rbOld,
+                   const int raOld, const int sOld, const int rbOld, const int tOld,
                    const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd) {
   const int qpNum = qpEnd-qpStart;
   int qpidx;
@@ -199,7 +200,7 @@ void UpdateMAllTwo_fsz_real(const int ma, const int s, const int mb, const int t
     #pragma omp for
     #pragma loop nounroll
     for(qpidx=0;qpidx<qpNum;qpidx++) {
-      updateMAllTwo_child_fsz_real(ma, s, mb, t, raOld, rbOld, eleIdx,eleSpn, qpStart, qpEnd, qpidx,
+      updateMAllTwo_child_fsz_real(ma, s, mb, t, raOld, sOld, rbOld, tOld, eleIdx,eleSpn, qpStart, qpEnd, qpidx,
                           vec1, vec2, vec3, vec4);
     }
   }
@@ -209,7 +210,7 @@ void UpdateMAllTwo_fsz_real(const int ma, const int s, const int mb, const int t
 }
 
 void updateMAllTwo_child_fsz_real(const int ma, const int s, const int mb, const int t,
-                         const int raOld, const int rbOld,
+                         const int raOld, const int sOld, const int rbOld, const int tOld,
                          const int *eleIdx,const int *eleSpn, const int qpStart, const int qpEnd, const int qpidx,
                          double *vecP, double *vecQ, double *vecS, double *vecT) {
   #pragma procedure serial
@@ -217,8 +218,8 @@ void updateMAllTwo_child_fsz_real(const int ma, const int s, const int mb, const
   const int msb = mb;//+t*Ne; fsz
   const int rsa = eleIdx[msa] + s*Nsite;
   const int rsb = eleIdx[msb] + t*Nsite;
-  const int rsaOld = raOld + s*Nsite;
-  const int rsbOld = rbOld + t*Nsite;
+  const int rsaOld = raOld + sOld*Nsite;
+  const int rsbOld = rbOld + tOld*Nsite;
   const int nsize = Nsize;
 
   const double *sltE = SlaterElm_real + (qpidx+qpStart)*Nsite2*Nsite2;;

--- a/src/mVMC/readdef.c
+++ b/src/mVMC/readdef.c
@@ -444,6 +444,7 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
   char *cerr;
   char ctmp[D_FileNameMax];
   char ctmp2[D_FileNameMax];
+  char updateWeightError[512];
 
   int rank, size, info = 0;
   const int nBufInt = ParamIdxInt_End;
@@ -472,6 +473,11 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
       fprintf(stderr, "  error: Definition files(*.def) are incomplete.\n");
       MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
     }
+    FlagUpdateWeight =
+        (strcmp(cFileNameListFile[KWInUpdateWeight], "") != 0);
+    UpdateWeights[UpdateWeightExchange] = 0.0;
+    UpdateWeights[UpdateWeightLocalSpinFlip] = 0.0;
+    UpdateWeights[UpdateWeightPairSpinFlip] = 0.0;
 
     for (iKWidx = 0; iKWidx < KWIdxInt_end; iKWidx++) {
       strcpy(defname, cFileNameListFile[iKWidx]);
@@ -645,6 +651,17 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
             cerr = ReadBuffInt(fp, &bufInt[IdxNQPTrans]);
             break;
 
+          case KWInUpdateWeight:
+            cerr = "";
+            updateWeightError[0] = '\0';
+            if (ReadUpdateWeight(fp, defname, UpdateWeights,
+                                 updateWeightError,
+                                 sizeof(updateWeightError)) != 0) {
+              fprintf(stderr, "Error: %s.\n", updateWeightError);
+              info = 1;
+            }
+            break;
+
           case KWOneBodyG:
             cerr = ReadBuffInt(fp, &bufInt[IdxNOneBodyG]);
             break;
@@ -781,6 +798,23 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
         fprintf(stderr, "Error: NCond (in modpara.def) must be even number.\n");
         info = 1;
       } else bufInt[IdxNe] = (bufInt[IdxNLocSpin] + bufInt[IdxNCond]) / 2;
+    }
+
+    updateWeightError[0] = '\0';
+    if (ValidateUpdateWeightContract(
+            FlagUpdateWeight, bufInt[IdxExUpdatePath], bufInt[Idx2Sz],
+            bufInt[IdxNsite], bufInt[IdxNLocSpin], bufInt[IdxNe],
+            iFlgOrbitalGeneral, UpdateWeights, updateWeightError,
+            sizeof(updateWeightError)) != 0) {
+      fprintf(stderr, "Error: %s.\n", updateWeightError);
+      info = 1;
+    } else if (FlagUpdateWeight) {
+      fprintf(stdout,
+              "  Normalized update weights: Exchange=%.17g "
+              "LocalSpinFlip=%.17g PairSpinFlip=%.17g.\n",
+              UpdateWeights[UpdateWeightExchange],
+              UpdateWeights[UpdateWeightLocalSpinFlip],
+              UpdateWeights[UpdateWeightPairSpinFlip]);
     }
 
     if (bufInt[IdxExUpdatePath] == 4 || bufInt[IdxExUpdatePath] == 5) {
@@ -955,10 +989,14 @@ int ReadDefFileNInt(char *xNameListFile, MPI_Comm comm) {
   MPI_Bcast(&hasLattice, 1, MPI_INT, 0, comm);
   MPI_Bcast(&hasBF, 1, MPI_INT, 0, comm);
   MPI_Bcast(&hasBFRange, 1, MPI_INT, 0, comm);
+  MPI_Bcast(&FlagUpdateWeight, 1, MPI_INT, 0, comm);
+  MPI_Bcast(UpdateWeights, UpdateWeightCount, MPI_DOUBLE, 0, comm);
   MPI_Bcast(bufDouble, nBufDouble, MPI_DOUBLE, 0, comm);
   MPI_Bcast(CDataFileHead, nBufChar, MPI_CHAR, 0, comm);
   MPI_Bcast(CParaFileHead, nBufChar, MPI_CHAR, 0, comm);
 #endif /* _mpi_use */
+
+  Counter_max = FlagUpdateWeight ? 8 : 6;
 
   if (ValidateNBodyCapabilities(
         bufInt[IdxNBF], bufInt[IdxNNBodyG], bufInt[IdxNNBodyInterAll],
@@ -1429,6 +1467,7 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
   int count_idx = 0;
   int bfRangeLoaded = 0;
   int rank;
+  char updateWeightError[512];
 
   MPI_Comm_rank(comm, &rank);
 
@@ -1447,6 +1486,10 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
       /*=======================================================================*/
       for (i = 0; i < IgnoreLinesInDef; i++) fgets(ctmp, sizeof(ctmp) / sizeof(char), fp);
       switch (iKWidx) {
+        case KWInUpdateWeight:
+          /* Parsed and normalized during ReadDefFileNInt(). */
+          break;
+
         case KWLocSpin: /* Read locspn.def----------------------------------------*/
           if (GetLocSpinInfo(fp, LocSpn, Nsite, NLocSpn, defname) != 0) info = 1;
           break;//locspn
@@ -1772,6 +1815,14 @@ int ReadDefFileIdxPara(char *xNameListFile, MPI_Comm comm) {
   SafeMpiBcast(ParaCoulombIntra, NTotalDefDouble, comm);
   SafeMpiBcast_fcmp(ParaQPTrans, NQPTrans, comm);
 #endif /* _mpi_use */
+
+  updateWeightError[0] = '\0';
+  if (ValidateUpdateWeightLocSpin(
+          FlagUpdateWeight, Nsite, NLocSpn, LocSpn, UpdateWeights,
+          updateWeightError, sizeof(updateWeightError)) != 0) {
+    if (rank == 0) fprintf(stderr, "Error: %s.\n", updateWeightError);
+    MPI_Abort(comm, EXIT_FAILURE);
+  }
 
   {
     int nSpinFlipTransfer = 0;

--- a/src/mVMC/update_weight.c
+++ b/src/mVMC/update_weight.c
@@ -1,0 +1,215 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models based on many-variable Variational Monte Carlo method
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include <ctype.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "include/update_weight.h"
+
+#define UPDATE_WEIGHT_LINE_MAX 512
+#define UPDATE_WEIGHT_NAME_MAX 64
+
+static const char *UpdateWeightNames[UpdateWeightCount] = {
+    "Exchange", "LocalSpinFlip", "PairSpinFlip"};
+
+static int SetUpdateWeightError(char *error, size_t errorSize,
+                                const char *format, ...) {
+  va_list arguments;
+  if (error != NULL && errorSize > 0) {
+    va_start(arguments, format);
+    vsnprintf(error, errorSize, format, arguments);
+    va_end(arguments);
+  }
+  return -1;
+}
+
+static int UpdateWeightNameIndex(const char *name) {
+  int index;
+  for (index = 0; index < UpdateWeightCount; index++) {
+    if (strcmp(name, UpdateWeightNames[index]) == 0) return index;
+  }
+  return -1;
+}
+
+static int IsBlankOrComment(const char *line) {
+  while (*line != '\0' && isspace((unsigned char)*line)) line++;
+  return *line == '\0' || *line == '#';
+}
+
+int ReadUpdateWeight(FILE *fp, const char *source,
+                     double weights[UpdateWeightCount],
+                     char *error, size_t errorSize) {
+  char line[UPDATE_WEIGHT_LINE_MAX];
+  char keyword[UPDATE_WEIGHT_NAME_MAX];
+  char extra[2];
+  int count, index, row, scanned;
+  int seen[UpdateWeightCount] = {0, 0, 0};
+  double total = 0.0;
+
+  if (fp == NULL || weights == NULL) {
+    return SetUpdateWeightError(error, errorSize,
+                                "invalid UpdateWeight parser arguments");
+  }
+  if (source == NULL) source = "UpdateWeight input";
+  for (index = 0; index < UpdateWeightCount; index++) weights[index] = 0.0;
+
+  if (fgets(line, sizeof(line), fp) == NULL ||
+      fgets(line, sizeof(line), fp) == NULL) {
+    return SetUpdateWeightError(error, errorSize,
+                                "%s: incomplete UpdateWeight header", source);
+  }
+  scanned = sscanf(line, "%63s %d %1s", keyword, &count, extra);
+  if (scanned != 2 || strcmp(keyword, "NUpdateWeight") != 0) {
+    return SetUpdateWeightError(
+        error, errorSize,
+        "%s: expected 'NUpdateWeight <count>' on header line 2", source);
+  }
+  if (count < 1 || count > UpdateWeightCount) {
+    return SetUpdateWeightError(
+        error, errorSize, "%s: NUpdateWeight must be in [1, %d] (got %d)",
+        source, UpdateWeightCount, count);
+  }
+  for (row = 0; row < 3; row++) {
+    if (fgets(line, sizeof(line), fp) == NULL) {
+      return SetUpdateWeightError(error, errorSize,
+                                  "%s: incomplete five-line header", source);
+    }
+  }
+
+  row = 0;
+  while (fgets(line, sizeof(line), fp) != NULL) {
+    double value;
+    if (IsBlankOrComment(line)) continue;
+    if (row >= count) {
+      return SetUpdateWeightError(
+          error, errorSize,
+          "%s: more data rows than NUpdateWeight=%d", source, count);
+    }
+    scanned = sscanf(line, "%63s %lf %1s", keyword, &value, extra);
+    if (scanned != 2) {
+      return SetUpdateWeightError(
+          error, errorSize, "%s: malformed UpdateWeight row %d", source,
+          row + 1);
+    }
+    index = UpdateWeightNameIndex(keyword);
+    if (index < 0) {
+      return SetUpdateWeightError(
+          error, errorSize, "%s: unknown update kernel '%s'", source,
+          keyword);
+    }
+    if (seen[index] != 0) {
+      return SetUpdateWeightError(
+          error, errorSize, "%s: duplicate update kernel '%s'", source,
+          keyword);
+    }
+    if (!isfinite(value) || value < 0.0) {
+      return SetUpdateWeightError(
+          error, errorSize,
+          "%s: weight for %s must be finite and non-negative", source,
+          keyword);
+    }
+    seen[index] = 1;
+    weights[index] = value;
+    total += value;
+    row++;
+  }
+  if (row != count) {
+    return SetUpdateWeightError(
+        error, errorSize, "%s: expected %d data rows but read %d", source,
+        count, row);
+  }
+  if (!isfinite(total) || total <= 0.0) {
+    return SetUpdateWeightError(
+        error, errorSize, "%s: total update weight must be positive", source);
+  }
+  for (index = 0; index < UpdateWeightCount; index++) {
+    weights[index] /= total;
+  }
+  return 0;
+}
+
+int ValidateUpdateWeightContract(
+    int enabled, int updatePath, int twoSz, int nsite, int nLocSpn, int ne,
+    int orbitalGeneral, const double weights[UpdateWeightCount],
+    char *error, size_t errorSize) {
+  if (!enabled) return 0;
+  if (weights == NULL) {
+    return SetUpdateWeightError(error, errorSize,
+                                "UpdateWeight values are unavailable");
+  }
+  if (updatePath != 2) {
+    return SetUpdateWeightError(
+        error, errorSize,
+        "InUpdateWeight currently requires NExUpdatePath=2 (got %d)",
+        updatePath);
+  }
+  if (weights[UpdateWeightLocalSpinFlip] > 0.0 &&
+      (twoSz != -1 || orbitalGeneral == 0)) {
+    return SetUpdateWeightError(
+        error, errorSize,
+        "LocalSpinFlip with NExUpdatePath=2 requires 2Sz=-1 and "
+        "OrbitalGeneral");
+  }
+  if (weights[UpdateWeightPairSpinFlip] <= 0.0) return 0;
+  if (twoSz != -1) {
+    return SetUpdateWeightError(
+        error, errorSize, "PairSpinFlip requires 2Sz=-1 (got %d)", twoSz);
+  }
+  if (orbitalGeneral == 0) {
+    return SetUpdateWeightError(error, errorSize,
+                                "PairSpinFlip requires OrbitalGeneral");
+  }
+  if (nsite < 2 || nLocSpn != nsite || 2LL * ne != nsite) {
+    return SetUpdateWeightError(
+        error, errorSize,
+        "PairSpinFlip requires Nsite>=2, NLocalSpin=Nsite, and Ncond=0 "
+        "(Nsite=%d, NLocalSpin=%d, 2*Ne=%lld)",
+        nsite, nLocSpn, 2LL * ne);
+  }
+  return 0;
+}
+
+int ValidateUpdateWeightLocSpin(
+    int enabled, int nsite, int nLocSpn, const int *locSpn,
+    const double weights[UpdateWeightCount], char *error, size_t errorSize) {
+  int site;
+  if (!enabled || weights == NULL ||
+      weights[UpdateWeightPairSpinFlip] <= 0.0) return 0;
+  if (locSpn == NULL || nLocSpn != nsite) {
+    return SetUpdateWeightError(
+        error, errorSize,
+        "PairSpinFlip requires one local-spin entry for every site");
+  }
+  for (site = 0; site < nsite; site++) {
+    if (locSpn[site] != 1) {
+      return SetUpdateWeightError(
+          error, errorSize,
+          "PairSpinFlip requires LocSpin=1 at every site (site %d has %d)",
+          site, locSpn[site]);
+    }
+  }
+  return 0;
+}
+
+int SelectUpdateWeight(const double weights[UpdateWeightCount], double draw) {
+  double cumulative = 0.0;
+  int index, lastPositive = -1;
+  if (weights == NULL || !isfinite(draw) || draw < 0.0 || draw >= 1.0)
+    return -1;
+  for (index = 0; index < UpdateWeightCount; index++) {
+    if (weights[index] > 0.0) lastPositive = index;
+    cumulative += weights[index];
+    if (draw < cumulative) return index;
+  }
+  return lastPositive;
+}

--- a/src/mVMC/vmcclock.c
+++ b/src/mVMC/vmcclock.c
@@ -72,17 +72,27 @@ static int ParseBFNBodyInjectionTerm(const char *value) {
 
 void OutputTime(int step) {
   time_t tx;
-  double pHop,pEx,pLSF;
+  double pHop,pEx,pLSF,pPSF;
 
   tx = time(NULL);
   if(step==0) {
-    fprintf(FileTime, "%05d  acc_hop acc_ex  acc_lsf n_hop    n_ex      n_lsf   : %s", step, ctime(&tx));
+    if(FlagUpdateWeight) {
+      fprintf(FileTime, "%05d  acc_hop acc_ex  acc_lsf n_hop    n_ex      n_lsf   acc_psf n_psf   : %s", step, ctime(&tx));
+    } else {
+      fprintf(FileTime, "%05d  acc_hop acc_ex  acc_lsf n_hop    n_ex      n_lsf   : %s", step, ctime(&tx));
+    }
   } else {
     pHop = (Counter[0] == 0) ? 0.0 : (double)Counter[1] / (double)Counter[0];
     pEx  = (Counter[2] == 0) ? 0.0 : (double)Counter[3] / (double)Counter[2];
     pLSF = (Counter[4] == 0) ? 0.0 : (double)Counter[5] / (double)Counter[4];
-    fprintf(FileTime, "%05d  %.5lf %.5lf %.5lf %-8d %-8d  %-8d: %s", step, pHop,pEx,pLSF,
-            Counter[0], Counter[2],Counter[4], ctime(&tx));
+    if(FlagUpdateWeight) {
+      pPSF = (Counter[6] == 0) ? 0.0 : (double)Counter[7] / (double)Counter[6];
+      fprintf(FileTime, "%05d  %.5lf %.5lf %.5lf %-8d %-8d  %-8d %.5lf %-8d: %s", step, pHop,pEx,pLSF,
+              Counter[0], Counter[2],Counter[4],pPSF,Counter[6], ctime(&tx));
+    } else {
+      fprintf(FileTime, "%05d  %.5lf %.5lf %.5lf %-8d %-8d  %-8d: %s", step, pHop,pEx,pLSF,
+              Counter[0], Counter[2],Counter[4], ctime(&tx));
+    }
   }
 }
 

--- a/src/mVMC/vmcmake.c
+++ b/src/mVMC/vmcmake.c
@@ -915,6 +915,13 @@ UpdateType getUpdateType(int path) {
   } else if (path==1) {
     return (genrand_real2()<0.5) ? EXCHANGE : HOPPING; /* exchange or hopping */
   } else if (path==2) {
+    if(FlagUpdateWeight) {
+      const int selected = SelectUpdateWeight(UpdateWeights, genrand_real2());
+      if(selected == UpdateWeightExchange) return EXCHANGE;
+      if(selected == UpdateWeightLocalSpinFlip) return LOCALSPINFLIP;
+      if(selected == UpdateWeightPairSpinFlip) return PAIRSPINFLIP;
+      return NONE;
+    }
     if(iFlgOrbitalGeneral==0){
       return EXCHANGE;
     }else{

--- a/src/mVMC/vmcmake_fsz.c
+++ b/src/mVMC/vmcmake_fsz.c
@@ -150,6 +150,7 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
   // Counter[0] ->  Hopping  all,      Counter[1] ->  Hopping accept
   // Counter[2] ->  exchange all,      Counter[3] ->  exchange accept
   // Counter[4] ->  localspinflip all, Counter[5] ->  localspin flip accept
+  // Counter[6] ->  pairspinflip all,  Counter[7] ->  pairspinflip accept
 
   for(outStep=0;outStep<nOutStep;outStep++) {
     for(inStep=0;inStep<nInStep;inStep++) {
@@ -325,7 +326,8 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
           // Inv already updated. Only need to get PfM again.
           updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
 #else
-          UpdateMAllTwo_fsz(mi, s, mj, t, ri, rj, TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+          UpdateMAllTwo_fsz(mi, s, mj, t, ri, s, rj, t,
+                            TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
 #endif
           StopTimer(68);
 
@@ -342,6 +344,57 @@ void VMCMakeSample_fsz(MPI_Comm comm) {
           revertEleConfig_fsz(mi,ri,rj,s,s,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
         }
         StopTimer(33);
+      }else if (updateType==PAIRSPINFLIP){
+        Counter[6]++;
+
+        StartTimer(31);
+        makeCandidate_PairSpinFlip_localspin(&mi, &mj, &ri, &rj, &s, &t,
+                              &rejectFlag, TmpEleIdx, TmpEleCfg, TmpEleNum,
+                              TmpEleSpn);
+        StopTimer(31);
+        if(rejectFlag) continue;
+
+        StartTimer(36);
+        updateEleConfig_fsz(mi,ri,ri,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+        UpdateProjCnt_fsz(ri,ri,s,t,projCntNew,TmpEleProjCnt,TmpEleNum);
+        updateEleConfig_fsz(mj,rj,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+        UpdateProjCnt_fsz(rj,rj,s,t,projCntNew,projCntNew,TmpEleNum);
+
+#ifdef _pf_block_update
+        updated_tdi_v_push_pair_z(NQPFull,
+                                  ri+t*Nsite, mi,
+                                  rj+t*Nsite, mj,
+                                  1, pfUpdator);
+        updated_tdi_v_get_pfa_z(NQPFull, pfMNew, pfUpdator);
+#else
+        CalculateNewPfMTwo2_fsz(mi, t, mj, t, pfMNew, TmpEleIdx,TmpEleSpn,
+                                qpStart,qpEnd);
+#endif
+        logIpNew = CalculateLogIP_fcmp(pfMNew,qpStart,qpEnd,comm);
+        x = LogProjRatio(projCntNew,TmpEleProjCnt);
+        w = exp(2.0*(x+creal(logIpNew-logIpOld)));
+        if( !isfinite(w) ) w = -1.0;
+
+        if(w > genrand_real2()) {
+#ifdef _pf_block_update
+          updated_tdi_v_get_pfa_z(NQPFull, PfM, pfUpdator);
+#else
+          UpdateMAllTwo_fsz(mi, t, mj, t, ri, s, rj, s,
+                            TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
+          for(i=0;i<NProj;i++) TmpEleProjCnt[i] = projCntNew[i];
+          logIpOld = logIpNew;
+          nAccept++;
+          Counter[7]++;
+        } else {
+#ifdef _pf_block_update
+          updated_tdi_v_pop_z(NQPFull, 0, pfUpdator);
+          updated_tdi_v_pop_z(NQPFull, 0, pfUpdator);
+#endif
+          revertEleConfig_fsz(mj,rj,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+          revertEleConfig_fsz(mi,ri,ri,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+        }
+        StopTimer(36);
       }else if (updateType==LOCALSPINFLIP){
         Counter[4]++;
 
@@ -2212,6 +2265,38 @@ void makeCandidate_exchange_fsz(int *mi_, int *ri_, int *rj_, int *s_, int *reje
   *rj_ = rj;
   *s_ = s;
   *rejectFlag_ = flag;
+  return;
+}
+//
+// Flip two distinct local spins with the same initial spin.  Drawing two
+// particle labels uniformly and rejecting opposite-spin pairs keeps the
+// forward and reverse proposal probabilities identical.
+void makeCandidate_PairSpinFlip_localspin(int *mi_, int *mj_, int *ri_, int *rj_, int *s_,int *t_, int *rejectFlag_,
+                           const int *eleIdx, const int *eleCfg,const int *eleNum,const int *eleSpn) {
+  int mi, mj, ri, rj, s;
+
+  if(Nsize < 2) {
+    *rejectFlag_ = 1;
+    return;
+  }
+
+  mi = gen_rand32()%Nsize;
+  do {
+    mj = gen_rand32()%Nsize;
+  } while(mj == mi);
+  ri = eleIdx[mi];
+  rj = eleIdx[mj];
+  s = eleSpn[mi];
+
+  *mi_ = mi;
+  *mj_ = mj;
+  *ri_ = ri;
+  *rj_ = rj;
+  *s_ = s;
+  *t_ = 1-s;
+  *rejectFlag_ = (eleSpn[mj] != s || LocSpn[ri] == 0 || LocSpn[rj] == 0);
+  (void)eleCfg;
+  (void)eleNum;
   return;
 }
 //

--- a/src/mVMC/vmcmake_fsz_real.c
+++ b/src/mVMC/vmcmake_fsz_real.c
@@ -134,6 +134,7 @@ void VMCMakeSample_fsz_real(MPI_Comm comm) {
   // Counter[0] ->  Hopping  all,      Counter[1] ->  Hopping accept
   // Counter[2] ->  exchange all,      Counter[3] ->  exchange accept
   // Counter[4] ->  localspinflip all, Counter[5] ->  localspin flip accept
+  // Counter[6] ->  pairspinflip all,  Counter[7] ->  pairspinflip accept
 
   for(outStep=0;outStep<nOutStep;outStep++) {
     for(inStep=0;inStep<nInStep;inStep++) {
@@ -309,7 +310,8 @@ void VMCMakeSample_fsz_real(MPI_Comm comm) {
           // Inv already updated. Only need to get PfM again.
           updated_tdi_v_get_pfa_d(NQPFull, PfM_real, pfUpdator);
 #else
-          UpdateMAllTwo_fsz_real(mi, s, mj, t, ri, rj, TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+          UpdateMAllTwo_fsz_real(mi, s, mj, t, ri, s, rj, t,
+                                 TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
 #endif
           StopTimer(68);
 
@@ -326,6 +328,57 @@ void VMCMakeSample_fsz_real(MPI_Comm comm) {
           revertEleConfig_fsz(mi,ri,rj,s,s,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
         }
         StopTimer(33);
+      }else if (updateType==PAIRSPINFLIP){
+        Counter[6]++;
+
+        StartTimer(31);
+        makeCandidate_PairSpinFlip_localspin(&mi, &mj, &ri, &rj, &s, &t,
+                              &rejectFlag, TmpEleIdx, TmpEleCfg, TmpEleNum,
+                              TmpEleSpn);
+        StopTimer(31);
+        if(rejectFlag) continue;
+
+        StartTimer(36);
+        updateEleConfig_fsz(mi,ri,ri,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+        UpdateProjCnt_fsz(ri,ri,s,t,projCntNew,TmpEleProjCnt,TmpEleNum);
+        updateEleConfig_fsz(mj,rj,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+        UpdateProjCnt_fsz(rj,rj,s,t,projCntNew,projCntNew,TmpEleNum);
+
+#ifdef _pf_block_update
+        updated_tdi_v_push_pair_d(NQPFull,
+                                  ri+t*Nsite, mi,
+                                  rj+t*Nsite, mj,
+                                  1, pfUpdator);
+        updated_tdi_v_get_pfa_d(NQPFull, pfMNew, pfUpdator);
+#else
+        CalculateNewPfMTwo2_fsz_real(mi, t, mj, t, pfMNew,
+                                     TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
+        logIpNew = CalculateLogIP_real(pfMNew,qpStart,qpEnd,comm);
+        x = LogProjRatio(projCntNew,TmpEleProjCnt);
+        w = exp(2.0*(x+(logIpNew-logIpOld)));
+        if( !isfinite(w) ) w = -1.0;
+
+        if(w > genrand_real2()) {
+#ifdef _pf_block_update
+          updated_tdi_v_get_pfa_d(NQPFull, PfM_real, pfUpdator);
+#else
+          UpdateMAllTwo_fsz_real(mi, t, mj, t, ri, s, rj, s,
+                                 TmpEleIdx,TmpEleSpn,qpStart,qpEnd);
+#endif
+          for(i=0;i<NProj;i++) TmpEleProjCnt[i] = projCntNew[i];
+          logIpOld = logIpNew;
+          nAccept++;
+          Counter[7]++;
+        } else {
+#ifdef _pf_block_update
+          updated_tdi_v_pop_d(NQPFull, 0, pfUpdator);
+          updated_tdi_v_pop_d(NQPFull, 0, pfUpdator);
+#endif
+          revertEleConfig_fsz(mj,rj,rj,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+          revertEleConfig_fsz(mi,ri,ri,s,t,TmpEleIdx,TmpEleCfg,TmpEleNum,TmpEleSpn);
+        }
+        StopTimer(36);
       }else if (updateType==LOCALSPINFLIP){
         Counter[4]++;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,14 @@ target_include_directories(lanczos2_contract_unit PRIVATE
     ${CMAKE_SOURCE_DIR}/src/mVMC/include)
 add_test(NAME Lanczos2Contract_Unit COMMAND lanczos2_contract_unit)
 
+add_executable(update_weight_unit
+    update_weight_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/update_weight.c)
+target_include_directories(update_weight_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+target_link_libraries(update_weight_unit m)
+add_test(NAME UpdateWeight_Unit COMMAND update_weight_unit)
+
 add_executable(lanczos2_solver_unit
     lanczos2_solver_unit.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/physcal_lanczos2.c

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -27,6 +27,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nbodyg.py DESTINATION ${CMAKE_BINA
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyg_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyinterall_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nbodyinterall_invalid.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_update_weight.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 
 function(add_python_vmc_test model)
     add_test(NAME ${model} COMMAND ${PYTHON_EXECUTABLE} runtest.py ${model})
@@ -414,6 +415,19 @@ endfunction(add_python_uhf_test)
 # TODO: replace it with find_package(Python3 REQUIRED
 #cmake_policy(SET CMP0148 OLD)
 find_package(PythonInterp 3.6 REQUIRED)
+
+add_test(NAME UpdateWeight_E2E
+    COMMAND ${PYTHON_EXECUTABLE} runtest_update_weight.py)
+set_tests_properties(UpdateWeight_E2E PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1"
+    RESOURCE_LOCK "update_weight_e2e_workdir")
+if(MPI_FOUND)
+    add_test(NAME UpdateWeight_E2E_MPI
+        COMMAND ${PYTHON_EXECUTABLE} runtest_update_weight.py)
+    set_tests_properties(UpdateWeight_E2E_MPI PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;MVMC_MPI_PROCS=2"
+        RESOURCE_LOCK "update_weight_e2e_workdir")
+endif()
 
 set(python_test_vmc_model
   HeisenbergChain

--- a/test/python/runtest_update_weight.py
+++ b/test/python/runtest_update_weight.py
@@ -1,0 +1,170 @@
+from __future__ import print_function
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+
+BASE_MODEL = "NBodyG_fsz_Compare"
+
+
+def replace_setting(path, name, value):
+    with open(path) as source:
+        text = source.read()
+    pattern = re.compile(r"^{}\s+.*$".format(re.escape(name)), re.MULTILINE)
+    updated, count = pattern.subn("{:<15s} {}".format(name, value), text)
+    if count != 1:
+        raise AssertionError("{}: expected one {} setting".format(path, name))
+    with open(path, "w") as destination:
+        destination.write(updated)
+
+
+def prepare_case(rootdir, name, pair_weight=None, two_sz=-1, update_path=2):
+    suffix = os.environ.get("MVMC_MPI_PROCS")
+    work_name = "UpdateWeight_{}{}".format(
+        name, "_mpi" if suffix else ""
+    )
+    workdir = os.path.join(rootdir, "work", work_name)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    source = os.path.join(rootdir, "data", BASE_MODEL)
+    for filename in os.listdir(source):
+        if filename.endswith(".def"):
+            shutil.copy2(
+                os.path.join(source, filename),
+                os.path.join(workdir, filename),
+            )
+
+    modpara = os.path.join(workdir, "modpara.def")
+    replace_setting(modpara, "Ncond", "0")
+    replace_setting(modpara, "2Sz", str(two_sz))
+    replace_setting(modpara, "NExUpdatePath", str(update_path))
+
+    locspin = os.path.join(workdir, "locspn.def")
+    with open(locspin) as source_file:
+        text = source_file.read()
+    text = re.sub(r"^NlocalSpin\s+0$", "NlocalSpin     6", text,
+                  flags=re.MULTILINE)
+    text = re.sub(r"^(\s*\d+\s+)0$", r"\g<1>1", text,
+                  flags=re.MULTILINE)
+    with open(locspin, "w") as destination:
+        destination.write(text)
+
+    if pair_weight is not None:
+        with open(os.path.join(workdir, "updateweight.def"), "w") as output:
+            output.write(
+                "================================\n"
+                "NUpdateWeight 3\n"
+                "================================\n"
+                "========UpdateType Weight=======\n"
+                "================================\n"
+                "Exchange 1.0\n"
+                "LocalSpinFlip 1.0\n"
+                "PairSpinFlip {:.17g}\n".format(pair_weight)
+            )
+        with open(os.path.join(workdir, "namelist.def"), "a") as namelist:
+            namelist.write("  InUpdateWeight  updateweight.def\n")
+    return workdir
+
+
+def run_vmc(rootdir, workdir, expect_success=True, diagnostic=None):
+    binary = os.path.join(rootdir, "..", "..", "src", "mVMC", "vmc.out")
+    command = [binary, "-e", "namelist.def", "initial.def"]
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    if mpi_procs:
+        command = ["mpirun", "-np", mpi_procs] + command
+    environment = os.environ.copy()
+    environment["OMP_NUM_THREADS"] = "1"
+    process = subprocess.run(
+        command,
+        cwd=workdir,
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+    if expect_success and process.returncode != 0:
+        raise AssertionError("UpdateWeight run failed:\n{}".format(process.stdout))
+    if not expect_success and process.returncode == 0:
+        raise AssertionError("invalid UpdateWeight run unexpectedly succeeded")
+    if diagnostic is not None and diagnostic not in process.stdout:
+        raise AssertionError(
+            "missing diagnostic {!r}:\n{}".format(diagnostic, process.stdout)
+        )
+    return process
+
+
+def read_bytes(path):
+    with open(path, "rb") as source:
+        return source.read()
+
+
+def time_lines(workdir):
+    path = os.path.join(workdir, "output", "zvo_time_001.dat")
+    with open(path) as source:
+        return [line.rstrip("\n") for line in source]
+
+
+def main():
+    rootdir = os.getcwd()
+    legacy = prepare_case(rootdir, "Legacy")
+    explicit_legacy = prepare_case(rootdir, "ExplicitLegacy", pair_weight=0.0)
+    pair = prepare_case(rootdir, "Pair", pair_weight=1.0)
+
+    run_vmc(rootdir, legacy)
+    run_vmc(rootdir, explicit_legacy)
+    run_vmc(rootdir, pair)
+
+    for filename in (
+        "zvo_NBodyG_001.dat", "zvo_out_001.dat", "zvo_var_001.dat"
+    ):
+        legacy_bytes = read_bytes(os.path.join(legacy, "output", filename))
+        explicit_bytes = read_bytes(
+            os.path.join(explicit_legacy, "output", filename)
+        )
+        if legacy_bytes != explicit_bytes:
+            raise AssertionError(
+                "legacy and explicit 1:1:0 outputs differ: {}".format(filename)
+            )
+
+    legacy_time = time_lines(legacy)
+    explicit_time = time_lines(explicit_legacy)
+    pair_time = time_lines(pair)
+    if "acc_psf" in legacy_time[0]:
+        raise AssertionError("legacy zvo_time format changed")
+    if "acc_psf" not in explicit_time[0]:
+        raise AssertionError("explicit zvo_time lacks pair counters")
+    proposals = sum(
+        int(line.split(":", 1)[0].split()[8]) for line in pair_time[1:]
+    )
+    if proposals <= 0:
+        raise AssertionError("PairSpinFlip produced no proposals")
+
+    invalid_path = prepare_case(
+        rootdir, "InvalidPath", pair_weight=1.0, update_path=1
+    )
+    run_vmc(
+        rootdir, invalid_path, expect_success=False,
+        diagnostic="InUpdateWeight currently requires NExUpdatePath=2",
+    )
+    invalid_sz = prepare_case(
+        rootdir, "InvalidSz", pair_weight=1.0, two_sz=0
+    )
+    run_vmc(
+        rootdir, invalid_sz, expect_success=False,
+        diagnostic="LocalSpinFlip with NExUpdatePath=2 requires 2Sz=-1",
+    )
+
+    print(
+        "UpdateWeight end-to-end{}: PASS (pair proposals={})".format(
+            " MPI" if os.environ.get("MVMC_MPI_PROCS") else "", proposals
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/update_weight_unit.c
+++ b/test/update_weight_unit.c
@@ -1,0 +1,136 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "update_weight.h"
+
+static int failures = 0;
+
+static void Expect(int condition, const char *message) {
+  if (!condition) {
+    fprintf(stderr, "FAIL: %s\n", message);
+    failures++;
+  }
+}
+
+static FILE *OpenText(const char *text) {
+  FILE *fp = tmpfile();
+  if (fp == NULL) return NULL;
+  fputs(text, fp);
+  rewind(fp);
+  return fp;
+}
+
+static void TestParserAndSelector(void) {
+  const char *text =
+      "================================\n"
+      "NUpdateWeight 3\n"
+      "================================\n"
+      "========UpdateType Weight=======\n"
+      "================================\n"
+      "Exchange 2.0\n"
+      "LocalSpinFlip 1.0\n"
+      "PairSpinFlip 1.0\n";
+  char error[256] = "";
+  double weights[UpdateWeightCount];
+  FILE *fp = OpenText(text);
+  Expect(fp != NULL, "tmpfile opens");
+  if (fp == NULL) return;
+  Expect(ReadUpdateWeight(fp, "unit", weights, error, sizeof(error)) == 0,
+         error);
+  fclose(fp);
+  Expect(fabs(weights[UpdateWeightExchange] - 0.5) < 1.0e-15,
+         "exchange weight normalizes");
+  Expect(fabs(weights[UpdateWeightLocalSpinFlip] - 0.25) < 1.0e-15,
+         "single-flip weight normalizes");
+  Expect(fabs(weights[UpdateWeightPairSpinFlip] - 0.25) < 1.0e-15,
+         "pair-flip weight normalizes");
+  Expect(SelectUpdateWeight(weights, 0.0) == UpdateWeightExchange,
+         "lower interval selects exchange");
+  Expect(SelectUpdateWeight(weights, 0.5) == UpdateWeightLocalSpinFlip,
+         "middle interval selects local spin flip");
+  Expect(SelectUpdateWeight(weights, 0.75) == UpdateWeightPairSpinFlip,
+         "upper interval selects pair spin flip");
+}
+
+static void TestMissingKernelDefaultsToZero(void) {
+  const char *text =
+      "================================\n"
+      "NUpdateWeight 1\n"
+      "================================\n"
+      "========UpdateType Weight=======\n"
+      "================================\n"
+      "Exchange 4.0\n";
+  char error[256] = "";
+  double weights[UpdateWeightCount];
+  FILE *fp = OpenText(text);
+  Expect(ReadUpdateWeight(fp, "unit", weights, error, sizeof(error)) == 0,
+         error);
+  fclose(fp);
+  Expect(weights[UpdateWeightExchange] == 1.0,
+         "single named kernel normalizes to one");
+  Expect(weights[UpdateWeightLocalSpinFlip] == 0.0,
+         "missing local spin flip defaults to zero");
+  Expect(weights[UpdateWeightPairSpinFlip] == 0.0,
+         "missing pair spin flip defaults to zero");
+}
+
+static void TestParserFailures(void) {
+  const char *cases[] = {
+      "=\nNUpdateWeight 2\n=\n=\n=\nExchange 1\nExchange 2\n",
+      "=\nNUpdateWeight 1\n=\n=\n=\nUnknown 1\n",
+      "=\nNUpdateWeight 1\n=\n=\n=\nExchange -1\n",
+      "=\nNUpdateWeight 2\n=\n=\n=\nExchange 1\n"};
+  int index;
+  for (index = 0; index < 4; index++) {
+    char error[256] = "";
+    double weights[UpdateWeightCount];
+    FILE *fp = OpenText(cases[index]);
+    Expect(ReadUpdateWeight(fp, "invalid", weights, error, sizeof(error)) != 0,
+           "invalid parser case fails");
+    Expect(error[0] != '\0', "invalid parser case reports diagnostic");
+    fclose(fp);
+  }
+}
+
+static void TestContract(void) {
+  char error[256] = "";
+  const double pairWeights[UpdateWeightCount] = {1.0 / 3.0, 1.0 / 3.0,
+                                                  1.0 / 3.0};
+  const double legacyWeights[UpdateWeightCount] = {0.5, 0.5, 0.0};
+  const int allLocal[4] = {1, 1, 1, 1};
+  const int mixed[4] = {1, 1, 0, 1};
+
+  Expect(ValidateUpdateWeightContract(1, 2, -1, 4, 4, 2, 1,
+                                      pairWeights, error, sizeof(error)) == 0,
+         "pure-spin pair-flip contract passes");
+  Expect(ValidateUpdateWeightLocSpin(1, 4, 4, allLocal, pairWeights,
+                                     error, sizeof(error)) == 0,
+         "all-local-spin detail contract passes");
+  Expect(ValidateUpdateWeightContract(1, 1, -1, 4, 4, 2, 1,
+                                      legacyWeights, error, sizeof(error)) != 0,
+         "weight file rejects non-path-2 mode");
+  Expect(ValidateUpdateWeightContract(1, 2, 0, 4, 4, 2, 1,
+                                      pairWeights, error, sizeof(error)) != 0,
+         "pair flip rejects fixed Sz");
+  Expect(ValidateUpdateWeightLocSpin(1, 4, 4, mixed, pairWeights,
+                                     error, sizeof(error)) != 0,
+         "pair flip rejects non-local site");
+  Expect(ValidateUpdateWeightContract(0, 0, 0, 0, 0, 0, 0, NULL,
+                                      error, sizeof(error)) == 0,
+         "disabled contract is a no-op");
+}
+
+int main(void) {
+  TestParserAndSelector();
+  TestMissingKernelDefaultsToZero();
+  TestParserFailures();
+  TestContract();
+  if (failures != 0) {
+    fprintf(stderr, "%d UpdateWeight unit checks failed\n", failures);
+    return EXIT_FAILURE;
+  }
+  printf("UpdateWeight unit checks: PASS\n");
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
### Summary

This PR adds an optional `InUpdateWeight` definition file for
`NExUpdatePath=2`. It allows users to assign relative weights to the existing
exchange and local-spin-flip kernels and to a new same-spin pair-flip kernel:

```text
================================
NUpdateWeight 3
================================
========UpdateType Weight=======
================================
Exchange          1.0
LocalSpinFlip     1.0
PairSpinFlip      1.0
```

The weights are validated, normalized internally, broadcast to all MPI ranks,
and printed when the input is read. Pair-flip proposals and acceptances are
reported separately in `zvo_time` when the optional file is active.

### Motivation

For unrestricted-spin `OrbitalGeneral` Pfaffian states, a single-spin flip can
have zero acceptance when the wave function has support only in one up-spin
parity sector. Flipping two same-spin local spins changes `2Sz` by four and can
connect nonzero-weight configurations within that sector. Keeping the kernel
mixture in an optional file avoids changing the established meaning of
`NExUpdatePath=2` and makes future update mixtures explicit.

### Compatibility and sampling contract

- Omitting `InUpdateWeight` preserves the legacy path-2 selector, random-number
  consumption, counter reduction length, and `zvo_time` layout.
- The regression test compares a file-free run with explicit weights `1:1:0`;
  `NBodyG`, energy, and variance outputs are byte-identical.
- Enabling the file consumes one selector random number per update even when
  only one kernel has positive weight. Therefore the legacy RNG stream is not
  preserved for file-enabled runs merely because they select the same kernel.
- Setting `LocalSpinFlip` to zero preserves up-spin-number parity. This is
  appropriate for a declared fixed-parity target. If the target distribution
  has support in both parity sectors, a positive `LocalSpinFlip` weight and
  observed accepted local-spin-flip moves are required; positive proposal
  weight alone does not guarantee ergodicity.
- `PairSpinFlip` requires `OrbitalGeneral`, `2Sz=-1`, `Ncond=0`,
  `NLocalSpin=Nsite`, and `LocSpin=1` at every site. Invalid candidates are
  rejected without state-dependent renormalization, keeping forward and
  reverse proposal probabilities equal.

### Implementation

- Adds a strict parser, contract validation, normalized weighted selector, and
  MPI broadcast for `updateweight.def`.
- Adds the same-spin pair-flip proposal to complex and real FSZ sampling.
- Generalizes the two-electron Pfaffian update to receive old and new spin
  indices explicitly.
- Keeps pair proposal / acceptance counters separate from exchange and
  single-spin-flip counters.
- Documents the format and sampling boundaries in the English and Japanese
  expert manuals.
- Registers the new Python E2E tests only after Python discovery so a fresh
  CMake cache records an explicit interpreter command.

### Validation

On current `develop` (`6e74669e`), fresh Release builds were tested with both
`PFAFFIAN_BLOCKED=OFF` and `PFAFFIAN_BLOCKED=ON` using one OpenMP thread.

The following tests pass in both configurations:

- `UpdateWeight_Unit`
- `UpdateWeight_E2E`
- `UpdateWeight_E2E_MPI` with two MPI ranks
- `NBodyOperator_Unit`
- `AbsolutePfaffian_Unit`
- `NBodyG_fsz_Compare`
- `NBodyG_fsz_AP_Compare`
- `NBodyG_fsz_N3_Oracle`

The E2E test also verifies invalid-path and fixed-`Sz` fail-fast diagnostics and
checks that pair-flip proposals are generated.
