### PR TITLE
Add singular-aware classic Pfaffian sampler reference

### DIFF
--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -11,7 +11,9 @@ include_directories("${STDFACE_DIR}/src")
 add_definitions(-DMEXP=19937)
 
 set(SOURCES_vmcmain
-        vmcmain.c absolute_pfaffian.c physcal_lanczos.c physcal_lanczos2.c
+        vmcmain.c absolute_pfaffian.c classic_pfaffian_state.c
+        classic_pfaffian_collective.c
+        physcal_lanczos.c physcal_lanczos2.c
         lanczos2_contract.c splitloop.c
  )
 
@@ -25,8 +27,12 @@ add_executable(vmcdry.out vmcdry.c)
 target_link_libraries(vmcdry.out StdFace_mvmc m)
 add_executable(vmc.out ${SOURCES_vmcmain} ${SOURCES_sfmt})
 if(Testing)
-  # Compile deliberate fault injection only into test-enabled builds.
-  target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION)
+  # Keep fault injection, reference sampler, and audit out of production.
+  target_sources(vmc.out PRIVATE classic_pfaffian_sampler.c
+      classic_pfaffian_audit.c)
+  target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION
+      MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
+      MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
 endif(Testing)
 target_link_libraries(vmc.out StdFace_mvmc m)
 target_link_libraries(vmc.out pfapack)

--- a/src/mVMC/absolute_pfaffian.c
+++ b/src/mVMC/absolute_pfaffian.c
@@ -31,6 +31,30 @@ typedef int MPI_Comm;
 #pragma GCC optimize("no-tree-loop-vectorize")
 #endif
 
+struct MVMCAbsolutePfaffianRealWorkspace {
+  int n;
+  size_t matrix_count;
+  int factor_lwork;
+  int inverse_lwork;
+  int *pivots;
+  double *factor;
+  double *inverse_factor;
+  double *factor_work;
+  double *inverse_work;
+};
+
+struct MVMCAbsolutePfaffianComplexWorkspace {
+  int n;
+  size_t matrix_count;
+  int factor_lwork;
+  int inverse_lwork;
+  int *pivots;
+  double complex *factor;
+  double complex *inverse_factor;
+  double complex *factor_work;
+  double complex *inverse_work;
+};
+
 static void initialize_result(MVMCAbsolutePfaffianResult *result,
                               uint64_t generation) {
   result->state = MVMC_PFAFFIAN_INVALID;
@@ -53,6 +77,176 @@ static int checked_square_size(int n, size_t element_size, size_t *count) {
   *count = dimension * dimension;
   if (*count > SIZE_MAX / element_size) return 0;
   return 1;
+}
+
+static int valid_real_lwork_query(double query, int *lwork) {
+  if (!isfinite(query) || query < 1.0 || query > (double)INT_MAX) return 0;
+  *lwork = (int)ceil(query);
+  return 1;
+}
+
+static int valid_complex_lwork_query(double complex query, int *lwork) {
+  if (!isfinite(creal(query)) || cimag(query) != 0.0 ||
+      creal(query) < 1.0 || creal(query) > (double)INT_MAX) {
+    return 0;
+  }
+  *lwork = (int)ceil(creal(query));
+  return 1;
+}
+
+void mvmc_absolute_pfaffian_real_workspace_destroy(
+    MVMCAbsolutePfaffianRealWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->inverse_work);
+  free(workspace->factor_work);
+  free(workspace->inverse_factor);
+  free(workspace->factor);
+  free(workspace->pivots);
+  free(workspace);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_workspace_create(
+    int n, MVMCAbsolutePfaffianRealWorkspace **workspace) {
+  MVMCAbsolutePfaffianRealWorkspace *created = NULL;
+  double factor_query = 0.0;
+  double inverse_query = 0.0;
+  int info = 0;
+  int query_lwork = -1;
+  int index;
+  size_t matrix_count;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (n <= 0 || (n % 2) != 0 ||
+      !checked_square_size(n, sizeof(double), &matrix_count) ||
+      (size_t)n > SIZE_MAX / sizeof(int)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCAbsolutePfaffianRealWorkspace *)calloc(1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  created->n = n;
+  created->matrix_count = matrix_count;
+  created->pivots = (int *)malloc((size_t)n * sizeof(*created->pivots));
+  created->factor =
+      (double *)calloc(created->matrix_count, sizeof(*created->factor));
+  created->inverse_factor = (double *)calloc(
+      created->matrix_count, sizeof(*created->inverse_factor));
+  if (created->pivots == NULL || created->factor == NULL ||
+      created->inverse_factor == NULL) {
+    mvmc_absolute_pfaffian_real_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  for (index = 0; index < n; ++index) created->pivots[index] = index + 1;
+
+  M_DSKTRF("U", "P", &n, created->factor, &n, created->pivots,
+           &factor_query, &query_lwork, &info);
+  if (info != 0 ||
+      !valid_real_lwork_query(factor_query, &created->factor_lwork) ||
+      (size_t)created->factor_lwork >
+          SIZE_MAX / sizeof(*created->factor_work)) {
+    mvmc_absolute_pfaffian_real_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  M_DGETRI(&n, created->inverse_factor, &n, created->pivots,
+           &inverse_query, &query_lwork, &info);
+  if (info != 0 ||
+      !valid_real_lwork_query(inverse_query, &created->inverse_lwork) ||
+      (size_t)created->inverse_lwork >
+          SIZE_MAX / sizeof(*created->inverse_work)) {
+    mvmc_absolute_pfaffian_real_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  created->factor_work = (double *)malloc(
+      (size_t)created->factor_lwork * sizeof(*created->factor_work));
+  created->inverse_work = (double *)malloc(
+      (size_t)created->inverse_lwork * sizeof(*created->inverse_work));
+  if (created->factor_work == NULL || created->inverse_work == NULL) {
+    mvmc_absolute_pfaffian_real_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_absolute_pfaffian_complex_workspace_destroy(
+    MVMCAbsolutePfaffianComplexWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->inverse_work);
+  free(workspace->factor_work);
+  free(workspace->inverse_factor);
+  free(workspace->factor);
+  free(workspace->pivots);
+  free(workspace);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_workspace_create(
+    int n, MVMCAbsolutePfaffianComplexWorkspace **workspace) {
+  MVMCAbsolutePfaffianComplexWorkspace *created = NULL;
+  double complex factor_query = 0.0;
+  double complex inverse_query = 0.0;
+  int info = 0;
+  int query_lwork = -1;
+  int index;
+  size_t matrix_count;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (n <= 0 || (n % 2) != 0 ||
+      !checked_square_size(n, sizeof(double complex), &matrix_count) ||
+      (size_t)n > SIZE_MAX / sizeof(int)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created =
+      (MVMCAbsolutePfaffianComplexWorkspace *)calloc(1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  created->n = n;
+  created->matrix_count = matrix_count;
+  created->pivots = (int *)malloc((size_t)n * sizeof(*created->pivots));
+  created->factor = (double complex *)calloc(
+      created->matrix_count, sizeof(*created->factor));
+  created->inverse_factor = (double complex *)calloc(
+      created->matrix_count, sizeof(*created->inverse_factor));
+  if (created->pivots == NULL || created->factor == NULL ||
+      created->inverse_factor == NULL) {
+    mvmc_absolute_pfaffian_complex_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  for (index = 0; index < n; ++index) created->pivots[index] = index + 1;
+
+  M_ZSKTRF("U", "P", &n, created->factor, &n, created->pivots,
+           &factor_query, &query_lwork, &info);
+  if (info != 0 ||
+      !valid_complex_lwork_query(factor_query, &created->factor_lwork) ||
+      (size_t)created->factor_lwork >
+          SIZE_MAX / sizeof(*created->factor_work)) {
+    mvmc_absolute_pfaffian_complex_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  M_ZGETRI(&n, created->inverse_factor, &n, created->pivots,
+           &inverse_query, &query_lwork, &info);
+  if (info != 0 ||
+      !valid_complex_lwork_query(inverse_query, &created->inverse_lwork) ||
+      (size_t)created->inverse_lwork >
+          SIZE_MAX / sizeof(*created->inverse_work)) {
+    mvmc_absolute_pfaffian_complex_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  created->factor_work = (double complex *)malloc(
+      (size_t)created->factor_lwork * sizeof(*created->factor_work));
+  created->inverse_work = (double complex *)malloc(
+      (size_t)created->inverse_lwork * sizeof(*created->inverse_work));
+  if (created->factor_work == NULL || created->inverse_work == NULL) {
+    mvmc_absolute_pfaffian_complex_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
 }
 
 static int real_matrix_properties(const double *matrix, int n, int lda,
@@ -191,20 +385,21 @@ int mvmc_absolute_pfaffian_strict_fp_enabled(void) {
 #endif
 }
 
-MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_with_workspace(
+    MVMCAbsolutePfaffianRealWorkspace *workspace,
     const double *matrix, int n, int lda,
     double *inverse_out, int inverse_lda,
     uint64_t rebuild_generation,
     double scaled_pivot_tolerance, double residual_tolerance,
     MVMCAbsolutePfaffianResult *result) {
-  double *factor = NULL;
-  double *inverse_factor = NULL;
-  double *inverse_work = NULL;
-  double *factor_work = NULL;
-  int *pivots = NULL;
+  double *factor = workspace == NULL ? NULL : workspace->factor;
+  double *inverse_factor =
+      workspace == NULL ? NULL : workspace->inverse_factor;
+  double *inverse_work = workspace == NULL ? NULL : workspace->inverse_work;
+  double *factor_work = workspace == NULL ? NULL : workspace->factor_work;
+  int *pivots = workspace == NULL ? NULL : workspace->pivots;
   size_t matrix_count;
   int column, row, info = 0, lwork;
-  double work_query = 0.0;
   double pfaffian = 0.0;
   double min_pivot = INFINITY;
   MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
@@ -214,11 +409,13 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
   if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
     return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
   }
-  if (matrix == NULL || inverse_out == NULL || n <= 0 || (n % 2) != 0 ||
+  if (workspace == NULL || workspace->n != n || matrix == NULL ||
+      inverse_out == NULL || n <= 0 || (n % 2) != 0 ||
       lda < n || inverse_lda < n ||
       !isfinite(scaled_pivot_tolerance) ||
       !isfinite(residual_tolerance) ||
-      !checked_square_size(n, sizeof(*factor), &matrix_count)) {
+      !checked_square_size(n, sizeof(*factor), &matrix_count) ||
+      workspace->matrix_count != matrix_count) {
     return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   }
   info = real_matrix_properties(matrix, n, lda, &result->matrix_scale);
@@ -228,12 +425,6 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
   }
   if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
 
-  factor = (double *)malloc(matrix_count * sizeof(*factor));
-  pivots = (int *)malloc((size_t)n * sizeof(*pivots));
-  if (factor == NULL || pivots == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
   for (column = 0; column < n; ++column) {
     for (row = 0; row < n; ++row) {
       factor[row + (size_t)column * (size_t)n] =
@@ -241,20 +432,7 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
     }
   }
 
-  lwork = -1;
-  M_DSKTRF("U", "P", &n, factor, &n, pivots, &work_query, &lwork, &info);
-  if (info != 0 || !isfinite(work_query) || work_query < 1.0 ||
-      work_query > (double)INT_MAX) {
-    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
-    goto cleanup;
-  }
-  lwork = (int)ceil(work_query);
-  factor_work = (double *)malloc((size_t)lwork * sizeof(*factor_work));
-  if (factor_work == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
-
+  lwork = workspace->factor_lwork;
   M_DSKTRF("U", "P", &n, factor, &n, pivots, factor_work, &lwork, &info);
   result->factor_info = info;
   if (info < 0) {
@@ -291,14 +469,6 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
     goto cleanup;
   }
 
-  free(factor_work);
-  factor_work = NULL;
-  inverse_factor =
-      (double *)malloc(matrix_count * sizeof(*inverse_factor));
-  if (inverse_factor == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
   for (column = 0; column < n; ++column) {
     for (row = 0; row < n; ++row) {
       inverse_factor[row + (size_t)column * (size_t)n] =
@@ -315,24 +485,7 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
     result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
     goto cleanup;
   }
-  lwork = -1;
-  M_DGETRI(&n, inverse_factor, &n, pivots, &work_query, &lwork, &info);
-  result->inverse_info = info;
-  if (info < 0 || !isfinite(work_query) || work_query < 1.0 ||
-      work_query > (double)INT_MAX) {
-    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
-    goto cleanup;
-  }
-  if (info > 0) {
-    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
-    goto cleanup;
-  }
-  lwork = (int)ceil(work_query);
-  inverse_work = (double *)malloc((size_t)lwork * sizeof(*inverse_work));
-  if (inverse_work == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  lwork = workspace->inverse_lwork;
   M_DGETRI(&n, inverse_factor, &n, pivots, inverse_work, &lwork, &info);
   result->inverse_info = info;
   if (info < 0) {
@@ -365,31 +518,18 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
   result->inverse_valid = 1;
 
 cleanup:
-  free(factor_work);
-  free(pivots);
-  free(inverse_work);
-  free(inverse_factor);
-  free(factor);
   return status;
 }
 
-MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
-    const double complex *matrix, int n, int lda,
-    double complex *inverse_out, int inverse_lda,
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real(
+    const double *matrix, int n, int lda,
+    double *inverse_out, int inverse_lda,
     uint64_t rebuild_generation,
     double scaled_pivot_tolerance, double residual_tolerance,
     MVMCAbsolutePfaffianResult *result) {
-  double complex *factor = NULL;
-  double complex *inverse_factor = NULL;
-  double complex *inverse_work = NULL;
-  double complex *factor_work = NULL;
-  int *pivots = NULL;
+  MVMCAbsolutePfaffianRealWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
   size_t matrix_count;
-  int column, row, info = 0, lwork;
-  double complex work_query = 0.0;
-  double complex pfaffian = 0.0;
-  double min_pivot = INFINITY;
-  MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
 
   if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   initialize_result(result, rebuild_generation);
@@ -400,7 +540,53 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
       lda < n || inverse_lda < n ||
       !isfinite(scaled_pivot_tolerance) ||
       !isfinite(residual_tolerance) ||
-      !checked_square_size(n, sizeof(*factor), &matrix_count)) {
+      !checked_square_size(n, sizeof(*matrix), &matrix_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = mvmc_absolute_pfaffian_real_workspace_create(n, &workspace);
+  if (status == MVMC_PFAFFIAN_STATUS_OK) {
+    status = mvmc_absolute_pfaffian_real_with_workspace(
+        workspace, matrix, n, lda, inverse_out, inverse_lda,
+        rebuild_generation, scaled_pivot_tolerance, residual_tolerance,
+        result);
+  }
+  mvmc_absolute_pfaffian_real_workspace_destroy(workspace);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_with_workspace(
+    MVMCAbsolutePfaffianComplexWorkspace *workspace,
+    const double complex *matrix, int n, int lda,
+    double complex *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result) {
+  double complex *factor = workspace == NULL ? NULL : workspace->factor;
+  double complex *inverse_factor =
+      workspace == NULL ? NULL : workspace->inverse_factor;
+  double complex *inverse_work =
+      workspace == NULL ? NULL : workspace->inverse_work;
+  double complex *factor_work =
+      workspace == NULL ? NULL : workspace->factor_work;
+  int *pivots = workspace == NULL ? NULL : workspace->pivots;
+  size_t matrix_count;
+  int column, row, info = 0, lwork;
+  double complex pfaffian = 0.0;
+  double min_pivot = INFINITY;
+  MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_result(result, rebuild_generation);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (workspace == NULL || workspace->n != n || matrix == NULL ||
+      inverse_out == NULL || n <= 0 || (n % 2) != 0 ||
+      lda < n || inverse_lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !isfinite(residual_tolerance) ||
+      !checked_square_size(n, sizeof(*factor), &matrix_count) ||
+      workspace->matrix_count != matrix_count) {
     return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   }
   info = complex_matrix_properties(matrix, n, lda, &result->matrix_scale);
@@ -410,12 +596,6 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
   }
   if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
 
-  factor = (double complex *)malloc(matrix_count * sizeof(*factor));
-  pivots = (int *)malloc((size_t)n * sizeof(*pivots));
-  if (factor == NULL || pivots == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
   for (column = 0; column < n; ++column) {
     for (row = 0; row < n; ++row) {
       factor[row + (size_t)column * (size_t)n] =
@@ -423,21 +603,7 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
     }
   }
 
-  lwork = -1;
-  M_ZSKTRF("U", "P", &n, factor, &n, pivots, &work_query, &lwork, &info);
-  if (info != 0 || !isfinite(creal(work_query)) || cimag(work_query) != 0.0 ||
-      creal(work_query) < 1.0 || creal(work_query) > (double)INT_MAX) {
-    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
-    goto cleanup;
-  }
-  lwork = (int)ceil(creal(work_query));
-  factor_work =
-      (double complex *)malloc((size_t)lwork * sizeof(*factor_work));
-  if (factor_work == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
-
+  lwork = workspace->factor_lwork;
   M_ZSKTRF("U", "P", &n, factor, &n, pivots, factor_work, &lwork, &info);
   result->factor_info = info;
   if (info < 0) {
@@ -475,14 +641,6 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
     goto cleanup;
   }
 
-  free(factor_work);
-  factor_work = NULL;
-  inverse_factor =
-      (double complex *)malloc(matrix_count * sizeof(*inverse_factor));
-  if (inverse_factor == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
   for (column = 0; column < n; ++column) {
     for (row = 0; row < n; ++row) {
       inverse_factor[row + (size_t)column * (size_t)n] =
@@ -499,26 +657,7 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
     result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
     goto cleanup;
   }
-  lwork = -1;
-  M_ZGETRI(&n, inverse_factor, &n, pivots, &work_query, &lwork, &info);
-  result->inverse_info = info;
-  if (info < 0 || !isfinite(creal(work_query)) ||
-      cimag(work_query) != 0.0 || creal(work_query) < 1.0 ||
-      creal(work_query) > (double)INT_MAX) {
-    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
-    goto cleanup;
-  }
-  if (info > 0) {
-    result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
-    goto cleanup;
-  }
-  lwork = (int)ceil(creal(work_query));
-  inverse_work =
-      (double complex *)malloc((size_t)lwork * sizeof(*inverse_work));
-  if (inverse_work == NULL) {
-    status = MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
-    goto cleanup;
-  }
+  lwork = workspace->inverse_lwork;
   M_ZGETRI(&n, inverse_factor, &n, pivots, inverse_work, &lwork, &info);
   result->inverse_info = info;
   if (info < 0) {
@@ -551,11 +690,39 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
   result->inverse_valid = 1;
 
 cleanup:
-  free(factor_work);
-  free(pivots);
-  free(inverse_work);
-  free(inverse_factor);
-  free(factor);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
+    const double complex *matrix, int n, int lda,
+    double complex *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result) {
+  MVMCAbsolutePfaffianComplexWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
+  size_t matrix_count;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_result(result, rebuild_generation);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (matrix == NULL || inverse_out == NULL || n <= 0 || (n % 2) != 0 ||
+      lda < n || inverse_lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !isfinite(residual_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = mvmc_absolute_pfaffian_complex_workspace_create(n, &workspace);
+  if (status == MVMC_PFAFFIAN_STATUS_OK) {
+    status = mvmc_absolute_pfaffian_complex_with_workspace(
+        workspace, matrix, n, lda, inverse_out, inverse_lda,
+        rebuild_generation, scaled_pivot_tolerance, residual_tolerance,
+        result);
+  }
+  mvmc_absolute_pfaffian_complex_workspace_destroy(workspace);
   return status;
 }
 
@@ -616,18 +783,27 @@ MVMCPfaffianStatus mvmc_projected_amplitude(
     value = cabs(term);
     corrected = value - abs_compensation;
     updated = abs_sum + corrected;
+    if (!isfinite(updated)) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
     abs_compensation = (updated - abs_sum) - corrected;
     abs_sum = updated;
 
     value = creal(term);
     corrected = value - real_compensation;
     updated = real_sum + corrected;
+    if (!isfinite(updated)) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
     real_compensation = (updated - real_sum) - corrected;
     real_sum = updated;
 
     value = cimag(term);
     corrected = value - imag_compensation;
     updated = imag_sum + corrected;
+    if (!isfinite(updated)) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
     imag_compensation = (updated - imag_sum) - corrected;
     imag_sum = updated;
   }

--- a/src/mVMC/classic_pfaffian_audit.c
+++ b/src/mVMC/classic_pfaffian_audit.c
@@ -1,0 +1,680 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_pfaffian_audit.h"
+
+#if !defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+#error "classic_pfaffian_audit.c is Testing-only"
+#endif
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  MVMCClassicPfaffianAuditMode mode;
+  int nsize;
+  int qp_total;
+  int qp_start;
+  int qp_end;
+  size_t local_qp_count;
+  size_t matrix_count;
+  size_t inverse_count;
+  double absolute_tolerance;
+  double relative_tolerance;
+  MVMCAbsolutePfaffianResult *components;
+} MVMCClassicPfaffianAuditLayout;
+
+struct MVMCClassicPfaffianRealAuditWorkspace {
+  MVMCClassicPfaffianAuditLayout layout;
+  double *inverse;
+};
+
+struct MVMCClassicPfaffianComplexAuditWorkspace {
+  MVMCClassicPfaffianAuditLayout layout;
+  double complex *inverse;
+};
+
+static int valid_mode(MVMCClassicPfaffianAuditMode mode) {
+  return mode >= MVMC_CLASSIC_AUDIT_OFF &&
+         mode <= MVMC_CLASSIC_AUDIT_ALWAYS;
+}
+
+static int checked_multiply(size_t left, size_t right, size_t *product) {
+  if (product == NULL || (left != 0 && right > SIZE_MAX / left)) return 0;
+  *product = left * right;
+  return 1;
+}
+
+static int initialize_layout(int nsize, int qp_total, int qp_start, int qp_end,
+                             MVMCClassicPfaffianAuditMode mode,
+                             double absolute_tolerance,
+                             double relative_tolerance,
+                             MVMCClassicPfaffianAuditLayout *layout) {
+  if (layout == NULL || !valid_mode(mode) || nsize <= 0 ||
+      qp_total <= 0 || qp_start < 0 || qp_end < qp_start ||
+      qp_end > qp_total || !isfinite(absolute_tolerance) ||
+      !isfinite(relative_tolerance) || absolute_tolerance < 0.0 ||
+      relative_tolerance < 0.0 ||
+      !checked_multiply((size_t)nsize, (size_t)nsize,
+                        &layout->matrix_count) ||
+      !checked_multiply((size_t)(qp_end - qp_start), layout->matrix_count,
+                        &layout->inverse_count)) {
+    return 0;
+  }
+  layout->mode = mode;
+  layout->nsize = nsize;
+  layout->qp_total = qp_total;
+  layout->qp_start = qp_start;
+  layout->qp_end = qp_end;
+  layout->local_qp_count = (size_t)(qp_end - qp_start);
+  layout->absolute_tolerance = absolute_tolerance;
+  layout->relative_tolerance = relative_tolerance;
+  return 1;
+}
+
+static void reset_report(MVMCClassicPfaffianAuditReport *report,
+                         MVMCClassicPfaffianAuditMode requested) {
+  if (report == NULL) return;
+  memset(report, 0, sizeof(*report));
+  report->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  report->requested_mode = requested;
+  report->effective_mode = MVMC_CLASSIC_AUDIT_OFF;
+  report->failure_rank = -1;
+  report->failure_local_qp = -1;
+  report->failure_global_qp = -1;
+}
+
+static int close_value(double difference, double reference,
+                       double observed,
+                       const MVMCClassicPfaffianAuditLayout *layout) {
+  const double scale = fmax(fabs(reference), fabs(observed));
+  return isfinite(difference) &&
+         difference <= layout->absolute_tolerance +
+                           layout->relative_tolerance * scale;
+}
+
+static int close_complex(double complex reference, double complex observed,
+                         const MVMCClassicPfaffianAuditLayout *layout) {
+  return close_value(cabs(reference - observed), cabs(reference),
+                     cabs(observed), layout);
+}
+
+static int valid_state(const MVMCClassicPfaffianState *state,
+                       size_t local_qp_count) {
+  return state != NULL && state->valid == 1 &&
+         state->local_aggregate.valid == 1 &&
+         (local_qp_count == 0 || state->components != NULL);
+}
+
+static MVMCPfaffianStatus project_observation(
+    const MVMCClassicPfaffianAuditLayout *layout,
+    const MVMCAbsolutePfaffianResult *components,
+    const double complex *global_weights,
+    MVMCProjectedAmplitudeResult *aggregate) {
+  if (layout->local_qp_count == 0) {
+    memset(aggregate, 0, sizeof(*aggregate));
+    aggregate->valid = 1;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  return mvmc_projected_amplitude_slice(
+      components, layout->local_qp_count, global_weights,
+      layout->qp_total, layout->qp_start, layout->qp_end, aggregate);
+}
+
+static int locally_eligible(
+    const MVMCClassicPfaffianAuditLayout *layout,
+    const MVMCClassicPfaffianState *accepted_state) {
+  size_t local_qp;
+
+  if (!valid_state(accepted_state, layout->local_qp_count)) return 0;
+  for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
+    const MVMCAbsolutePfaffianResult *component =
+        &accepted_state->components[local_qp];
+    if (component->state != MVMC_PFAFFIAN_REGULAR ||
+        component->inverse_valid != 1 ||
+        !isfinite(component->scaled_min_pivot) ||
+        !isfinite(component->inverse_residual)) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int close_aggregate(
+    const MVMCProjectedAmplitudeResult *reference,
+    const MVMCProjectedAmplitudeResult *observed,
+    const MVMCClassicPfaffianAuditLayout *layout) {
+  return reference != NULL && observed != NULL &&
+         reference->valid == 1 && observed->valid == 1 &&
+         reference->regular_count == observed->regular_count &&
+         reference->near_singular_count == observed->near_singular_count &&
+         reference->singular_count == observed->singular_count &&
+         close_complex(reference->total, observed->total, layout) &&
+         close_value(fabs(reference->sum_abs - observed->sum_abs),
+                     reference->sum_abs, observed->sum_abs, layout) &&
+         close_value(fabs(reference->cancellation_ratio -
+                              observed->cancellation_ratio),
+                     reference->cancellation_ratio,
+                     observed->cancellation_ratio, layout);
+}
+
+static int compare_real_components(
+    const MVMCClassicPfaffianAuditLayout *layout,
+    const MVMCClassicPfaffianState *reference_state,
+    const double *reference_inverse,
+    const MVMCClassicPfaffianState *observed_state,
+    const double *observed_inverse,
+    int *failure_local_qp, int *failure_global_qp) {
+  size_t local_qp, index;
+
+  if (!valid_state(reference_state, layout->local_qp_count) ||
+      !valid_state(observed_state, layout->local_qp_count) ||
+      (layout->inverse_count != 0 &&
+       (reference_inverse == NULL || observed_inverse == NULL))) {
+    return 0;
+  }
+  for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
+    const MVMCAbsolutePfaffianResult *reference =
+        &reference_state->components[local_qp];
+    const MVMCAbsolutePfaffianResult *observed =
+        &observed_state->components[local_qp];
+    int match = reference->state == observed->state &&
+                reference->inverse_valid == observed->inverse_valid &&
+                close_complex(reference->pfaffian, observed->pfaffian,
+                              layout);
+    for (index = 0; match && index < layout->matrix_count; ++index) {
+      const size_t offset = local_qp * layout->matrix_count + index;
+      if (reference->state == MVMC_PFAFFIAN_REGULAR) {
+        match = close_value(fabs(reference_inverse[offset] -
+                                     observed_inverse[offset]),
+                            reference_inverse[offset],
+                            observed_inverse[offset], layout);
+      } else {
+        match = reference_inverse[offset] == 0.0 &&
+                observed_inverse[offset] == 0.0;
+      }
+    }
+    if (!match) {
+      *failure_local_qp = (int)local_qp;
+      *failure_global_qp = layout->qp_start + (int)local_qp;
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int compare_complex_components(
+    const MVMCClassicPfaffianAuditLayout *layout,
+    const MVMCClassicPfaffianState *reference_state,
+    const double complex *reference_inverse,
+    const MVMCClassicPfaffianState *observed_state,
+    const double complex *observed_inverse,
+    int *failure_local_qp, int *failure_global_qp) {
+  size_t local_qp, index;
+
+  if (!valid_state(reference_state, layout->local_qp_count) ||
+      !valid_state(observed_state, layout->local_qp_count) ||
+      (layout->inverse_count != 0 &&
+       (reference_inverse == NULL || observed_inverse == NULL))) {
+    return 0;
+  }
+  for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
+    const MVMCAbsolutePfaffianResult *reference =
+        &reference_state->components[local_qp];
+    const MVMCAbsolutePfaffianResult *observed =
+        &observed_state->components[local_qp];
+    int match = reference->state == observed->state &&
+                reference->inverse_valid == observed->inverse_valid &&
+                close_complex(reference->pfaffian, observed->pfaffian,
+                              layout);
+    for (index = 0; match && index < layout->matrix_count; ++index) {
+      const size_t offset = local_qp * layout->matrix_count + index;
+      if (reference->state == MVMC_PFAFFIAN_REGULAR) {
+        match = close_complex(reference_inverse[offset],
+                              observed_inverse[offset], layout);
+      } else {
+        match = reference_inverse[offset] == 0.0 &&
+                observed_inverse[offset] == 0.0;
+      }
+    }
+    if (!match) {
+      *failure_local_qp = (int)local_qp;
+      *failure_global_qp = layout->qp_start + (int)local_qp;
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static MVMCPfaffianStatus finish_collective_compare(
+    const MVMCClassicPfaffianAuditLayout *layout,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCPfaffianStatus local_status,
+    const MVMCClassicPfaffianState *observed_state,
+    int failure_local_qp, int failure_global_qp,
+    const MVMCProjectedAmplitudeResult *reference_global_aggregate,
+    MVMCClassicPfaffianAuditReport *report) {
+  MVMCClassicPfaffianCollectiveResult collected;
+  MVMCPfaffianStatus status = mvmc_classic_pfaffian_collective_aggregate(
+      collective_workspace, local_status,
+      observed_state == NULL ? NULL : &observed_state->local_aggregate,
+      layout->qp_total, layout->qp_start, layout->qp_end,
+      failure_local_qp, failure_global_qp, &collected);
+
+  report->executed = 1;
+  report->effective_mode = report->requested_mode == MVMC_CLASSIC_AUDIT_OFF
+                               ? MVMC_CLASSIC_AUDIT_ALWAYS
+                               : report->requested_mode;
+  report->valid = 1;
+  report->status = status;
+  if (status != MVMC_PFAFFIAN_STATUS_OK) {
+    report->mismatch = 1;
+    report->failure_rank = collected.failure_rank;
+    report->failure_local_qp = collected.failure_local_qp;
+    report->failure_global_qp = collected.failure_global_qp;
+    return status;
+  }
+  report->observed_aggregate = collected.aggregate;
+  if (!close_aggregate(reference_global_aggregate, &collected.aggregate,
+                       layout)) {
+    report->mismatch = 1;
+    report->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    return report->status;
+  }
+  report->status = MVMC_PFAFFIAN_STATUS_OK;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_audit_workspace_create(
+    const MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianAuditMode mode,
+    double absolute_tolerance, double relative_tolerance,
+    MVMCClassicPfaffianRealAuditWorkspace **workspace) {
+  MVMCClassicPfaffianRealAuditWorkspace *created = NULL;
+  int nsize, qp_total, qp_start, qp_end;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_classic_pfaffian_real_layout(
+          state_workspace, &nsize, &qp_total, &qp_start, &qp_end)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCClassicPfaffianRealAuditWorkspace *)calloc(
+      1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  if (!initialize_layout(nsize, qp_total, qp_start, qp_end, mode,
+                         absolute_tolerance, relative_tolerance,
+                         &created->layout)) {
+    free(created);
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (created->layout.local_qp_count != 0) {
+    created->layout.components = (MVMCAbsolutePfaffianResult *)calloc(
+        created->layout.local_qp_count, sizeof(*created->layout.components));
+    created->inverse = (double *)calloc(created->layout.inverse_count,
+                                        sizeof(*created->inverse));
+  }
+  if (created->layout.local_qp_count != 0 &&
+      (created->layout.components == NULL || created->inverse == NULL)) {
+    mvmc_classic_pfaffian_real_audit_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_classic_pfaffian_real_audit_workspace_destroy(
+    MVMCClassicPfaffianRealAuditWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->inverse);
+  free(workspace->layout.components);
+  free(workspace);
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_audit_workspace_create(
+    const MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianAuditMode mode,
+    double absolute_tolerance, double relative_tolerance,
+    MVMCClassicPfaffianComplexAuditWorkspace **workspace) {
+  MVMCClassicPfaffianComplexAuditWorkspace *created = NULL;
+  int nsize, qp_total, qp_start, qp_end;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_classic_pfaffian_complex_layout(
+          state_workspace, &nsize, &qp_total, &qp_start, &qp_end)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCClassicPfaffianComplexAuditWorkspace *)calloc(
+      1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  if (!initialize_layout(nsize, qp_total, qp_start, qp_end, mode,
+                         absolute_tolerance, relative_tolerance,
+                         &created->layout)) {
+    free(created);
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (created->layout.local_qp_count != 0) {
+    created->layout.components = (MVMCAbsolutePfaffianResult *)calloc(
+        created->layout.local_qp_count, sizeof(*created->layout.components));
+    created->inverse = (double complex *)calloc(
+        created->layout.inverse_count, sizeof(*created->inverse));
+  }
+  if (created->layout.local_qp_count != 0 &&
+      (created->layout.components == NULL || created->inverse == NULL)) {
+    mvmc_classic_pfaffian_complex_audit_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_classic_pfaffian_complex_audit_workspace_destroy(
+    MVMCClassicPfaffianComplexAuditWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->inverse);
+  free(workspace->layout.components);
+  free(workspace);
+}
+
+MVMCClassicPfaffianAuditMode mvmc_classic_pfaffian_real_audit_mode(
+    const MVMCClassicPfaffianRealAuditWorkspace *workspace) {
+  return workspace == NULL ? MVMC_CLASSIC_AUDIT_OFF : workspace->layout.mode;
+}
+
+MVMCClassicPfaffianAuditMode mvmc_classic_pfaffian_complex_audit_mode(
+    const MVMCClassicPfaffianComplexAuditWorkspace *workspace) {
+  return workspace == NULL ? MVMC_CLASSIC_AUDIT_OFF : workspace->layout.mode;
+}
+
+static int compatible_layout(const MVMCClassicPfaffianAuditLayout *audit,
+                             int nsize, int qp_total,
+                             int qp_start, int qp_end) {
+  return audit != NULL && audit->nsize == nsize &&
+         audit->qp_total == qp_total && audit->qp_start == qp_start &&
+         audit->qp_end == qp_end;
+}
+
+int mvmc_classic_pfaffian_real_audit_compatible(
+    const MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    const MVMCClassicPfaffianRealWorkspace *state_workspace) {
+  int nsize, qp_total, qp_start, qp_end;
+  return audit_workspace != NULL &&
+         mvmc_classic_pfaffian_real_layout(
+             state_workspace, &nsize, &qp_total, &qp_start, &qp_end) &&
+         compatible_layout(&audit_workspace->layout, nsize, qp_total,
+                           qp_start, qp_end);
+}
+
+int mvmc_classic_pfaffian_complex_audit_compatible(
+    const MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    const MVMCClassicPfaffianComplexWorkspace *state_workspace) {
+  int nsize, qp_total, qp_start, qp_end;
+  return audit_workspace != NULL &&
+         mvmc_classic_pfaffian_complex_layout(
+             state_workspace, &nsize, &qp_total, &qp_start, &qp_end) &&
+         compatible_layout(&audit_workspace->layout, nsize, qp_total,
+                           qp_start, qp_end);
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_audit_compare(
+    MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *reference_state,
+    const double *reference_inverse,
+    const MVMCProjectedAmplitudeResult *reference_global_aggregate,
+    const MVMCClassicPfaffianState *observed_state,
+    const double *observed_inverse,
+    MVMCClassicPfaffianAuditReport *report) {
+  MVMCPfaffianStatus local_status = MVMC_PFAFFIAN_STATUS_OK;
+  int failure_local_qp = -1, failure_global_qp = -1;
+  MVMCClassicPfaffianAuditMode mode =
+      mvmc_classic_pfaffian_real_audit_mode(audit_workspace);
+
+  reset_report(report, mode);
+  if (audit_workspace == NULL || collective_workspace == NULL ||
+      report == NULL || reference_global_aggregate == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!compare_real_components(
+          &audit_workspace->layout, reference_state, reference_inverse,
+          observed_state, observed_inverse, &failure_local_qp,
+          &failure_global_qp)) {
+    local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return finish_collective_compare(
+      &audit_workspace->layout, collective_workspace, local_status,
+      observed_state, failure_local_qp, failure_global_qp,
+      reference_global_aggregate, report);
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_audit_compare(
+    MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *reference_state,
+    const double complex *reference_inverse,
+    const MVMCProjectedAmplitudeResult *reference_global_aggregate,
+    const MVMCClassicPfaffianState *observed_state,
+    const double complex *observed_inverse,
+    MVMCClassicPfaffianAuditReport *report) {
+  MVMCPfaffianStatus local_status = MVMC_PFAFFIAN_STATUS_OK;
+  int failure_local_qp = -1, failure_global_qp = -1;
+  MVMCClassicPfaffianAuditMode mode =
+      mvmc_classic_pfaffian_complex_audit_mode(audit_workspace);
+
+  reset_report(report, mode);
+  if (audit_workspace == NULL || collective_workspace == NULL ||
+      report == NULL || reference_global_aggregate == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!compare_complex_components(
+          &audit_workspace->layout, reference_state, reference_inverse,
+          observed_state, observed_inverse, &failure_local_qp,
+          &failure_global_qp)) {
+    local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return finish_collective_compare(
+      &audit_workspace->layout, collective_workspace, local_status,
+      observed_state, failure_local_qp, failure_global_qp,
+      reference_global_aggregate, report);
+}
+
+static MVMCPfaffianStatus select_audit_mode(
+    MVMCClassicPfaffianAuditLayout *layout,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *accepted_state,
+    MVMCClassicPfaffianAuditReport *report) {
+  int all_eligible = 1;
+  MVMCPfaffianStatus status;
+
+  if (layout->mode == MVMC_CLASSIC_AUDIT_OFF) {
+    report->valid = 1;
+    report->status = MVMC_PFAFFIAN_STATUS_OK;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (layout->mode == MVMC_CLASSIC_AUDIT_GUARDED) {
+    status = mvmc_classic_pfaffian_collective_all_true(
+        collective_workspace, locally_eligible(layout, accepted_state),
+        &all_eligible);
+    if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+    if (!all_eligible) {
+      report->valid = 1;
+      report->status = MVMC_PFAFFIAN_STATUS_OK;
+      report->fallback = 1;
+      return MVMC_PFAFFIAN_STATUS_OK;
+    }
+  }
+  report->effective_mode = layout->mode;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_audit_candidate(
+    MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *accepted_state,
+    const MVMCClassicPfaffianState *absolute_candidate,
+    const double *absolute_candidate_inverse,
+    const MVMCProjectedAmplitudeResult *absolute_global_aggregate,
+    const double complex *global_weights,
+    MVMCClassicPfaffianRealObserver observer, void *observer_context,
+    MVMCClassicPfaffianAuditReport *report) {
+  MVMCClassicPfaffianRealObservation observation;
+  MVMCClassicPfaffianState observed_state;
+  MVMCPfaffianStatus local_status;
+  MVMCPfaffianStatus status;
+
+  reset_report(report, mvmc_classic_pfaffian_real_audit_mode(audit_workspace));
+  if (audit_workspace == NULL || collective_workspace == NULL ||
+      report == NULL || absolute_candidate == NULL ||
+      absolute_global_aggregate == NULL || global_weights == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = select_audit_mode(&audit_workspace->layout, collective_workspace,
+                             accepted_state, report);
+  if (status != MVMC_PFAFFIAN_STATUS_OK || report->fallback ||
+      audit_workspace->layout.mode == MVMC_CLASSIC_AUDIT_OFF) {
+    return status;
+  }
+  if (observer == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (audit_workspace->layout.local_qp_count != 0) {
+    memset(audit_workspace->layout.components, 0,
+           audit_workspace->layout.local_qp_count *
+               sizeof(*audit_workspace->layout.components));
+  }
+  if (audit_workspace->layout.inverse_count != 0) {
+    memset(audit_workspace->inverse, 0,
+           audit_workspace->layout.inverse_count *
+               sizeof(*audit_workspace->inverse));
+  }
+  memset(&observation, 0, sizeof(observation));
+  observation.component_count = audit_workspace->layout.local_qp_count;
+  observation.matrix_element_count = audit_workspace->layout.matrix_count;
+  observation.components = audit_workspace->layout.components;
+  observation.inverse = audit_workspace->inverse;
+  local_status = observer(observer_context, absolute_candidate,
+                          absolute_candidate_inverse, &observation);
+  memset(&observed_state, 0, sizeof(observed_state));
+  observed_state.components = audit_workspace->layout.components;
+  if (local_status == MVMC_PFAFFIAN_STATUS_OK &&
+      observation.valid == 1 &&
+      observation.components == audit_workspace->layout.components &&
+      observation.inverse == audit_workspace->inverse &&
+      observation.component_count == audit_workspace->layout.local_qp_count &&
+      observation.matrix_element_count == audit_workspace->layout.matrix_count) {
+    observed_state.valid = 1;
+    observed_state.components = observation.components;
+    local_status = project_observation(
+        &audit_workspace->layout, observation.components, global_weights,
+        &observed_state.local_aggregate);
+  } else if (local_status == MVMC_PFAFFIAN_STATUS_OK) {
+    local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (local_status != MVMC_PFAFFIAN_STATUS_OK) {
+    observed_state.valid = 0;
+  }
+  {
+    int failure_local_qp = -1, failure_global_qp = -1;
+    if (local_status == MVMC_PFAFFIAN_STATUS_OK &&
+        !compare_real_components(
+            &audit_workspace->layout, absolute_candidate,
+            absolute_candidate_inverse, &observed_state,
+            audit_workspace->inverse, &failure_local_qp,
+            &failure_global_qp)) {
+      local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    return finish_collective_compare(
+        &audit_workspace->layout, collective_workspace, local_status,
+        &observed_state, failure_local_qp, failure_global_qp,
+        absolute_global_aggregate, report);
+  }
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_audit_candidate(
+    MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *accepted_state,
+    const MVMCClassicPfaffianState *absolute_candidate,
+    const double complex *absolute_candidate_inverse,
+    const MVMCProjectedAmplitudeResult *absolute_global_aggregate,
+    const double complex *global_weights,
+    MVMCClassicPfaffianComplexObserver observer, void *observer_context,
+    MVMCClassicPfaffianAuditReport *report) {
+  MVMCClassicPfaffianComplexObservation observation;
+  MVMCClassicPfaffianState observed_state;
+  MVMCPfaffianStatus local_status;
+  MVMCPfaffianStatus status;
+
+  reset_report(report,
+               mvmc_classic_pfaffian_complex_audit_mode(audit_workspace));
+  if (audit_workspace == NULL || collective_workspace == NULL ||
+      report == NULL || absolute_candidate == NULL ||
+      absolute_global_aggregate == NULL || global_weights == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = select_audit_mode(&audit_workspace->layout, collective_workspace,
+                             accepted_state, report);
+  if (status != MVMC_PFAFFIAN_STATUS_OK || report->fallback ||
+      audit_workspace->layout.mode == MVMC_CLASSIC_AUDIT_OFF) {
+    return status;
+  }
+  if (observer == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (audit_workspace->layout.local_qp_count != 0) {
+    memset(audit_workspace->layout.components, 0,
+           audit_workspace->layout.local_qp_count *
+               sizeof(*audit_workspace->layout.components));
+  }
+  if (audit_workspace->layout.inverse_count != 0) {
+    memset(audit_workspace->inverse, 0,
+           audit_workspace->layout.inverse_count *
+               sizeof(*audit_workspace->inverse));
+  }
+  memset(&observation, 0, sizeof(observation));
+  observation.component_count = audit_workspace->layout.local_qp_count;
+  observation.matrix_element_count = audit_workspace->layout.matrix_count;
+  observation.components = audit_workspace->layout.components;
+  observation.inverse = audit_workspace->inverse;
+  local_status = observer(observer_context, absolute_candidate,
+                          absolute_candidate_inverse, &observation);
+  memset(&observed_state, 0, sizeof(observed_state));
+  observed_state.components = audit_workspace->layout.components;
+  if (local_status == MVMC_PFAFFIAN_STATUS_OK &&
+      observation.valid == 1 &&
+      observation.components == audit_workspace->layout.components &&
+      observation.inverse == audit_workspace->inverse &&
+      observation.component_count == audit_workspace->layout.local_qp_count &&
+      observation.matrix_element_count == audit_workspace->layout.matrix_count) {
+    observed_state.valid = 1;
+    observed_state.components = observation.components;
+    local_status = project_observation(
+        &audit_workspace->layout, observation.components, global_weights,
+        &observed_state.local_aggregate);
+  } else if (local_status == MVMC_PFAFFIAN_STATUS_OK) {
+    local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (local_status != MVMC_PFAFFIAN_STATUS_OK) {
+    observed_state.valid = 0;
+  }
+  {
+    int failure_local_qp = -1, failure_global_qp = -1;
+    if (local_status == MVMC_PFAFFIAN_STATUS_OK &&
+        !compare_complex_components(
+            &audit_workspace->layout, absolute_candidate,
+            absolute_candidate_inverse, &observed_state,
+            audit_workspace->inverse, &failure_local_qp,
+            &failure_global_qp)) {
+      local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    return finish_collective_compare(
+        &audit_workspace->layout, collective_workspace, local_status,
+        &observed_state, failure_local_qp, failure_global_qp,
+        absolute_global_aggregate, report);
+  }
+}

--- a/src/mVMC/classic_pfaffian_collective.c
+++ b/src/mVMC/classic_pfaffian_collective.c
@@ -1,0 +1,573 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_pfaffian_collective.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct MVMCClassicPfaffianCollectiveWorkspace {
+  int rank;
+  int size;
+  int *ranges;
+#ifdef _mpi_use
+  MPI_Comm communicator;
+#endif
+};
+
+static int valid_status(MVMCPfaffianStatus status) {
+  return status >= MVMC_PFAFFIAN_STATUS_OK &&
+         status <= MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+}
+
+#ifdef _mpi_use
+static int status_severity(MVMCPfaffianStatus status) {
+  switch (status) {
+    case MVMC_PFAFFIAN_STATUS_OK:
+      return 0;
+    case MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT:
+      return 1;
+    case MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE:
+      return 2;
+    case MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE:
+      return 3;
+    case MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE:
+      return 4;
+    default:
+      return 1;
+  }
+}
+#endif
+
+static int valid_local_aggregate(
+    const MVMCProjectedAmplitudeResult *aggregate, size_t expected_count) {
+  size_t counted;
+
+  if (aggregate == NULL || aggregate->valid != 1 ||
+      !isfinite(creal(aggregate->total)) ||
+      !isfinite(cimag(aggregate->total)) ||
+      !isfinite(aggregate->sum_abs) || aggregate->sum_abs < 0.0 ||
+      !isfinite(aggregate->cancellation_ratio) ||
+      aggregate->cancellation_ratio < 0.0 ||
+      aggregate->cancellation_ratio > 1.0 ||
+      aggregate->regular_count > expected_count ||
+      aggregate->near_singular_count > expected_count ||
+      aggregate->singular_count > expected_count) {
+    return 0;
+  }
+  counted = aggregate->regular_count + aggregate->near_singular_count;
+  if (counted < aggregate->regular_count ||
+      aggregate->singular_count > SIZE_MAX - counted) {
+    return 0;
+  }
+  return counted + aggregate->singular_count == expected_count;
+}
+
+static void reset_collective_result(
+    MVMCClassicPfaffianCollectiveResult *result) {
+  if (result == NULL) return;
+  memset(result, 0, sizeof(*result));
+  result->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  result->failure_rank = -1;
+  result->failure_local_qp = -1;
+  result->failure_global_qp = -1;
+}
+
+static int first_invalid_partition(const int *ranges, int size) {
+  /*
+   * Rank 0 supplies the comparison qp_total.  The returned blame rank is
+   * therefore the first rank that disagrees with rank 0, not necessarily the
+   * rank where an erroneous caller value originated.
+   */
+  const int qp_total = ranges[0];
+  int rank;
+
+  if (qp_total <= 0) return 0;
+  for (rank = 0; rank < size; ++rank) {
+    const int *range = ranges + (size_t)rank * 3;
+    if (range[0] != qp_total || range[1] < 0 ||
+        range[2] < range[1] || range[2] > qp_total) {
+      return rank;
+    }
+    if ((rank == 0 && range[1] != 0) ||
+        (rank > 0 && range[1] != ranges[(size_t)(rank - 1) * 3 + 2])) {
+      return rank;
+    }
+  }
+  return ranges[(size_t)(size - 1) * 3 + 2] == qp_total ? -1 : size - 1;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_workspace_create(
+    MVMCClassicPfaffianCommunicator communicator,
+    MVMCClassicPfaffianCollectiveWorkspace **workspace) {
+  MVMCClassicPfaffianCollectiveWorkspace *created = NULL;
+  int size = 1;
+#ifdef _mpi_use
+  MPI_Comm duplicated = MPI_COMM_NULL;
+  int initialized = 0;
+  int allocation_ok, all_allocation_ok;
+
+  if (workspace == NULL || communicator == MPI_COMM_NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (MPI_Initialized(&initialized) != MPI_SUCCESS || !initialized ||
+      MPI_Comm_dup(communicator, &duplicated) != MPI_SUCCESS ||
+      MPI_Comm_size(duplicated, &size) != MPI_SUCCESS || size <= 0) {
+    if (duplicated != MPI_COMM_NULL) MPI_Comm_free(&duplicated);
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCClassicPfaffianCollectiveWorkspace *)calloc(
+      1, sizeof(*created));
+  if (created != NULL &&
+      (size_t)size <= SIZE_MAX / (3 * sizeof(*created->ranges))) {
+    created->ranges = (int *)calloc((size_t)size * 3,
+                                    sizeof(*created->ranges));
+  }
+  allocation_ok = created != NULL && created->ranges != NULL;
+  if (MPI_Allreduce(&allocation_ok, &all_allocation_ok, 1, MPI_INT, MPI_MIN,
+                    duplicated) != MPI_SUCCESS) {
+    all_allocation_ok = 0;
+  }
+  if (!all_allocation_ok || created == NULL || created->ranges == NULL) {
+    if (created != NULL) {
+      free(created->ranges);
+      free(created);
+    }
+    MPI_Comm_free(&duplicated);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  if (MPI_Comm_rank(duplicated, &created->rank) != MPI_SUCCESS) {
+    free(created->ranges);
+    free(created);
+    MPI_Comm_free(&duplicated);
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created->size = size;
+  created->communicator = duplicated;
+#else
+  (void)communicator;
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  created = (MVMCClassicPfaffianCollectiveWorkspace *)calloc(
+      1, sizeof(*created));
+  if (created != NULL) {
+    created->ranges = (int *)calloc(3, sizeof(*created->ranges));
+  }
+  if (created == NULL || created->ranges == NULL) {
+    if (created != NULL) free(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  created->rank = 0;
+  created->size = size;
+#endif
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_classic_pfaffian_collective_workspace_destroy(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace) {
+  if (workspace == NULL) return;
+#ifdef _mpi_use
+  if (workspace->communicator != MPI_COMM_NULL) {
+    MPI_Comm_free(&workspace->communicator);
+  }
+#endif
+  free(workspace->ranges);
+  free(workspace);
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_aggregate(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    MVMCPfaffianStatus local_status,
+    const MVMCProjectedAmplitudeResult *local_aggregate,
+    int qp_total, int qp_start, int qp_end,
+    int failure_local_qp, int failure_global_qp,
+    MVMCClassicPfaffianCollectiveResult *result) {
+  MVMCClassicPfaffianCollectiveResult discarded_result;
+  MVMCPfaffianStatus effective_status;
+  const int result_available = result != NULL;
+  int local_range[3] = {qp_total, qp_start, qp_end};
+  int partition_failure_rank;
+  int selected_rank;
+  int failure_payload[3] = {
+      (int)MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT, -1, -1};
+  double complex local_total = 0.0;
+  double complex global_total = 0.0;
+  double local_sum_abs = 0.0;
+  double global_sum_abs = 0.0;
+  uint64_t local_counts[3] = {0, 0, 0};
+  uint64_t global_counts[3] = {0, 0, 0};
+  size_t expected_count = 0;
+#ifdef _mpi_use
+  struct {
+    int value;
+    int index;
+  } local_selection, global_selection;
+#endif
+
+  if (!result_available) result = &discarded_result;
+  reset_collective_result(result);
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+
+#ifdef _mpi_use
+  if (MPI_Allgather(local_range, 3, MPI_INT, workspace->ranges, 3, MPI_INT,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  memcpy(workspace->ranges, local_range, sizeof(local_range));
+#endif
+  partition_failure_rank =
+      first_invalid_partition(workspace->ranges, workspace->size);
+
+  effective_status = valid_status(local_status)
+                         ? local_status
+                         : MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (!result_available &&
+      effective_status == MVMC_PFAFFIAN_STATUS_OK) {
+    effective_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    failure_local_qp = -1;
+    failure_global_qp = -1;
+  }
+  if (partition_failure_rank == workspace->rank &&
+      effective_status == MVMC_PFAFFIAN_STATUS_OK) {
+    effective_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    failure_local_qp = -1;
+    failure_global_qp = -1;
+  }
+  if (qp_start >= 0 && qp_end >= qp_start) {
+    expected_count = (size_t)(qp_end - qp_start);
+  }
+  if (effective_status == MVMC_PFAFFIAN_STATUS_OK &&
+      local_aggregate == NULL) {
+    effective_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    failure_local_qp = -1;
+    failure_global_qp = -1;
+  }
+  if (effective_status == MVMC_PFAFFIAN_STATUS_OK &&
+      !valid_local_aggregate(local_aggregate, expected_count)) {
+    effective_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    failure_local_qp = -1;
+    failure_global_qp = -1;
+  }
+#if SIZE_MAX > UINT64_MAX
+  if (effective_status == MVMC_PFAFFIAN_STATUS_OK &&
+      (local_aggregate->regular_count > UINT64_MAX ||
+       local_aggregate->near_singular_count > UINT64_MAX ||
+       local_aggregate->singular_count > UINT64_MAX)) {
+    effective_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    failure_local_qp = -1;
+    failure_global_qp = -1;
+  }
+#endif
+
+#ifdef _mpi_use
+  local_selection.value = status_severity(effective_status);
+  local_selection.index = workspace->rank;
+  if (MPI_Allreduce(&local_selection, &global_selection, 1, MPI_2INT,
+                    MPI_MAXLOC, workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  selected_rank = global_selection.index;
+#else
+  selected_rank = 0;
+#endif
+  if (workspace->rank == selected_rank) {
+    failure_payload[0] = (int)effective_status;
+    failure_payload[1] = effective_status == MVMC_PFAFFIAN_STATUS_OK
+                             ? -1
+                             : failure_local_qp;
+    failure_payload[2] = effective_status == MVMC_PFAFFIAN_STATUS_OK
+                             ? -1
+                             : failure_global_qp;
+  }
+#ifdef _mpi_use
+  if (MPI_Bcast(failure_payload, 3, MPI_INT, selected_rank,
+                workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#endif
+
+  if (effective_status == MVMC_PFAFFIAN_STATUS_OK) {
+    local_total = local_aggregate->total;
+    local_sum_abs = local_aggregate->sum_abs;
+    local_counts[0] = (uint64_t)local_aggregate->regular_count;
+    local_counts[1] = (uint64_t)local_aggregate->near_singular_count;
+    local_counts[2] = (uint64_t)local_aggregate->singular_count;
+  }
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_total, &global_total, 1, MPI_C_DOUBLE_COMPLEX,
+                    MPI_SUM, workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(&local_sum_abs, &global_sum_abs, 1, MPI_DOUBLE, MPI_SUM,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(local_counts, global_counts, 3, MPI_UINT64_T, MPI_SUM,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  global_total = local_total;
+  global_sum_abs = local_sum_abs;
+  memcpy(global_counts, local_counts, sizeof(global_counts));
+#endif
+
+  result->status = (MVMCPfaffianStatus)failure_payload[0];
+  if (result->status != MVMC_PFAFFIAN_STATUS_OK) {
+    result->failure_rank = selected_rank;
+    result->failure_local_qp = failure_payload[1];
+    result->failure_global_qp = failure_payload[2];
+    return result->status;
+  }
+  if (!isfinite(creal(global_total)) || !isfinite(cimag(global_total)) ||
+      !isfinite(global_sum_abs) || global_sum_abs < 0.0 ||
+      global_counts[0] + global_counts[1] < global_counts[0] ||
+      global_counts[2] > UINT64_MAX -
+                             (global_counts[0] + global_counts[1]) ||
+      global_counts[0] + global_counts[1] + global_counts[2] !=
+          (uint64_t)workspace->ranges[0]) {
+    result->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    return result->status;
+  }
+#if SIZE_MAX < UINT64_MAX
+  if (global_counts[0] > (uint64_t)SIZE_MAX ||
+      global_counts[1] > (uint64_t)SIZE_MAX ||
+      global_counts[2] > (uint64_t)SIZE_MAX) {
+    result->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    return result->status;
+  }
+#endif
+
+  result->aggregate.total = global_total;
+  result->aggregate.sum_abs = global_sum_abs;
+  result->aggregate.cancellation_ratio =
+      global_sum_abs == 0.0
+          ? 0.0
+          : fmin(1.0, cabs(global_total) / global_sum_abs);
+  result->aggregate.regular_count = (size_t)global_counts[0];
+  result->aggregate.near_singular_count = (size_t)global_counts[1];
+  result->aggregate.singular_count = (size_t)global_counts[2];
+  result->aggregate.valid = 1;
+  result->valid = 1;
+  result->status = MVMC_PFAFFIAN_STATUS_OK;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_prepare_collective(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCClassicPfaffianCollectiveResult *result) {
+  MVMCPfaffianStatus local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  MVMCPfaffianStatus global_status;
+  const MVMCClassicPfaffianState *candidate = NULL;
+  int qp_total = -1, qp_start = -1, qp_end = -1;
+  int failure_local_qp = -1, failure_global_qp = -1;
+
+  if (state_workspace != NULL &&
+      mvmc_classic_pfaffian_real_qp_range(
+          state_workspace, &qp_total, &qp_start, &qp_end)) {
+    local_status = mvmc_classic_pfaffian_real_prepare(
+        state_workspace, slater_elm, ele_idx, global_weights,
+        scaled_pivot_tolerance, residual_tolerance);
+    failure_local_qp =
+        mvmc_classic_pfaffian_real_failure_local_qp(state_workspace);
+    failure_global_qp =
+        mvmc_classic_pfaffian_real_failure_global_qp(state_workspace);
+    if (local_status == MVMC_PFAFFIAN_STATUS_OK) {
+      candidate = mvmc_classic_pfaffian_real_candidate(state_workspace);
+    }
+  }
+  global_status = mvmc_classic_pfaffian_collective_aggregate(
+      collective_workspace, local_status,
+      candidate == NULL ? NULL : &candidate->local_aggregate,
+      qp_total, qp_start, qp_end, failure_local_qp, failure_global_qp,
+      result);
+  if (global_status != MVMC_PFAFFIAN_STATUS_OK && state_workspace != NULL) {
+    mvmc_classic_pfaffian_real_discard_candidate(state_workspace);
+  }
+  return global_status;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_prepare_collective(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCClassicPfaffianCollectiveResult *result) {
+  MVMCPfaffianStatus local_status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  MVMCPfaffianStatus global_status;
+  const MVMCClassicPfaffianState *candidate = NULL;
+  int qp_total = -1, qp_start = -1, qp_end = -1;
+  int failure_local_qp = -1, failure_global_qp = -1;
+
+  if (state_workspace != NULL &&
+      mvmc_classic_pfaffian_complex_qp_range(
+          state_workspace, &qp_total, &qp_start, &qp_end)) {
+    local_status = mvmc_classic_pfaffian_complex_prepare(
+        state_workspace, slater_elm, ele_idx, global_weights,
+        scaled_pivot_tolerance, residual_tolerance);
+    failure_local_qp =
+        mvmc_classic_pfaffian_complex_failure_local_qp(state_workspace);
+    failure_global_qp =
+        mvmc_classic_pfaffian_complex_failure_global_qp(state_workspace);
+    if (local_status == MVMC_PFAFFIAN_STATUS_OK) {
+      candidate = mvmc_classic_pfaffian_complex_candidate(state_workspace);
+    }
+  }
+  global_status = mvmc_classic_pfaffian_collective_aggregate(
+      collective_workspace, local_status,
+      candidate == NULL ? NULL : &candidate->local_aggregate,
+      qp_total, qp_start, qp_end, failure_local_qp, failure_global_qp,
+      result);
+  if (global_status != MVMC_PFAFFIAN_STATUS_OK && state_workspace != NULL) {
+    mvmc_classic_pfaffian_complex_discard_candidate(state_workspace);
+  }
+  return global_status;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_metropolis(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    double complex current_total, double complex proposal_total,
+    double log_non_pfaffian_ratio, double uniform,
+    MVMCClassicPfaffianMetropolisResult *result) {
+  MVMCClassicPfaffianMetropolisResult discarded_result;
+  double values[6] = {creal(current_total), cimag(current_total),
+                      creal(proposal_total), cimag(proposal_total),
+                      log_non_pfaffian_ratio, uniform};
+  double minimum[6];
+  double maximum[6];
+  int local_valid;
+  int global_valid;
+  int i;
+  double log_acceptance;
+
+  if (result == NULL) result = &discarded_result;
+  memset(result, 0, sizeof(*result));
+  result->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  result->log_acceptance_ratio = -INFINITY;
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+
+  local_valid = isfinite(values[0]) && isfinite(values[1]) &&
+                isfinite(values[2]) && isfinite(values[3]) &&
+                !isnan(log_non_pfaffian_ratio) && isfinite(uniform) &&
+                uniform >= 0.0 && uniform < 1.0 &&
+                cabs(current_total) != 0.0 &&
+                result != &discarded_result;
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_valid, &global_valid, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(values, minimum, 6, MPI_DOUBLE, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(values, maximum, 6, MPI_DOUBLE, MPI_MAX,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  global_valid = local_valid;
+  memcpy(minimum, values, sizeof(minimum));
+  memcpy(maximum, values, sizeof(maximum));
+#endif
+  for (i = 0; i < 6; ++i) {
+    if (minimum[i] != maximum[i]) global_valid = 0;
+  }
+  if (!global_valid) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+
+  if (cabs(proposal_total) == 0.0) {
+    result->valid = 1;
+    result->status = MVMC_PFAFFIAN_STATUS_OK;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  log_acceptance = 2.0 *
+      (log_non_pfaffian_ratio + log(cabs(proposal_total)) -
+       log(cabs(current_total)));
+  if (isnan(log_acceptance)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  result->accepted = log_acceptance != -INFINITY &&
+      (uniform == 0.0 ||
+       log(uniform) < fmin(0.0, log_acceptance));
+  result->log_acceptance_ratio = log_acceptance;
+  result->valid = 1;
+  result->status = MVMC_PFAFFIAN_STATUS_OK;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_preflight(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    int local_valid, int branch_kind) {
+  int global_valid;
+  int minimum_kind;
+  int maximum_kind;
+
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  local_valid = local_valid == 1;
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_valid, &global_valid, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(&branch_kind, &minimum_kind, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(&branch_kind, &maximum_kind, 1, MPI_INT, MPI_MAX,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  global_valid = local_valid;
+  minimum_kind = branch_kind;
+  maximum_kind = branch_kind;
+#endif
+  return global_valid && minimum_kind == maximum_kind
+             ? MVMC_PFAFFIAN_STATUS_OK
+             : MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_true(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    int local_true, int *all_true) {
+  int local_valid;
+  int global_valid;
+  int global_true;
+
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  local_valid = (local_true == 0 || local_true == 1) && all_true != NULL;
+  if (!local_valid) local_true = 0;
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_valid, &global_valid, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(&local_true, &global_true, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  global_valid = local_valid;
+  global_true = local_true;
+#endif
+  if (!global_valid) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *all_true = global_true;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}

--- a/src/mVMC/classic_pfaffian_sampler.c
+++ b/src/mVMC/classic_pfaffian_sampler.c
@@ -1,0 +1,467 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_pfaffian_sampler.h"
+
+#if !defined(MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE)
+#error "classic_pfaffian_sampler.c is Testing-only"
+#endif
+#if !defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+#error "classic_pfaffian_sampler.c requires the Testing-only audit module"
+#endif
+
+#include <math.h>
+#include <string.h>
+
+enum {
+  MVMC_CLASSIC_BRANCH_INITIALIZE = 0,
+  MVMC_CLASSIC_BRANCH_PROPOSE_BASE = 1,
+  MVMC_CLASSIC_BRANCH_PROPOSE_STRIDE = 3,
+  MVMC_CLASSIC_BRANCH_REBUILD_REAL = 13,
+  MVMC_CLASSIC_BRANCH_REBUILD_COMPLEX = 16
+};
+
+static int valid_move(MVMCClassicMoveKind move) {
+  return move >= MVMC_CLASSIC_MOVE_HOPPING &&
+         move <= MVMC_CLASSIC_MOVE_PAIR_HOPPING;
+}
+
+static void reset_sampler_state(MVMCClassicSamplerState *state) {
+  if (state != NULL) memset(state, 0, sizeof(*state));
+}
+
+static void reset_proposal_result(MVMCClassicProposalResult *result,
+                                  MVMCClassicMoveKind move) {
+  if (result == NULL) return;
+  memset(result, 0, sizeof(*result));
+  result->status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  result->move = move;
+  result->decision = MVMC_CLASSIC_PROPOSAL_ERROR;
+  result->uniform = NAN;
+  result->log_acceptance_ratio = -INFINITY;
+  result->audit.status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  result->audit.failure_rank = -1;
+  result->audit.failure_local_qp = -1;
+  result->audit.failure_global_qp = -1;
+}
+
+static int valid_metadata(const MVMCClassicProposalMetadata *metadata) {
+  return metadata == NULL ||
+         (metadata->index_count >= 0 &&
+          metadata->index_count <= MVMC_CLASSIC_TRACE_INDEX_CAPACITY);
+}
+
+static void reset_trace(MVMCClassicProposalTrace *trace,
+                        MVMCClassicMoveKind move,
+                        const MVMCClassicProposalMetadata *metadata,
+                        MVMCClassicPfaffianAuditMode requested_mode) {
+  int index;
+
+  if (trace == NULL) return;
+  memset(trace, 0, sizeof(*trace));
+  trace->move = move;
+  trace->requested_audit_mode = requested_mode;
+  trace->effective_audit_mode = MVMC_CLASSIC_AUDIT_OFF;
+  trace->uniform = NAN;
+  if (metadata == NULL || !valid_metadata(metadata)) return;
+  trace->proposal_id = metadata->proposal_id;
+  trace->index_count = metadata->index_count;
+  for (index = 0; index < metadata->index_count; ++index) {
+    trace->indices[index] = metadata->indices[index];
+  }
+}
+
+static void finish_trace(MVMCClassicProposalTrace *trace,
+                         const MVMCClassicProposalResult *result,
+                         const MVMCProjectedAmplitudeResult *proposal) {
+  if (trace == NULL || result == NULL || proposal == NULL) return;
+  trace->effective_audit_mode = result->audit.effective_mode;
+  trace->audit_executed = result->audit.executed;
+  trace->audit_fallback = result->audit.fallback;
+  trace->uniform_draw_count = result->uniform_draw_count;
+  trace->uniform = result->uniform;
+  trace->current_total = result->current_total;
+  trace->proposal_total = result->proposal_total;
+  trace->regular_count = proposal->regular_count;
+  trace->near_singular_count = proposal->near_singular_count;
+  trace->singular_count = proposal->singular_count;
+  trace->decision = result->decision;
+  trace->accepted_generation = result->accepted_generation;
+  trace->valid = result->valid;
+}
+
+MVMCPfaffianStatus mvmc_classic_sampler_real_initialize(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double *legacy_storage, size_t legacy_element_count,
+    MVMCClassicSamplerState *sampler_state) {
+  MVMCClassicPfaffianCollectiveResult prepared;
+  MVMCPfaffianStatus status;
+
+  reset_sampler_state(sampler_state);
+  status = mvmc_classic_pfaffian_collective_preflight(
+      collective_workspace,
+      sampler_state != NULL && state_workspace != NULL &&
+          legacy_storage != NULL &&
+          legacy_element_count >=
+              mvmc_classic_pfaffian_real_legacy_element_count(
+                  state_workspace),
+      MVMC_CLASSIC_BRANCH_INITIALIZE);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, slater_elm, ele_idx,
+      global_weights, scaled_pivot_tolerance, residual_tolerance, &prepared);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  if (cabs(prepared.aggregate.total) == 0.0) {
+    mvmc_classic_pfaffian_real_discard_candidate(state_workspace);
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = mvmc_classic_pfaffian_real_publish(
+      state_workspace, legacy_storage, legacy_element_count);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  sampler_state->accepted_aggregate = prepared.aggregate;
+  sampler_state->valid = 1;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_initialize(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double complex *legacy_storage, size_t legacy_element_count,
+    MVMCClassicSamplerState *sampler_state) {
+  MVMCClassicPfaffianCollectiveResult prepared;
+  MVMCPfaffianStatus status;
+
+  reset_sampler_state(sampler_state);
+  status = mvmc_classic_pfaffian_collective_preflight(
+      collective_workspace,
+      sampler_state != NULL && state_workspace != NULL &&
+          legacy_storage != NULL &&
+          legacy_element_count >=
+              mvmc_classic_pfaffian_complex_legacy_element_count(
+                  state_workspace),
+      MVMC_CLASSIC_BRANCH_INITIALIZE);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  status = mvmc_classic_pfaffian_complex_prepare_collective(
+      state_workspace, collective_workspace, slater_elm, ele_idx,
+      global_weights, scaled_pivot_tolerance, residual_tolerance, &prepared);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  if (cabs(prepared.aggregate.total) == 0.0) {
+    mvmc_classic_pfaffian_complex_discard_candidate(state_workspace);
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = mvmc_classic_pfaffian_complex_publish(
+      state_workspace, legacy_storage, legacy_element_count);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  sampler_state->accepted_aggregate = prepared.aggregate;
+  sampler_state->valid = 1;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+#define DEFINE_PROPOSE_INTERNAL(                                               \
+    NAME, TYPE, AUDIT_CONTROL, PREPARE, PUBLISH, DISCARD, ACCEPTED,            \
+    CANDIDATE, CANDIDATE_INVERSE, LEGACY_COUNT, AUDIT_MODE,                    \
+    AUDIT_COMPATIBLE, AUDIT_CANDIDATE)                                         \
+static MVMCPfaffianStatus NAME(                                                \
+    TYPE *state_workspace,                                                    \
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,             \
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,          \
+    const ELEMENT_TYPE *slater_elm, const int *ele_idx,                        \
+    const double complex *global_weights,                                     \
+    double scaled_pivot_tolerance, double residual_tolerance,                  \
+    double log_projection_ratio, double log_rbm_ratio,                         \
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,                   \
+    const AUDIT_CONTROL *audit,                                                \
+    ELEMENT_TYPE *legacy_storage, size_t legacy_element_count,                 \
+    MVMCClassicProposalResult *result) {                                       \
+  MVMCClassicPfaffianCollectiveResult prepared;                                \
+  MVMCClassicPfaffianMetropolisResult metropolis;                              \
+  const MVMCClassicPfaffianState *accepted;                                    \
+  const MVMCClassicProposalMetadata *metadata =                                \
+      audit == NULL ? NULL : audit->metadata;                                  \
+  MVMCClassicProposalTrace *trace = audit == NULL ? NULL : audit->trace;       \
+  MVMCClassicPfaffianAuditMode audit_mode =                                    \
+      audit == NULL ? MVMC_CLASSIC_AUDIT_OFF : AUDIT_MODE(audit->workspace);   \
+  MVMCPfaffianStatus status;                                                   \
+  int branch_kind;                                                             \
+  int audit_valid;                                                             \
+  double uniform;                                                              \
+  reset_proposal_result(result, move);                                         \
+  reset_trace(trace, move, metadata, audit_mode);                              \
+  audit_valid = audit == NULL ||                                               \
+      (audit->workspace != NULL && valid_metadata(metadata) &&                 \
+       AUDIT_COMPATIBLE(audit->workspace, state_workspace) &&                  \
+       (audit_mode == MVMC_CLASSIC_AUDIT_OFF || audit->observer != NULL));      \
+  branch_kind = valid_move(move)                                               \
+      ? MVMC_CLASSIC_BRANCH_PROPOSE_BASE +                                     \
+            (int)move * MVMC_CLASSIC_BRANCH_PROPOSE_STRIDE + (int)audit_mode   \
+      : MVMC_CLASSIC_BRANCH_PROPOSE_BASE;                                      \
+  status = mvmc_classic_pfaffian_collective_preflight(                         \
+      collective_workspace,                                                   \
+      state_workspace != NULL && sampler_state != NULL &&                      \
+          sampler_state->valid && result != NULL && valid_move(move) &&        \
+          draw_uniform != NULL && !isnan(log_projection_ratio) &&              \
+          !isnan(log_rbm_ratio) && legacy_storage != NULL && audit_valid &&    \
+          legacy_element_count >= LEGACY_COUNT(state_workspace),               \
+      branch_kind);                                                            \
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;                        \
+  /* Keep a local guard after collective preflight: it is both defensive and  \
+   * makes the pointer contract explicit to static analysis. */                \
+  if (state_workspace == NULL || sampler_state == NULL ||                      \
+      !sampler_state->valid || result == NULL || !valid_move(move) ||          \
+      draw_uniform == NULL || isnan(log_projection_ratio) ||                   \
+      isnan(log_rbm_ratio) || legacy_storage == NULL || !audit_valid ||        \
+      legacy_element_count < LEGACY_COUNT(state_workspace)) {                  \
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;                              \
+  }                                                                            \
+  result->current_total = sampler_state->accepted_aggregate.total;             \
+  status = PREPARE(state_workspace, collective_workspace, slater_elm, ele_idx,\
+                   global_weights, scaled_pivot_tolerance,                     \
+                   residual_tolerance, &prepared);                             \
+  if (status != MVMC_PFAFFIAN_STATUS_OK) {                                     \
+    result->status = status;                                                   \
+    return status;                                                             \
+  }                                                                            \
+  result->proposal_total = prepared.aggregate.total;                           \
+  if (audit != NULL) {                                                         \
+    status = AUDIT_CANDIDATE(                                                  \
+        audit->workspace, collective_workspace, ACCEPTED(state_workspace),    \
+        CANDIDATE(state_workspace), CANDIDATE_INVERSE(state_workspace),        \
+        &prepared.aggregate, global_weights, audit->observer,                  \
+        audit->observer_context, &result->audit);                              \
+    if (status != MVMC_PFAFFIAN_STATUS_OK) {                                   \
+      DISCARD(state_workspace);                                                \
+      result->status = status;                                                 \
+      return status;                                                           \
+    }                                                                          \
+  } else {                                                                     \
+    result->audit.valid = 1;                                                   \
+    result->audit.status = MVMC_PFAFFIAN_STATUS_OK;                            \
+    result->audit.requested_mode = MVMC_CLASSIC_AUDIT_OFF;                     \
+    result->audit.effective_mode = MVMC_CLASSIC_AUDIT_OFF;                     \
+  }                                                                            \
+  uniform = draw_uniform(draw_context);                                        \
+  result->uniform = uniform;                                                   \
+  result->uniform_draw_count = 1;                                              \
+  status = mvmc_classic_pfaffian_collective_metropolis(                        \
+      collective_workspace, result->current_total, result->proposal_total,    \
+      log_projection_ratio + log_rbm_ratio, uniform, &metropolis);             \
+  if (status != MVMC_PFAFFIAN_STATUS_OK) {                                     \
+    DISCARD(state_workspace);                                                  \
+    result->status = status;                                                   \
+    return status;                                                             \
+  }                                                                            \
+  result->log_acceptance_ratio = metropolis.log_acceptance_ratio;              \
+  if (metropolis.accepted) {                                                   \
+    /* Preflight validated mirror capacity; prepare validated candidate. */    \
+    status = PUBLISH(state_workspace, legacy_storage, legacy_element_count);   \
+    if (status != MVMC_PFAFFIAN_STATUS_OK) {                                   \
+      result->status = status;                                                 \
+      return status;                                                           \
+    }                                                                          \
+    sampler_state->accepted_aggregate = prepared.aggregate;                    \
+    result->decision = MVMC_CLASSIC_PROPOSAL_ACCEPTED;                         \
+  } else {                                                                     \
+    DISCARD(state_workspace);                                                  \
+    result->decision = MVMC_CLASSIC_PROPOSAL_REJECTED;                         \
+  }                                                                            \
+  accepted = ACCEPTED(state_workspace);                                        \
+  result->accepted_generation = accepted == NULL ? 0 : accepted->generation;   \
+  result->valid = 1;                                                           \
+  result->status = MVMC_PFAFFIAN_STATUS_OK;                                    \
+  finish_trace(trace, result, &prepared.aggregate);                            \
+  return MVMC_PFAFFIAN_STATUS_OK;                                              \
+}
+
+#define ELEMENT_TYPE double
+DEFINE_PROPOSE_INTERNAL(
+    propose_real_internal, MVMCClassicPfaffianRealWorkspace,
+    MVMCClassicRealProposalAudit,
+    mvmc_classic_pfaffian_real_prepare_collective,
+    mvmc_classic_pfaffian_real_publish,
+    mvmc_classic_pfaffian_real_discard_candidate,
+    mvmc_classic_pfaffian_real_accepted,
+    mvmc_classic_pfaffian_real_candidate,
+    mvmc_classic_pfaffian_real_candidate_inverse,
+    mvmc_classic_pfaffian_real_legacy_element_count,
+    mvmc_classic_pfaffian_real_audit_mode,
+    mvmc_classic_pfaffian_real_audit_compatible,
+    mvmc_classic_pfaffian_real_audit_candidate)
+#undef ELEMENT_TYPE
+
+#define ELEMENT_TYPE double complex
+DEFINE_PROPOSE_INTERNAL(
+    propose_complex_internal, MVMCClassicPfaffianComplexWorkspace,
+    MVMCClassicComplexProposalAudit,
+    mvmc_classic_pfaffian_complex_prepare_collective,
+    mvmc_classic_pfaffian_complex_publish,
+    mvmc_classic_pfaffian_complex_discard_candidate,
+    mvmc_classic_pfaffian_complex_accepted,
+    mvmc_classic_pfaffian_complex_candidate,
+    mvmc_classic_pfaffian_complex_candidate_inverse,
+    mvmc_classic_pfaffian_complex_legacy_element_count,
+    mvmc_classic_pfaffian_complex_audit_mode,
+    mvmc_classic_pfaffian_complex_audit_compatible,
+    mvmc_classic_pfaffian_complex_audit_candidate)
+#undef ELEMENT_TYPE
+#undef DEFINE_PROPOSE_INTERNAL
+
+MVMCPfaffianStatus mvmc_classic_sampler_real_propose(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    double *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result) {
+  return propose_real_internal(
+      state_workspace, collective_workspace, sampler_state, move, slater_elm,
+      ele_idx, global_weights, scaled_pivot_tolerance, residual_tolerance,
+      log_projection_ratio, log_rbm_ratio, draw_uniform, draw_context, NULL,
+      legacy_storage, legacy_element_count, result);
+}
+
+MVMCPfaffianStatus mvmc_classic_sampler_real_propose_with_audit(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    const MVMCClassicRealProposalAudit *audit,
+    double *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result) {
+  return propose_real_internal(
+      state_workspace, collective_workspace, sampler_state, move, slater_elm,
+      ele_idx, global_weights, scaled_pivot_tolerance, residual_tolerance,
+      log_projection_ratio, log_rbm_ratio, draw_uniform, draw_context, audit,
+      legacy_storage, legacy_element_count, result);
+}
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_propose(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    double complex *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result) {
+  return propose_complex_internal(
+      state_workspace, collective_workspace, sampler_state, move, slater_elm,
+      ele_idx, global_weights, scaled_pivot_tolerance, residual_tolerance,
+      log_projection_ratio, log_rbm_ratio, draw_uniform, draw_context, NULL,
+      legacy_storage, legacy_element_count, result);
+}
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_propose_with_audit(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    const MVMCClassicComplexProposalAudit *audit,
+    double complex *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result) {
+  return propose_complex_internal(
+      state_workspace, collective_workspace, sampler_state, move, slater_elm,
+      ele_idx, global_weights, scaled_pivot_tolerance, residual_tolerance,
+      log_projection_ratio, log_rbm_ratio, draw_uniform, draw_context, audit,
+      legacy_storage, legacy_element_count, result);
+}
+
+#define DEFINE_REBUILD_AUDIT(                                                  \
+    NAME, TYPE, ELEMENT_TYPE, AUDIT_TYPE, PREPARE, ACCEPTED,                   \
+    ACCEPTED_INVERSE, CANDIDATE, CANDIDATE_INVERSE, DISCARD,                   \
+    AUDIT_MODE, AUDIT_COMPATIBLE, AUDIT_COMPARE, BRANCH_BASE)                  \
+MVMCPfaffianStatus NAME(                                                       \
+    TYPE *state_workspace,                                                     \
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,             \
+    MVMCClassicSamplerState *sampler_state,                                    \
+    const ELEMENT_TYPE *slater_elm, const int *ele_idx,                        \
+    const double complex *global_weights,                                      \
+    double scaled_pivot_tolerance, double residual_tolerance,                  \
+    AUDIT_TYPE *audit_workspace,                                               \
+    MVMCClassicPfaffianAuditReport *report) {                                  \
+  MVMCClassicPfaffianCollectiveResult prepared;                                \
+  MVMCClassicPfaffianAuditMode mode = AUDIT_MODE(audit_workspace);             \
+  MVMCPfaffianStatus status;                                                   \
+  status = mvmc_classic_pfaffian_collective_preflight(                         \
+      collective_workspace,                                                   \
+      state_workspace != NULL && sampler_state != NULL &&                      \
+          sampler_state->valid && audit_workspace != NULL && report != NULL && \
+          AUDIT_COMPATIBLE(audit_workspace, state_workspace),                  \
+      BRANCH_BASE + (int)mode);                                                \
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;                        \
+  if (state_workspace == NULL || sampler_state == NULL ||                      \
+      !sampler_state->valid || audit_workspace == NULL || report == NULL ||    \
+      !AUDIT_COMPATIBLE(audit_workspace, state_workspace)) {                   \
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;                              \
+  }                                                                            \
+  status = PREPARE(state_workspace, collective_workspace, slater_elm, ele_idx,\
+                   global_weights, scaled_pivot_tolerance,                     \
+                   residual_tolerance, &prepared);                             \
+  if (status != MVMC_PFAFFIAN_STATUS_OK) return status;                        \
+  status = AUDIT_COMPARE(                                                      \
+      audit_workspace, collective_workspace, ACCEPTED(state_workspace),       \
+      ACCEPTED_INVERSE(state_workspace),                                       \
+      &sampler_state->accepted_aggregate, CANDIDATE(state_workspace),          \
+      CANDIDATE_INVERSE(state_workspace), report);                             \
+  DISCARD(state_workspace);                                                    \
+  return status;                                                               \
+}
+
+DEFINE_REBUILD_AUDIT(
+    mvmc_classic_sampler_real_rebuild_audit,
+    MVMCClassicPfaffianRealWorkspace, double,
+    MVMCClassicPfaffianRealAuditWorkspace,
+    mvmc_classic_pfaffian_real_prepare_collective,
+    mvmc_classic_pfaffian_real_accepted,
+    mvmc_classic_pfaffian_real_accepted_inverse,
+    mvmc_classic_pfaffian_real_candidate,
+    mvmc_classic_pfaffian_real_candidate_inverse,
+    mvmc_classic_pfaffian_real_discard_candidate,
+    mvmc_classic_pfaffian_real_audit_mode,
+    mvmc_classic_pfaffian_real_audit_compatible,
+    mvmc_classic_pfaffian_real_audit_compare,
+    MVMC_CLASSIC_BRANCH_REBUILD_REAL)
+
+DEFINE_REBUILD_AUDIT(
+    mvmc_classic_sampler_complex_rebuild_audit,
+    MVMCClassicPfaffianComplexWorkspace, double complex,
+    MVMCClassicPfaffianComplexAuditWorkspace,
+    mvmc_classic_pfaffian_complex_prepare_collective,
+    mvmc_classic_pfaffian_complex_accepted,
+    mvmc_classic_pfaffian_complex_accepted_inverse,
+    mvmc_classic_pfaffian_complex_candidate,
+    mvmc_classic_pfaffian_complex_candidate_inverse,
+    mvmc_classic_pfaffian_complex_discard_candidate,
+    mvmc_classic_pfaffian_complex_audit_mode,
+    mvmc_classic_pfaffian_complex_audit_compatible,
+    mvmc_classic_pfaffian_complex_audit_compare,
+    MVMC_CLASSIC_BRANCH_REBUILD_COMPLEX)
+
+#undef DEFINE_REBUILD_AUDIT

--- a/src/mVMC/classic_pfaffian_state.c
+++ b/src/mVMC/classic_pfaffian_state.c
@@ -1,0 +1,825 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_pfaffian_state.h"
+
+#include <limits.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  int nsite;
+  int nsite2;
+  int nsize;
+  int qp_total;
+  int qp_start;
+  int qp_end;
+  size_t local_qp_count;
+  size_t matrix_count;
+  size_t slater_matrix_count;
+  size_t inverse_count;
+  size_t legacy_element_count;
+  int candidate_ready;
+  int failure_local_qp;
+  int failure_global_qp;
+} MVMCClassicPfaffianLayout;
+
+struct MVMCClassicPfaffianRealWorkspace {
+  MVMCClassicPfaffianLayout layout;
+  MVMCClassicPfaffianState accepted;
+  MVMCClassicPfaffianState candidate;
+  double *accepted_inverse;
+  double *candidate_inverse;
+  double *matrix_scratch;
+  MVMCAbsolutePfaffianRealWorkspace *absolute_workspace;
+};
+
+struct MVMCClassicPfaffianComplexWorkspace {
+  MVMCClassicPfaffianLayout layout;
+  MVMCClassicPfaffianState accepted;
+  MVMCClassicPfaffianState candidate;
+  double complex *accepted_inverse;
+  double complex *candidate_inverse;
+  double complex *matrix_scratch;
+  MVMCAbsolutePfaffianComplexWorkspace *absolute_workspace;
+};
+
+static int checked_multiply(size_t left, size_t right, size_t *product) {
+  if (product == NULL || (left != 0 && right > SIZE_MAX / left)) return 0;
+  *product = left * right;
+  return 1;
+}
+
+static int initialize_layout(int nsite, int nsize, int qp_total,
+                             int qp_start, int qp_end,
+                             size_t element_size,
+                             MVMCClassicPfaffianLayout *layout) {
+  size_t nsite2;
+  size_t total_matrix_elements;
+  size_t legacy_per_qp;
+
+  if (layout == NULL) return 0;
+  memset(layout, 0, sizeof(*layout));
+  layout->failure_local_qp = -1;
+  layout->failure_global_qp = -1;
+  if (nsite <= 0 || nsite > INT_MAX / 2 || nsize <= 0 ||
+      (nsize % 2) != 0 || nsize / 2 > nsite || qp_total <= 0 ||
+      qp_start < 0 || qp_end < qp_start || qp_end > qp_total) {
+    return 0;
+  }
+  nsite2 = (size_t)nsite * 2;
+  if (!checked_multiply((size_t)nsize, (size_t)nsize,
+                        &layout->matrix_count) ||
+      layout->matrix_count > SIZE_MAX / element_size ||
+      !checked_multiply(nsite2, nsite2, &layout->slater_matrix_count) ||
+      layout->slater_matrix_count > SIZE_MAX / element_size ||
+      !checked_multiply((size_t)qp_total, layout->slater_matrix_count,
+                        &total_matrix_elements) ||
+      total_matrix_elements > SIZE_MAX / element_size ||
+      !checked_multiply((size_t)(qp_end - qp_start),
+                        layout->matrix_count, &layout->inverse_count) ||
+      layout->inverse_count > SIZE_MAX / element_size ||
+      layout->matrix_count == SIZE_MAX ||
+      !checked_multiply((size_t)qp_total, layout->matrix_count + 1,
+                        &layout->legacy_element_count) ||
+      layout->legacy_element_count > SIZE_MAX / element_size) {
+    return 0;
+  }
+  legacy_per_qp = layout->matrix_count + 1;
+  if (legacy_per_qp == 0) return 0;
+  layout->nsite = nsite;
+  layout->nsite2 = (int)nsite2;
+  layout->nsize = nsize;
+  layout->qp_total = qp_total;
+  layout->qp_start = qp_start;
+  layout->qp_end = qp_end;
+  layout->local_qp_count = (size_t)(qp_end - qp_start);
+  return 1;
+}
+
+static void reset_state(MVMCClassicPfaffianState *state,
+                        size_t component_count, uint64_t generation) {
+  size_t index;
+  MVMCAbsolutePfaffianResult *components;
+
+  if (state == NULL) return;
+  components = (MVMCAbsolutePfaffianResult *)state->components;
+  memset(&state->local_aggregate, 0, sizeof(state->local_aggregate));
+  state->valid = 0;
+  state->generation = generation;
+  for (index = 0; index < component_count; ++index) {
+    memset(&components[index], 0, sizeof(components[index]));
+    components[index].state = MVMC_PFAFFIAN_INVALID;
+    components[index].rebuild_generation = generation;
+  }
+}
+
+static MVMCAbsolutePfaffianResult *mutable_components(
+    MVMCClassicPfaffianState *state) {
+  return state == NULL ? NULL
+                       : (MVMCAbsolutePfaffianResult *)state->components;
+}
+
+static int validate_ele_idx(const MVMCClassicPfaffianLayout *layout,
+                            const int *ele_idx) {
+  int index;
+
+  if (layout == NULL || ele_idx == NULL) return 0;
+  for (index = 0; index < layout->nsize; ++index) {
+    if (ele_idx[index] < 0 || ele_idx[index] >= layout->nsite) return 0;
+  }
+  return 1;
+}
+
+static int validate_component(const MVMCAbsolutePfaffianResult *component) {
+  if (component == NULL ||
+      !isfinite(creal(component->pfaffian)) ||
+      !isfinite(cimag(component->pfaffian))) {
+    return 0;
+  }
+  switch (component->state) {
+    case MVMC_PFAFFIAN_REGULAR:
+      return component->inverse_valid == 1;
+    case MVMC_PFAFFIAN_NEAR_SINGULAR:
+      return component->inverse_valid == 0;
+    case MVMC_PFAFFIAN_SINGULAR:
+      return component->inverse_valid == 0 && component->pfaffian == 0.0;
+    default:
+      return 0;
+  }
+}
+
+static int validate_aggregate(const MVMCProjectedAmplitudeResult *aggregate,
+                              size_t component_count) {
+  size_t counted;
+
+  if (aggregate == NULL || !aggregate->valid ||
+      !isfinite(creal(aggregate->total)) ||
+      !isfinite(cimag(aggregate->total)) ||
+      !isfinite(aggregate->sum_abs) || aggregate->sum_abs < 0.0 ||
+      !isfinite(aggregate->cancellation_ratio) ||
+      aggregate->cancellation_ratio < 0.0 ||
+      aggregate->cancellation_ratio > 1.0 ||
+      aggregate->regular_count > component_count ||
+      aggregate->near_singular_count > component_count ||
+      aggregate->singular_count > component_count) {
+    return 0;
+  }
+  counted = aggregate->regular_count + aggregate->near_singular_count;
+  if (counted < aggregate->regular_count ||
+      aggregate->singular_count > SIZE_MAX - counted) {
+    return 0;
+  }
+  counted += aggregate->singular_count;
+  return counted == component_count;
+}
+
+static void set_failure(MVMCClassicPfaffianLayout *layout,
+                        int local_qp, int global_qp) {
+  layout->failure_local_qp = local_qp;
+  layout->failure_global_qp = global_qp;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_workspace_create(
+    int nsite, int nsize, int qp_total, int qp_start, int qp_end,
+    MVMCClassicPfaffianRealWorkspace **workspace) {
+  MVMCClassicPfaffianRealWorkspace *created;
+  MVMCClassicPfaffianLayout layout;
+  MVMCPfaffianStatus status;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (!initialize_layout(nsite, nsize, qp_total, qp_start, qp_end,
+                         sizeof(double), &layout)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCClassicPfaffianRealWorkspace *)calloc(1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  created->layout = layout;
+  created->matrix_scratch =
+      (double *)malloc(created->layout.matrix_count *
+                       sizeof(*created->matrix_scratch));
+  if (created->layout.local_qp_count != 0) {
+    created->accepted.components = (MVMCAbsolutePfaffianResult *)calloc(
+        created->layout.local_qp_count, sizeof(*created->accepted.components));
+    created->candidate.components = (MVMCAbsolutePfaffianResult *)calloc(
+        created->layout.local_qp_count, sizeof(*created->candidate.components));
+    created->accepted_inverse = (double *)calloc(
+        created->layout.inverse_count, sizeof(*created->accepted_inverse));
+    created->candidate_inverse = (double *)calloc(
+        created->layout.inverse_count, sizeof(*created->candidate_inverse));
+  }
+  if (created->matrix_scratch == NULL ||
+      (created->layout.local_qp_count != 0 &&
+       (created->accepted.components == NULL ||
+        created->candidate.components == NULL ||
+        created->accepted_inverse == NULL ||
+        created->candidate_inverse == NULL))) {
+    mvmc_classic_pfaffian_real_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  status = mvmc_absolute_pfaffian_real_workspace_create(
+      nsize, &created->absolute_workspace);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) {
+    mvmc_classic_pfaffian_real_workspace_destroy(created);
+    return status;
+  }
+  reset_state(&created->accepted, created->layout.local_qp_count, 0);
+  reset_state(&created->candidate, created->layout.local_qp_count, 0);
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_classic_pfaffian_real_workspace_destroy(
+    MVMCClassicPfaffianRealWorkspace *workspace) {
+  if (workspace == NULL) return;
+  mvmc_absolute_pfaffian_real_workspace_destroy(workspace->absolute_workspace);
+  free(workspace->matrix_scratch);
+  free(workspace->candidate_inverse);
+  free(workspace->accepted_inverse);
+  free((void *)workspace->candidate.components);
+  free((void *)workspace->accepted.components);
+  free(workspace);
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_workspace_create(
+    int nsite, int nsize, int qp_total, int qp_start, int qp_end,
+    MVMCClassicPfaffianComplexWorkspace **workspace) {
+  MVMCClassicPfaffianComplexWorkspace *created;
+  MVMCClassicPfaffianLayout layout;
+  MVMCPfaffianStatus status;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (!initialize_layout(nsite, nsize, qp_total, qp_start, qp_end,
+                         sizeof(double complex), &layout)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created =
+      (MVMCClassicPfaffianComplexWorkspace *)calloc(1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  created->layout = layout;
+  created->matrix_scratch = (double complex *)malloc(
+      created->layout.matrix_count * sizeof(*created->matrix_scratch));
+  if (created->layout.local_qp_count != 0) {
+    created->accepted.components = (MVMCAbsolutePfaffianResult *)calloc(
+        created->layout.local_qp_count, sizeof(*created->accepted.components));
+    created->candidate.components = (MVMCAbsolutePfaffianResult *)calloc(
+        created->layout.local_qp_count, sizeof(*created->candidate.components));
+    created->accepted_inverse = (double complex *)calloc(
+        created->layout.inverse_count, sizeof(*created->accepted_inverse));
+    created->candidate_inverse = (double complex *)calloc(
+        created->layout.inverse_count, sizeof(*created->candidate_inverse));
+  }
+  if (created->matrix_scratch == NULL ||
+      (created->layout.local_qp_count != 0 &&
+       (created->accepted.components == NULL ||
+        created->candidate.components == NULL ||
+        created->accepted_inverse == NULL ||
+        created->candidate_inverse == NULL))) {
+    mvmc_classic_pfaffian_complex_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  status = mvmc_absolute_pfaffian_complex_workspace_create(
+      nsize, &created->absolute_workspace);
+  if (status != MVMC_PFAFFIAN_STATUS_OK) {
+    mvmc_classic_pfaffian_complex_workspace_destroy(created);
+    return status;
+  }
+  reset_state(&created->accepted, created->layout.local_qp_count, 0);
+  reset_state(&created->candidate, created->layout.local_qp_count, 0);
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_classic_pfaffian_complex_workspace_destroy(
+    MVMCClassicPfaffianComplexWorkspace *workspace) {
+  if (workspace == NULL) return;
+  mvmc_absolute_pfaffian_complex_workspace_destroy(
+      workspace->absolute_workspace);
+  free(workspace->matrix_scratch);
+  free(workspace->candidate_inverse);
+  free(workspace->accepted_inverse);
+  free((void *)workspace->candidate.components);
+  free((void *)workspace->accepted.components);
+  free(workspace);
+}
+
+static void build_real_matrix(const MVMCClassicPfaffianLayout *layout,
+                              const double *slater, const int *ele_idx,
+                              double *matrix) {
+  const int ne = layout->nsize / 2;
+  int column, row;
+
+  for (column = 0; column < layout->nsize; ++column) {
+    const int slater_column =
+        ele_idx[column] + (column / ne) * layout->nsite;
+    for (row = 0; row < layout->nsize; ++row) {
+      const int slater_row = ele_idx[row] + (row / ne) * layout->nsite;
+      matrix[row + (size_t)column * (size_t)layout->nsize] =
+          -slater[(size_t)slater_column * (size_t)layout->nsite2 +
+                  (size_t)slater_row];
+    }
+  }
+}
+
+static void build_complex_matrix(const MVMCClassicPfaffianLayout *layout,
+                                 const double complex *slater,
+                                 const int *ele_idx,
+                                 double complex *matrix) {
+  const int ne = layout->nsize / 2;
+  int column, row;
+
+  for (column = 0; column < layout->nsize; ++column) {
+    const int slater_column =
+        ele_idx[column] + (column / ne) * layout->nsite;
+    for (row = 0; row < layout->nsize; ++row) {
+      const int slater_row = ele_idx[row] + (row / ne) * layout->nsite;
+      matrix[row + (size_t)column * (size_t)layout->nsize] =
+          -slater[(size_t)slater_column * (size_t)layout->nsite2 +
+                  (size_t)slater_row];
+    }
+  }
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_prepare(
+    MVMCClassicPfaffianRealWorkspace *workspace,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance) {
+  MVMCClassicPfaffianLayout *layout;
+  uint64_t generation;
+  size_t local_qp;
+  int global_qp;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  layout = &workspace->layout;
+  layout->candidate_ready = 0;
+  set_failure(layout, -1, -1);
+  if (slater_elm == NULL || global_weights == NULL ||
+      !validate_ele_idx(layout, ele_idx) ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !isfinite(residual_tolerance) ||
+      workspace->accepted.generation == UINT64_MAX) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  for (global_qp = 0; global_qp < layout->qp_total; ++global_qp) {
+    if (!isfinite(creal(global_weights[global_qp])) ||
+        !isfinite(cimag(global_weights[global_qp])) ||
+        cimag(global_weights[global_qp]) != 0.0) {
+      set_failure(layout,
+                  global_qp >= layout->qp_start && global_qp < layout->qp_end
+                      ? global_qp - layout->qp_start
+                      : -1,
+                  global_qp);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  generation = workspace->accepted.generation + 1;
+  reset_state(&workspace->candidate, layout->local_qp_count, generation);
+  if (layout->inverse_count != 0) {
+    memset(workspace->candidate_inverse, 0,
+           layout->inverse_count * sizeof(*workspace->candidate_inverse));
+  }
+  for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
+    MVMCPfaffianStatus status;
+    global_qp = layout->qp_start + (int)local_qp;
+    build_real_matrix(
+        layout,
+        slater_elm + (size_t)global_qp * layout->slater_matrix_count,
+        ele_idx, workspace->matrix_scratch);
+    status = mvmc_absolute_pfaffian_real_with_workspace(
+        workspace->absolute_workspace, workspace->matrix_scratch,
+        layout->nsize, layout->nsize,
+        workspace->candidate_inverse + local_qp * layout->matrix_count,
+        layout->nsize, generation, scaled_pivot_tolerance,
+        residual_tolerance,
+        &mutable_components(&workspace->candidate)[local_qp]);
+    if (status != MVMC_PFAFFIAN_STATUS_OK ||
+        !validate_component(&workspace->candidate.components[local_qp]) ||
+        cimag(workspace->candidate.components[local_qp].pfaffian) != 0.0) {
+      set_failure(layout, (int)local_qp, global_qp);
+      return status == MVMC_PFAFFIAN_STATUS_OK
+                 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                 : status;
+    }
+    {
+      const double complex term =
+          global_weights[global_qp] *
+          workspace->candidate.components[local_qp].pfaffian;
+      if (!isfinite(creal(term)) || !isfinite(cimag(term))) {
+        set_failure(layout, (int)local_qp, global_qp);
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+      }
+    }
+  }
+  if (layout->local_qp_count == 0) {
+    memset(&workspace->candidate.local_aggregate, 0,
+           sizeof(workspace->candidate.local_aggregate));
+    workspace->candidate.local_aggregate.valid = 1;
+  } else {
+    MVMCPfaffianStatus status = mvmc_projected_amplitude_slice(
+        workspace->candidate.components, layout->local_qp_count,
+        global_weights, layout->qp_total, layout->qp_start, layout->qp_end,
+        &workspace->candidate.local_aggregate);
+    if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  }
+  if (!validate_aggregate(&workspace->candidate.local_aggregate,
+                          layout->local_qp_count) ||
+      cimag(workspace->candidate.local_aggregate.total) != 0.0) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  workspace->candidate.valid = 1;
+  layout->candidate_ready = 1;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_prepare(
+    MVMCClassicPfaffianComplexWorkspace *workspace,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance) {
+  MVMCClassicPfaffianLayout *layout;
+  uint64_t generation;
+  size_t local_qp;
+  int global_qp;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  layout = &workspace->layout;
+  layout->candidate_ready = 0;
+  set_failure(layout, -1, -1);
+  if (slater_elm == NULL || global_weights == NULL ||
+      !validate_ele_idx(layout, ele_idx) ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !isfinite(residual_tolerance) ||
+      workspace->accepted.generation == UINT64_MAX) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  for (global_qp = 0; global_qp < layout->qp_total; ++global_qp) {
+    if (!isfinite(creal(global_weights[global_qp])) ||
+        !isfinite(cimag(global_weights[global_qp]))) {
+      set_failure(layout,
+                  global_qp >= layout->qp_start && global_qp < layout->qp_end
+                      ? global_qp - layout->qp_start
+                      : -1,
+                  global_qp);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  generation = workspace->accepted.generation + 1;
+  reset_state(&workspace->candidate, layout->local_qp_count, generation);
+  if (layout->inverse_count != 0) {
+    memset(workspace->candidate_inverse, 0,
+           layout->inverse_count * sizeof(*workspace->candidate_inverse));
+  }
+  for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
+    MVMCPfaffianStatus status;
+    global_qp = layout->qp_start + (int)local_qp;
+    build_complex_matrix(
+        layout,
+        slater_elm + (size_t)global_qp * layout->slater_matrix_count,
+        ele_idx, workspace->matrix_scratch);
+    status = mvmc_absolute_pfaffian_complex_with_workspace(
+        workspace->absolute_workspace, workspace->matrix_scratch,
+        layout->nsize, layout->nsize,
+        workspace->candidate_inverse + local_qp * layout->matrix_count,
+        layout->nsize, generation, scaled_pivot_tolerance,
+        residual_tolerance,
+        &mutable_components(&workspace->candidate)[local_qp]);
+    if (status != MVMC_PFAFFIAN_STATUS_OK ||
+        !validate_component(&workspace->candidate.components[local_qp])) {
+      set_failure(layout, (int)local_qp, global_qp);
+      return status == MVMC_PFAFFIAN_STATUS_OK
+                 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                 : status;
+    }
+    {
+      const double complex term =
+          global_weights[global_qp] *
+          workspace->candidate.components[local_qp].pfaffian;
+      if (!isfinite(creal(term)) || !isfinite(cimag(term))) {
+        set_failure(layout, (int)local_qp, global_qp);
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+      }
+    }
+  }
+  if (layout->local_qp_count == 0) {
+    memset(&workspace->candidate.local_aggregate, 0,
+           sizeof(workspace->candidate.local_aggregate));
+    workspace->candidate.local_aggregate.valid = 1;
+  } else {
+    MVMCPfaffianStatus status = mvmc_projected_amplitude_slice(
+        workspace->candidate.components, layout->local_qp_count,
+        global_weights, layout->qp_total, layout->qp_start, layout->qp_end,
+        &workspace->candidate.local_aggregate);
+    if (status != MVMC_PFAFFIAN_STATUS_OK) return status;
+  }
+  if (!validate_aggregate(&workspace->candidate.local_aggregate,
+                          layout->local_qp_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  workspace->candidate.valid = 1;
+  layout->candidate_ready = 1;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_publish(
+    MVMCClassicPfaffianRealWorkspace *workspace,
+    double *legacy_storage, size_t legacy_element_count) {
+  MVMCClassicPfaffianState state_swap;
+  double *inverse_swap;
+  double *legacy_pfaffian;
+  size_t local_qp, index;
+
+  if (workspace == NULL || legacy_storage == NULL ||
+      !workspace->layout.candidate_ready || !workspace->candidate.valid ||
+      !validate_aggregate(&workspace->candidate.local_aggregate,
+                          workspace->layout.local_qp_count) ||
+      cimag(workspace->candidate.local_aggregate.total) != 0.0 ||
+      legacy_element_count < workspace->layout.legacy_element_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  for (local_qp = 0; local_qp < workspace->layout.local_qp_count;
+       ++local_qp) {
+    const MVMCAbsolutePfaffianResult *component =
+        &workspace->candidate.components[local_qp];
+    if (!validate_component(component) || cimag(component->pfaffian) != 0.0 ||
+        component->rebuild_generation != workspace->candidate.generation) {
+      set_failure(&workspace->layout, (int)local_qp,
+                  workspace->layout.qp_start + (int)local_qp);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (component->state == MVMC_PFAFFIAN_REGULAR) {
+      for (index = 0; index < workspace->layout.matrix_count; ++index) {
+        if (!isfinite(workspace->candidate_inverse[
+                local_qp * workspace->layout.matrix_count + index])) {
+          set_failure(&workspace->layout, (int)local_qp,
+                      workspace->layout.qp_start + (int)local_qp);
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+      }
+    }
+  }
+  legacy_pfaffian = legacy_storage +
+                     (size_t)workspace->layout.qp_total *
+                         workspace->layout.matrix_count;
+  for (local_qp = 0; local_qp < workspace->layout.local_qp_count;
+       ++local_qp) {
+    const MVMCAbsolutePfaffianResult *component =
+        &workspace->candidate.components[local_qp];
+    double *legacy_inverse =
+        legacy_storage + local_qp * workspace->layout.matrix_count;
+    if (component->state == MVMC_PFAFFIAN_REGULAR) {
+      for (index = 0; index < workspace->layout.matrix_count; ++index) {
+        legacy_inverse[index] =
+            -workspace->candidate_inverse[
+                local_qp * workspace->layout.matrix_count + index];
+      }
+    } else {
+      memset(legacy_inverse, 0,
+             workspace->layout.matrix_count * sizeof(*legacy_inverse));
+    }
+    legacy_pfaffian[local_qp] = creal(component->pfaffian);
+  }
+  state_swap = workspace->accepted;
+  workspace->accepted = workspace->candidate;
+  workspace->candidate = state_swap;
+  inverse_swap = workspace->accepted_inverse;
+  workspace->accepted_inverse = workspace->candidate_inverse;
+  workspace->candidate_inverse = inverse_swap;
+  workspace->candidate.valid = 0;
+  workspace->layout.candidate_ready = 0;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_publish(
+    MVMCClassicPfaffianComplexWorkspace *workspace,
+    double complex *legacy_storage, size_t legacy_element_count) {
+  MVMCClassicPfaffianState state_swap;
+  double complex *inverse_swap;
+  double complex *legacy_pfaffian;
+  size_t local_qp, index;
+
+  if (workspace == NULL || legacy_storage == NULL ||
+      !workspace->layout.candidate_ready || !workspace->candidate.valid ||
+      !validate_aggregate(&workspace->candidate.local_aggregate,
+                          workspace->layout.local_qp_count) ||
+      legacy_element_count < workspace->layout.legacy_element_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  for (local_qp = 0; local_qp < workspace->layout.local_qp_count;
+       ++local_qp) {
+    const MVMCAbsolutePfaffianResult *component =
+        &workspace->candidate.components[local_qp];
+    if (!validate_component(component) ||
+        component->rebuild_generation != workspace->candidate.generation) {
+      set_failure(&workspace->layout, (int)local_qp,
+                  workspace->layout.qp_start + (int)local_qp);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (component->state == MVMC_PFAFFIAN_REGULAR) {
+      for (index = 0; index < workspace->layout.matrix_count; ++index) {
+        const double complex value = workspace->candidate_inverse[
+            local_qp * workspace->layout.matrix_count + index];
+        if (!isfinite(creal(value)) || !isfinite(cimag(value))) {
+          set_failure(&workspace->layout, (int)local_qp,
+                      workspace->layout.qp_start + (int)local_qp);
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+      }
+    }
+  }
+  legacy_pfaffian = legacy_storage +
+                     (size_t)workspace->layout.qp_total *
+                         workspace->layout.matrix_count;
+  for (local_qp = 0; local_qp < workspace->layout.local_qp_count;
+       ++local_qp) {
+    const MVMCAbsolutePfaffianResult *component =
+        &workspace->candidate.components[local_qp];
+    double complex *legacy_inverse =
+        legacy_storage + local_qp * workspace->layout.matrix_count;
+    if (component->state == MVMC_PFAFFIAN_REGULAR) {
+      for (index = 0; index < workspace->layout.matrix_count; ++index) {
+        legacy_inverse[index] =
+            -workspace->candidate_inverse[
+                local_qp * workspace->layout.matrix_count + index];
+      }
+    } else {
+      memset(legacy_inverse, 0,
+             workspace->layout.matrix_count * sizeof(*legacy_inverse));
+    }
+    legacy_pfaffian[local_qp] = component->pfaffian;
+  }
+  state_swap = workspace->accepted;
+  workspace->accepted = workspace->candidate;
+  workspace->candidate = state_swap;
+  inverse_swap = workspace->accepted_inverse;
+  workspace->accepted_inverse = workspace->candidate_inverse;
+  workspace->candidate_inverse = inverse_swap;
+  workspace->candidate.valid = 0;
+  workspace->layout.candidate_ready = 0;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_classic_pfaffian_real_discard_candidate(
+    MVMCClassicPfaffianRealWorkspace *workspace) {
+  if (workspace == NULL) return;
+  workspace->candidate.valid = 0;
+  workspace->layout.candidate_ready = 0;
+}
+
+void mvmc_classic_pfaffian_complex_discard_candidate(
+    MVMCClassicPfaffianComplexWorkspace *workspace) {
+  if (workspace == NULL) return;
+  workspace->candidate.valid = 0;
+  workspace->layout.candidate_ready = 0;
+}
+
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_real_accepted(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL ? NULL : &workspace->accepted;
+}
+
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_real_candidate(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL || !workspace->layout.candidate_ready
+             ? NULL
+             : &workspace->candidate;
+}
+
+const double *mvmc_classic_pfaffian_real_accepted_inverse(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL || !workspace->accepted.valid
+             ? NULL
+             : workspace->accepted_inverse;
+}
+
+const double *mvmc_classic_pfaffian_real_candidate_inverse(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL || !workspace->layout.candidate_ready ||
+                 !workspace->candidate.valid
+             ? NULL
+             : workspace->candidate_inverse;
+}
+
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_complex_accepted(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL ? NULL : &workspace->accepted;
+}
+
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_complex_candidate(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL || !workspace->layout.candidate_ready
+             ? NULL
+             : &workspace->candidate;
+}
+
+const double complex *mvmc_classic_pfaffian_complex_accepted_inverse(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL || !workspace->accepted.valid
+             ? NULL
+             : workspace->accepted_inverse;
+}
+
+const double complex *mvmc_classic_pfaffian_complex_candidate_inverse(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL || !workspace->layout.candidate_ready ||
+                 !workspace->candidate.valid
+             ? NULL
+             : workspace->candidate_inverse;
+}
+
+int mvmc_classic_pfaffian_real_failure_local_qp(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL ? -1 : workspace->layout.failure_local_qp;
+}
+
+int mvmc_classic_pfaffian_real_failure_global_qp(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL ? -1 : workspace->layout.failure_global_qp;
+}
+
+int mvmc_classic_pfaffian_complex_failure_local_qp(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL ? -1 : workspace->layout.failure_local_qp;
+}
+
+int mvmc_classic_pfaffian_complex_failure_global_qp(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL ? -1 : workspace->layout.failure_global_qp;
+}
+
+size_t mvmc_classic_pfaffian_real_legacy_element_count(
+    const MVMCClassicPfaffianRealWorkspace *workspace) {
+  return workspace == NULL ? 0 : workspace->layout.legacy_element_count;
+}
+
+size_t mvmc_classic_pfaffian_complex_legacy_element_count(
+    const MVMCClassicPfaffianComplexWorkspace *workspace) {
+  return workspace == NULL ? 0 : workspace->layout.legacy_element_count;
+}
+
+static int copy_qp_range(const MVMCClassicPfaffianLayout *layout,
+                         int *qp_total, int *qp_start, int *qp_end) {
+  if (layout == NULL || qp_total == NULL || qp_start == NULL ||
+      qp_end == NULL) {
+    return 0;
+  }
+  *qp_total = layout->qp_total;
+  *qp_start = layout->qp_start;
+  *qp_end = layout->qp_end;
+  return 1;
+}
+
+int mvmc_classic_pfaffian_real_qp_range(
+    const MVMCClassicPfaffianRealWorkspace *workspace,
+    int *qp_total, int *qp_start, int *qp_end) {
+  return workspace != NULL &&
+         copy_qp_range(&workspace->layout, qp_total, qp_start, qp_end);
+}
+
+int mvmc_classic_pfaffian_complex_qp_range(
+    const MVMCClassicPfaffianComplexWorkspace *workspace,
+    int *qp_total, int *qp_start, int *qp_end) {
+  return workspace != NULL &&
+         copy_qp_range(&workspace->layout, qp_total, qp_start, qp_end);
+}
+
+static int copy_layout(const MVMCClassicPfaffianLayout *layout,
+                       int *nsize, int *qp_total,
+                       int *qp_start, int *qp_end) {
+  if (layout == NULL || nsize == NULL || qp_total == NULL ||
+      qp_start == NULL || qp_end == NULL) {
+    return 0;
+  }
+  *nsize = layout->nsize;
+  return copy_qp_range(layout, qp_total, qp_start, qp_end);
+}
+
+int mvmc_classic_pfaffian_real_layout(
+    const MVMCClassicPfaffianRealWorkspace *workspace,
+    int *nsize, int *qp_total, int *qp_start, int *qp_end) {
+  return workspace != NULL &&
+         copy_layout(&workspace->layout, nsize, qp_total, qp_start, qp_end);
+}
+
+int mvmc_classic_pfaffian_complex_layout(
+    const MVMCClassicPfaffianComplexWorkspace *workspace,
+    int *nsize, int *qp_total, int *qp_start, int *qp_end) {
+  return workspace != NULL &&
+         copy_layout(&workspace->layout, nsize, qp_total, qp_start, qp_end);
+}

--- a/src/mVMC/include/absolute_pfaffian.h
+++ b/src/mVMC/include/absolute_pfaffian.h
@@ -24,6 +24,7 @@ typedef enum {
 } MVMCPfaffianState;
 
 typedef enum {
+  /* Keep this list contiguous and synchronize collective status severity. */
   MVMC_PFAFFIAN_STATUS_OK = 0,
   MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
   MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE,
@@ -52,6 +53,43 @@ typedef struct {
   size_t near_singular_count;
   size_t singular_count;
 } MVMCProjectedAmplitudeResult;
+
+typedef struct MVMCAbsolutePfaffianRealWorkspace
+    MVMCAbsolutePfaffianRealWorkspace;
+typedef struct MVMCAbsolutePfaffianComplexWorkspace
+    MVMCAbsolutePfaffianComplexWorkspace;
+
+/*
+ * Reusable factorization workspaces for sampler hot paths.  Creation may
+ * allocate and query LAPACK/PFAPACK workspace sizes; evaluation with an
+ * existing workspace performs no allocation.  A workspace is bound to n and
+ * requires exclusive use while an evaluation is in progress.
+ */
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_workspace_create(
+    int n, MVMCAbsolutePfaffianRealWorkspace **workspace);
+void mvmc_absolute_pfaffian_real_workspace_destroy(
+    MVMCAbsolutePfaffianRealWorkspace *workspace);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_workspace_create(
+    int n, MVMCAbsolutePfaffianComplexWorkspace **workspace);
+void mvmc_absolute_pfaffian_complex_workspace_destroy(
+    MVMCAbsolutePfaffianComplexWorkspace *workspace);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_with_workspace(
+    MVMCAbsolutePfaffianRealWorkspace *workspace,
+    const double *matrix, int n, int lda,
+    double *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_with_workspace(
+    MVMCAbsolutePfaffianComplexWorkspace *workspace,
+    const double complex *matrix, int n, int lda,
+    double complex *inverse_out, int inverse_lda,
+    uint64_t rebuild_generation,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCAbsolutePfaffianResult *result);
 
 /*
  * Evaluate an even-dimensional skew-symmetric matrix without modifying it.

--- a/src/mVMC/include/classic_pfaffian_audit.h
+++ b/src/mVMC/include/classic_pfaffian_audit.h
@@ -1,0 +1,155 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_PFAFFIAN_AUDIT_H
+#define MVMC_CLASSIC_PFAFFIAN_AUDIT_H
+
+#include "classic_pfaffian_collective.h"
+
+#if defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+
+typedef enum {
+  MVMC_CLASSIC_AUDIT_OFF = 0,
+  MVMC_CLASSIC_AUDIT_GUARDED,
+  MVMC_CLASSIC_AUDIT_ALWAYS
+} MVMCClassicPfaffianAuditMode;
+
+typedef struct {
+  int valid;
+  MVMCPfaffianStatus status;
+  MVMCClassicPfaffianAuditMode requested_mode;
+  MVMCClassicPfaffianAuditMode effective_mode;
+  int executed;
+  int fallback;
+  int mismatch;
+  int failure_rank;
+  int failure_local_qp;
+  int failure_global_qp;
+  MVMCProjectedAmplitudeResult observed_aggregate;
+} MVMCClassicPfaffianAuditReport;
+
+typedef struct {
+  int valid;
+  size_t component_count;
+  size_t matrix_element_count;
+  MVMCAbsolutePfaffianResult *components;
+  double *inverse;
+} MVMCClassicPfaffianRealObservation;
+
+typedef struct {
+  int valid;
+  size_t component_count;
+  size_t matrix_element_count;
+  MVMCAbsolutePfaffianResult *components;
+  double complex *inverse;
+} MVMCClassicPfaffianComplexObservation;
+
+typedef MVMCPfaffianStatus (*MVMCClassicPfaffianRealObserver)(
+    void *context, const MVMCClassicPfaffianState *absolute_candidate,
+    const double *absolute_inverse,
+    MVMCClassicPfaffianRealObservation *observation);
+
+typedef MVMCPfaffianStatus (*MVMCClassicPfaffianComplexObserver)(
+    void *context, const MVMCClassicPfaffianState *absolute_candidate,
+    const double complex *absolute_inverse,
+    MVMCClassicPfaffianComplexObservation *observation);
+
+typedef struct MVMCClassicPfaffianRealAuditWorkspace
+    MVMCClassicPfaffianRealAuditWorkspace;
+typedef struct MVMCClassicPfaffianComplexAuditWorkspace
+    MVMCClassicPfaffianComplexAuditWorkspace;
+
+/* Creation is allowed to allocate; every later audit call is allocation-free. */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_audit_workspace_create(
+    const MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianAuditMode mode,
+    double absolute_tolerance, double relative_tolerance,
+    MVMCClassicPfaffianRealAuditWorkspace **workspace);
+void mvmc_classic_pfaffian_real_audit_workspace_destroy(
+    MVMCClassicPfaffianRealAuditWorkspace *workspace);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_audit_workspace_create(
+    const MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianAuditMode mode,
+    double absolute_tolerance, double relative_tolerance,
+    MVMCClassicPfaffianComplexAuditWorkspace **workspace);
+void mvmc_classic_pfaffian_complex_audit_workspace_destroy(
+    MVMCClassicPfaffianComplexAuditWorkspace *workspace);
+
+MVMCClassicPfaffianAuditMode mvmc_classic_pfaffian_real_audit_mode(
+    const MVMCClassicPfaffianRealAuditWorkspace *workspace);
+MVMCClassicPfaffianAuditMode mvmc_classic_pfaffian_complex_audit_mode(
+    const MVMCClassicPfaffianComplexAuditWorkspace *workspace);
+
+int mvmc_classic_pfaffian_real_audit_compatible(
+    const MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    const MVMCClassicPfaffianRealWorkspace *state_workspace);
+int mvmc_classic_pfaffian_complex_audit_compatible(
+    const MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    const MVMCClassicPfaffianComplexWorkspace *state_workspace);
+
+/*
+ * Observe and compare one proposal.  In GUARDED mode every rank first checks
+ * the accepted state; one ineligible rank selects absolute-only fallback for
+ * all ranks.  The observer writes only to the supplied preallocated output.
+ * These are collective operations: every rank in collective_workspace must
+ * call with a valid, layout-compatible workspace, state, weight array, and
+ * observer.  Sampler entry points enforce that precondition collectively.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_audit_candidate(
+    MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *accepted_state,
+    const MVMCClassicPfaffianState *absolute_candidate,
+    const double *absolute_candidate_inverse,
+    const MVMCProjectedAmplitudeResult *absolute_global_aggregate,
+    const double complex *global_weights,
+    MVMCClassicPfaffianRealObserver observer, void *observer_context,
+    MVMCClassicPfaffianAuditReport *report);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_audit_candidate(
+    MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *accepted_state,
+    const MVMCClassicPfaffianState *absolute_candidate,
+    const double complex *absolute_candidate_inverse,
+    const MVMCProjectedAmplitudeResult *absolute_global_aggregate,
+    const double complex *global_weights,
+    MVMCClassicPfaffianComplexObserver observer, void *observer_context,
+    MVMCClassicPfaffianAuditReport *report);
+
+/*
+ * Force a state comparison, used by periodic rebuild regardless of mode.
+ * These are collective operations with the same all-rank validity contract.
+ * A forced comparison reports effective_mode=ALWAYS even if requested_mode=OFF.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_audit_compare(
+    MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *reference_state,
+    const double *reference_inverse,
+    const MVMCProjectedAmplitudeResult *reference_global_aggregate,
+    const MVMCClassicPfaffianState *observed_state,
+    const double *observed_inverse,
+    MVMCClassicPfaffianAuditReport *report);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_audit_compare(
+    MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const MVMCClassicPfaffianState *reference_state,
+    const double complex *reference_inverse,
+    const MVMCProjectedAmplitudeResult *reference_global_aggregate,
+    const MVMCClassicPfaffianState *observed_state,
+    const double complex *observed_inverse,
+    MVMCClassicPfaffianAuditReport *report);
+
+#endif /* MVMC_ENABLE_PFAFFIAN_STATE_AUDIT */
+
+#endif /* MVMC_CLASSIC_PFAFFIAN_AUDIT_H */

--- a/src/mVMC/include/classic_pfaffian_collective.h
+++ b/src/mVMC/include/classic_pfaffian_collective.h
@@ -1,0 +1,127 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_PFAFFIAN_COLLECTIVE_H
+#define MVMC_CLASSIC_PFAFFIAN_COLLECTIVE_H
+
+#include "classic_pfaffian_state.h"
+
+#ifdef _mpi_use
+#include <mpi.h>
+typedef MPI_Comm MVMCClassicPfaffianCommunicator;
+#else
+typedef int MVMCClassicPfaffianCommunicator;
+#endif
+
+typedef struct MVMCClassicPfaffianCollectiveWorkspace
+    MVMCClassicPfaffianCollectiveWorkspace;
+
+typedef struct {
+  int valid;
+  MVMCPfaffianStatus status;
+  int failure_rank;
+  int failure_local_qp;
+  int failure_global_qp;
+  MVMCProjectedAmplitudeResult aggregate;
+} MVMCClassicPfaffianCollectiveResult;
+
+typedef struct {
+  int valid;
+  MVMCPfaffianStatus status;
+  int accepted;
+  double log_acceptance_ratio;
+} MVMCClassicPfaffianMetropolisResult;
+
+/*
+ * Creation and destruction are collective on communicator in MPI builds.
+ * The workspace duplicates the passed communicator and preallocates its
+ * ownership audit buffer; aggregate/prepare calls allocate no memory.
+ * MPI communicators must retain the default MPI_ERRORS_ARE_FATAL handler.
+ * Primitive MPI failures cannot be recovered collectively after only a
+ * subset of ranks returns an error.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_workspace_create(
+    MVMCClassicPfaffianCommunicator communicator,
+    MVMCClassicPfaffianCollectiveWorkspace **workspace);
+void mvmc_classic_pfaffian_collective_workspace_destroy(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace);
+
+/*
+ * All ranks must call in the same order with a workspace from the same
+ * communicator.  Local QP ranges must form one rank-ordered contiguous
+ * partition [0, qp_total); empty ranges are valid.  A local failure still
+ * participates in every collective and is reported identically on all
+ * ranks.  Severity is fixed as factorization > allocation > unsupported-FP
+ * > invalid-input > OK, with the lowest communicator rank breaking ties.
+ * Failure leaves result->aggregate zeroed and invalid.
+ * A null result on one rank is propagated as invalid input without allowing
+ * that rank to skip the collective sequence.
+ * The workspace itself must be valid on every rank; without its communicator
+ * a rank cannot participate in failure propagation.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_aggregate(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    MVMCPfaffianStatus local_status,
+    const MVMCProjectedAmplitudeResult *local_aggregate,
+    int qp_total, int qp_start, int qp_end,
+    int failure_local_qp, int failure_global_qp,
+    MVMCClassicPfaffianCollectiveResult *result);
+
+/*
+ * Collective absolute proposals.  Each rank first evaluates its bound local
+ * QP slice, then all ranks enter the same status/aggregate collective.  If
+ * any rank fails, every local candidate is discarded and accepted state is
+ * unchanged.  Successful calls leave local candidates ready for publish.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_prepare_collective(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCClassicPfaffianCollectiveResult *result);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_prepare_collective(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCClassicPfaffianCollectiveResult *result);
+
+/*
+ * Make one communicator-wide Metropolis decision from authoritative global
+ * totals.  Inputs must be identical on every rank.  A zero proposal total is
+ * a valid rejection; a zero current total is invalid.  Infinite log factors
+ * are supported, NaN is not.  The caller owns the single uniform draw and
+ * must pass a value in [0,1).
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_metropolis(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    double complex current_total, double complex proposal_total,
+    double log_non_pfaffian_ratio, double uniform,
+    MVMCClassicPfaffianMetropolisResult *result);
+
+/* Collective guard for a branch that must precede proposal evaluation. */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_preflight(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    int local_valid, int branch_kind);
+
+/*
+ * Return the communicator-wide logical AND without treating false as an
+ * error.  This is used to select an optional branch collectively.  local_true
+ * must be exactly 0 or 1 on every rank; invalid values are propagated only
+ * after every rank has participated in the reduction.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_true(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    int local_true, int *all_true);
+
+#endif /* MVMC_CLASSIC_PFAFFIAN_COLLECTIVE_H */

--- a/src/mVMC/include/classic_pfaffian_sampler.h
+++ b/src/mVMC/include/classic_pfaffian_sampler.h
@@ -1,0 +1,217 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_PFAFFIAN_SAMPLER_H
+#define MVMC_CLASSIC_PFAFFIAN_SAMPLER_H
+
+#include "classic_pfaffian_collective.h"
+#if defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+#include "classic_pfaffian_audit.h"
+#endif
+
+#include <stdint.h>
+
+#if defined(MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE)
+
+typedef enum {
+  MVMC_CLASSIC_MOVE_HOPPING = 0,
+  MVMC_CLASSIC_MOVE_SPIN_HOPPING,
+  MVMC_CLASSIC_MOVE_EXCHANGE,
+  MVMC_CLASSIC_MOVE_PAIR_HOPPING
+} MVMCClassicMoveKind;
+
+typedef enum {
+  MVMC_CLASSIC_PROPOSAL_ERROR = 0,
+  MVMC_CLASSIC_PROPOSAL_REJECTED,
+  MVMC_CLASSIC_PROPOSAL_ACCEPTED
+} MVMCClassicProposalDecision;
+
+typedef double (*MVMCClassicUniformDraw)(void *context);
+
+typedef struct {
+  int valid;
+  MVMCProjectedAmplitudeResult accepted_aggregate;
+} MVMCClassicSamplerState;
+
+typedef struct {
+  int valid;
+  MVMCPfaffianStatus status;
+  MVMCClassicMoveKind move;
+  MVMCClassicProposalDecision decision;
+  int uniform_draw_count;
+  double uniform;
+  double log_acceptance_ratio;
+  double complex current_total;
+  double complex proposal_total;
+  uint64_t accepted_generation;
+#if defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+  MVMCClassicPfaffianAuditReport audit;
+#endif
+} MVMCClassicProposalResult;
+
+#if defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+
+#define MVMC_CLASSIC_TRACE_INDEX_CAPACITY 4
+
+typedef struct {
+  /* Diagnostic identity only; it never affects state or acceptance. */
+  uint64_t proposal_id;
+  int index_count;
+  int indices[MVMC_CLASSIC_TRACE_INDEX_CAPACITY];
+} MVMCClassicProposalMetadata;
+
+typedef struct {
+  int valid;
+  uint64_t proposal_id;
+  MVMCClassicMoveKind move;
+  int index_count;
+  int indices[MVMC_CLASSIC_TRACE_INDEX_CAPACITY];
+  MVMCClassicPfaffianAuditMode requested_audit_mode;
+  MVMCClassicPfaffianAuditMode effective_audit_mode;
+  int audit_executed;
+  int audit_fallback;
+  int uniform_draw_count;
+  double uniform;
+  double complex current_total;
+  double complex proposal_total;
+  size_t regular_count;
+  size_t near_singular_count;
+  size_t singular_count;
+  MVMCClassicProposalDecision decision;
+  uint64_t accepted_generation;
+} MVMCClassicProposalTrace;
+
+typedef struct {
+  const MVMCClassicProposalMetadata *metadata;
+  MVMCClassicPfaffianRealAuditWorkspace *workspace;
+  MVMCClassicPfaffianRealObserver observer;
+  void *observer_context;
+  MVMCClassicProposalTrace *trace;
+} MVMCClassicRealProposalAudit;
+
+typedef struct {
+  const MVMCClassicProposalMetadata *metadata;
+  MVMCClassicPfaffianComplexAuditWorkspace *workspace;
+  MVMCClassicPfaffianComplexObserver observer;
+  void *observer_context;
+  MVMCClassicProposalTrace *trace;
+} MVMCClassicComplexProposalAudit;
+
+#endif /* MVMC_ENABLE_PFAFFIAN_STATE_AUDIT */
+
+/*
+ * These entry points exist only in Testing builds.  The caller has already
+ * applied a candidate configuration before propose().  On rejection it must
+ * revert that configuration; on acceptance the absolute candidate and its
+ * legacy mirror are published atomically.  A proposal that reaches this API
+ * consumes exactly one uniform draw, including an exact-zero total.
+ */
+MVMCPfaffianStatus mvmc_classic_sampler_real_initialize(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double *legacy_storage, size_t legacy_element_count,
+    MVMCClassicSamplerState *sampler_state);
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_initialize(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double complex *legacy_storage, size_t legacy_element_count,
+    MVMCClassicSamplerState *sampler_state);
+
+MVMCPfaffianStatus mvmc_classic_sampler_real_propose(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    double *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result);
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_propose(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    double complex *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result);
+
+#if defined(MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+
+/*
+ * Audit entry points are collective.  All ranks must supply the same audit
+ * mode and valid metadata shape.  Metadata values are caller-owned diagnostic
+ * labels and do not participate in the Metropolis decision.
+ */
+
+MVMCPfaffianStatus mvmc_classic_sampler_real_propose_with_audit(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    const MVMCClassicRealProposalAudit *audit,
+    double *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result);
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_propose_with_audit(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state, MVMCClassicMoveKind move,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    double log_projection_ratio, double log_rbm_ratio,
+    MVMCClassicUniformDraw draw_uniform, void *draw_context,
+    const MVMCClassicComplexProposalAudit *audit,
+    double complex *legacy_storage, size_t legacy_element_count,
+    MVMCClassicProposalResult *result);
+
+/* Re-evaluate accepted configuration, compare, and always discard candidate. */
+MVMCPfaffianStatus mvmc_classic_sampler_real_rebuild_audit(
+    MVMCClassicPfaffianRealWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCClassicPfaffianRealAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianAuditReport *report);
+
+MVMCPfaffianStatus mvmc_classic_sampler_complex_rebuild_audit(
+    MVMCClassicPfaffianComplexWorkspace *state_workspace,
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace,
+    MVMCClassicSamplerState *sampler_state,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance,
+    MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace,
+    MVMCClassicPfaffianAuditReport *report);
+
+#endif /* MVMC_ENABLE_PFAFFIAN_STATE_AUDIT */
+
+#endif /* MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE */
+
+#endif /* MVMC_CLASSIC_PFAFFIAN_SAMPLER_H */

--- a/src/mVMC/include/classic_pfaffian_state.h
+++ b/src/mVMC/include/classic_pfaffian_state.h
@@ -1,0 +1,138 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_PFAFFIAN_STATE_H
+#define MVMC_CLASSIC_PFAFFIAN_STATE_H
+
+#include "absolute_pfaffian.h"
+
+#include <complex.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+  int valid;
+  uint64_t generation;
+  const MVMCAbsolutePfaffianResult *components;
+  MVMCProjectedAmplitudeResult local_aggregate;
+} MVMCClassicPfaffianState;
+
+typedef struct MVMCClassicPfaffianRealWorkspace
+    MVMCClassicPfaffianRealWorkspace;
+typedef struct MVMCClassicPfaffianComplexWorkspace
+    MVMCClassicPfaffianComplexWorkspace;
+
+/*
+ * Classic non-FSZ layout: nsize is even, the first/second nsize/2 electron
+ * indices are spin up/down, and Slater matrices are global-QP-major followed
+ * by row-major (2*nsite)-square matrices.  The caller must provide at least
+ * qp_total*(2*nsite)*(2*nsite) Slater elements and nsize electron indices.
+ * QP weights are global and replicated.  qp_start == qp_end is a valid empty
+ * rank-local slice.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_workspace_create(
+    int nsite, int nsize, int qp_total, int qp_start, int qp_end,
+    MVMCClassicPfaffianRealWorkspace **workspace);
+void mvmc_classic_pfaffian_real_workspace_destroy(
+    MVMCClassicPfaffianRealWorkspace *workspace);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_workspace_create(
+    int nsite, int nsize, int qp_total, int qp_start, int qp_end,
+    MVMCClassicPfaffianComplexWorkspace **workspace);
+void mvmc_classic_pfaffian_complex_workspace_destroy(
+    MVMCClassicPfaffianComplexWorkspace *workspace);
+
+/*
+ * Prepare evaluates every local component out of place.  It never modifies
+ * accepted state or a legacy mirror and performs no allocation after create.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_prepare(
+    MVMCClassicPfaffianRealWorkspace *workspace,
+    const double *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_prepare(
+    MVMCClassicPfaffianComplexWorkspace *workspace,
+    const double complex *slater_elm, const int *ele_idx,
+    const double complex *global_weights,
+    double scaled_pivot_tolerance, double residual_tolerance);
+
+/*
+ * Publish validates the complete candidate before writing.  legacy_storage
+ * is the existing full allocation whose first qp_total*nsize*nsize elements
+ * are InvM and whose tail qp_total elements are aliased as PfM.  Local QP
+ * component k is mirrored at local slot k, matching CalculateMAll*.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_real_publish(
+    MVMCClassicPfaffianRealWorkspace *workspace,
+    double *legacy_storage, size_t legacy_element_count);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_complex_publish(
+    MVMCClassicPfaffianComplexWorkspace *workspace,
+    double complex *legacy_storage, size_t legacy_element_count);
+
+void mvmc_classic_pfaffian_real_discard_candidate(
+    MVMCClassicPfaffianRealWorkspace *workspace);
+void mvmc_classic_pfaffian_complex_discard_candidate(
+    MVMCClassicPfaffianComplexWorkspace *workspace);
+
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_real_accepted(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_real_candidate(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+const double *mvmc_classic_pfaffian_real_accepted_inverse(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+const double *mvmc_classic_pfaffian_real_candidate_inverse(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_complex_accepted(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+const MVMCClassicPfaffianState *mvmc_classic_pfaffian_complex_candidate(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+const double complex *mvmc_classic_pfaffian_complex_accepted_inverse(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+const double complex *mvmc_classic_pfaffian_complex_candidate_inverse(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+
+int mvmc_classic_pfaffian_real_failure_local_qp(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+int mvmc_classic_pfaffian_real_failure_global_qp(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+int mvmc_classic_pfaffian_complex_failure_local_qp(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+int mvmc_classic_pfaffian_complex_failure_global_qp(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+
+size_t mvmc_classic_pfaffian_real_legacy_element_count(
+    const MVMCClassicPfaffianRealWorkspace *workspace);
+size_t mvmc_classic_pfaffian_complex_legacy_element_count(
+    const MVMCClassicPfaffianComplexWorkspace *workspace);
+
+/*
+ * Return the immutable rank-local QP ownership bound at workspace creation.
+ * All output pointers are required; false is returned for invalid arguments.
+ */
+int mvmc_classic_pfaffian_real_qp_range(
+    const MVMCClassicPfaffianRealWorkspace *workspace,
+    int *qp_total, int *qp_start, int *qp_end);
+int mvmc_classic_pfaffian_complex_qp_range(
+    const MVMCClassicPfaffianComplexWorkspace *workspace,
+    int *qp_total, int *qp_start, int *qp_end);
+
+/* Read-only layout metadata used to bind preallocated audit workspaces. */
+int mvmc_classic_pfaffian_real_layout(
+    const MVMCClassicPfaffianRealWorkspace *workspace,
+    int *nsize, int *qp_total, int *qp_start, int *qp_end);
+int mvmc_classic_pfaffian_complex_layout(
+    const MVMCClassicPfaffianComplexWorkspace *workspace,
+    int *nsize, int *qp_total, int *qp_start, int *qp_end);
+
+#endif /* MVMC_CLASSIC_PFAFFIAN_STATE_H */

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -16,6 +16,8 @@ endif
 
 OBJS = \
 	absolute_pfaffian.o \
+	classic_pfaffian_state.o \
+	classic_pfaffian_collective.o \
 	physcal_lanczos.o \
 	splitloop.o \
 	vmcmain.o \
@@ -24,6 +26,8 @@ OBJS = \
 
 SOURCES = \
 absolute_pfaffian.c \
+classic_pfaffian_state.c \
+classic_pfaffian_collective.c \
 backflow.c \
 backflow_measure.c \
 backflow_nbody.c \
@@ -84,6 +88,8 @@ workspace.c
 
 HEADERS = \
 ./include/absolute_pfaffian.h \
+./include/classic_pfaffian_state.h \
+./include/classic_pfaffian_collective.h \
 ./include/backflow.h \
 ./include/backflow_nbody.h \
 ./include/average.h \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,4 +68,123 @@ if(MPI_FOUND)
                 ${MPIEXEC_POSTFLAGS})
 endif()
 
+add_executable(classic_pfaffian_state_unit
+    classic_pfaffian_state_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_include_directories(classic_pfaffian_state_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(classic_pfaffian_state_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(classic_pfaffian_state_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(classic_pfaffian_state_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(classic_pfaffian_state_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ClassicPfaffianState_Unit COMMAND classic_pfaffian_state_unit)
+
+add_executable(classic_pfaffian_collective_unit
+    classic_pfaffian_collective_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_include_directories(classic_pfaffian_collective_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(classic_pfaffian_collective_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(classic_pfaffian_collective_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(classic_pfaffian_collective_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(classic_pfaffian_collective_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ClassicPfaffianCollective_Unit
+    COMMAND classic_pfaffian_collective_unit)
+if(MPI_FOUND)
+    add_test(NAME ClassicPfaffianCollective_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_pfaffian_collective_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME ClassicPfaffianCollective_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_pfaffian_collective_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(ClassicPfaffianCollective_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(ClassicPfaffianCollective_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
+
+add_executable(classic_pfaffian_sampler_unit
+    classic_pfaffian_sampler_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_sampler.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_audit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(classic_pfaffian_sampler_unit PRIVATE
+    MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
+    MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+target_include_directories(classic_pfaffian_sampler_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(classic_pfaffian_sampler_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(classic_pfaffian_sampler_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(classic_pfaffian_sampler_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(classic_pfaffian_sampler_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ClassicPfaffianSampler_Unit
+    COMMAND classic_pfaffian_sampler_unit)
+if(MPI_FOUND)
+    add_test(NAME ClassicPfaffianSampler_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_pfaffian_sampler_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME ClassicPfaffianSampler_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_pfaffian_sampler_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(ClassicPfaffianSampler_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(ClassicPfaffianSampler_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
+
+add_executable(classic_pfaffian_legacy_ab_unit
+    classic_pfaffian_legacy_ab_unit.c
+    classic_pfaffian_legacy_matrix_tu.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_include_directories(classic_pfaffian_legacy_ab_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+target_link_libraries(classic_pfaffian_legacy_ab_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(classic_pfaffian_legacy_ab_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(classic_pfaffian_legacy_ab_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ClassicPfaffianLegacyExecutionAB_Unit
+    COMMAND classic_pfaffian_legacy_ab_unit)
+
 add_subdirectory(python)

--- a/test/absolute_pfaffian_unit.c
+++ b/test/absolute_pfaffian_unit.c
@@ -1,6 +1,7 @@
 #include "absolute_pfaffian.h"
 
 #include <complex.h>
+#include <float.h>
 #include <limits.h>
 #include <math.h>
 #include <stdio.h>
@@ -583,6 +584,15 @@ static void test_projected_amplitude(void) {
   CHECK(result.valid == 0 && result.total == 0.0 &&
             result.regular_count == 0,
         "failed aggregation does not expose a partial result");
+
+  components[0] = component(MVMC_PFAFFIAN_REGULAR, DBL_MAX);
+  components[1] = component(MVMC_PFAFFIAN_REGULAR, DBL_MAX);
+  weights[0] = weights[1] = 1.0;
+  CHECK(mvmc_projected_amplitude(components, weights, 2, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "finite terms whose aggregate overflows are rejected");
+  CHECK(result.valid == 0 && result.total == 0.0,
+        "overflowing aggregate does not expose a partial result");
 }
 
 static void test_rank_local_projected_amplitude(void) {

--- a/test/classic_pfaffian_collective_unit.c
+++ b/test/classic_pfaffian_collective_unit.c
@@ -1,0 +1,514 @@
+#include "classic_pfaffian_collective.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failure_count = 0;
+static int world_rank = 0;
+static int world_size = 1;
+
+#define CHECK(condition, message)                                         \
+  do {                                                                    \
+    if (!(condition)) {                                                   \
+      fprintf(stderr, "FAIL rank %d: %s (line %d)\n", world_rank,       \
+              (message), __LINE__);                                       \
+      ++failure_count;                                                    \
+    }                                                                     \
+  } while (0)
+
+static int close_complex(double complex actual, double complex expected,
+                         double tolerance) {
+  return cabs(actual - expected) <= tolerance * fmax(1.0, cabs(expected));
+}
+
+static void rank_partition(int qp_total, int rank, int size,
+                           int *qp_start, int *qp_end) {
+  *qp_start = (qp_total * rank) / size;
+  *qp_end = (qp_total * (rank + 1)) / size;
+}
+
+static void make_local_aggregate(int qp_total, int qp_start, int qp_end,
+                                 MVMCProjectedAmplitudeResult *aggregate) {
+  static const double complex terms[2] = {1.0 + 2.0 * I,
+                                           -0.25 + 0.5 * I};
+  int qp;
+
+  memset(aggregate, 0, sizeof(*aggregate));
+  for (qp = qp_start; qp < qp_end; ++qp) {
+    aggregate->total += terms[qp];
+    aggregate->sum_abs += cabs(terms[qp]);
+    if (qp == 0) {
+      ++aggregate->regular_count;
+    } else {
+      ++aggregate->near_singular_count;
+    }
+  }
+  aggregate->cancellation_ratio =
+      aggregate->sum_abs == 0.0
+          ? 0.0
+          : fmin(1.0, cabs(aggregate->total) / aggregate->sum_abs);
+  aggregate->valid = qp_total == 2;
+}
+
+static void test_global_aggregate(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace) {
+  static const MVMCPfaffianStatus lower_severity[3] = {
+      MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+      MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE,
+      MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE};
+  static const MVMCPfaffianStatus higher_severity[3] = {
+      MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE,
+      MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE,
+      MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE};
+  const int qp_total = 2;
+  const double complex expected_total = 0.75 + 2.5 * I;
+  const double expected_sum_abs = cabs(1.0 + 2.0 * I) +
+                                  cabs(-0.25 + 0.5 * I);
+  MVMCProjectedAmplitudeResult local;
+  MVMCClassicPfaffianCollectiveResult result;
+  MVMCPfaffianStatus status;
+  int qp_start, qp_end;
+  int target = world_size - 1;
+  int severity_case;
+
+  rank_partition(qp_total, world_rank, world_size, &qp_start, &qp_end);
+  make_local_aggregate(qp_total, qp_start, qp_end, &local);
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      qp_total, qp_start, qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.aggregate.valid,
+        "valid aggregate succeeds on every rank");
+  CHECK(close_complex(result.aggregate.total, expected_total, 2.0e-14),
+        "global complex total is reduced");
+  CHECK(fabs(result.aggregate.sum_abs - expected_sum_abs) <= 2.0e-14,
+        "global sum_abs is reduced");
+  CHECK(result.aggregate.regular_count == 1 &&
+            result.aggregate.near_singular_count == 1 &&
+            result.aggregate.singular_count == 0,
+        "global state counters are reduced");
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, NULL,
+      qp_total, qp_start, qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT && !result.valid &&
+            result.failure_rank == 0,
+        "OK status with a null local aggregate fails collectively");
+
+  memset(&local, 0, sizeof(local));
+  if (qp_start == 0 && qp_end > qp_start) {
+    local.total += 1.0;
+    local.sum_abs += 1.0;
+    ++local.regular_count;
+  }
+  if (qp_end == 2 && qp_start < qp_end) {
+    local.total -= 1.0;
+    local.sum_abs += 1.0;
+    ++local.regular_count;
+  }
+  local.cancellation_ratio =
+      local.sum_abs == 0.0
+          ? 0.0
+          : fmin(1.0, cabs(local.total) / local.sum_abs);
+  local.valid = 1;
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      qp_total, qp_start, qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK &&
+            result.aggregate.total == 0.0 &&
+            result.aggregate.sum_abs == 2.0 &&
+            result.aggregate.cancellation_ratio == 0.0,
+        "global cancellation ratio is recomputed after reduction");
+
+  make_local_aggregate(qp_total, qp_start, qp_end, &local);
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace,
+      world_rank == target ? MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE
+                           : MVMC_PFAFFIAN_STATUS_OK,
+      world_rank == target ? NULL : &local,
+      qp_total, qp_start, qp_end,
+      world_rank == target ? 7 : -1,
+      world_rank == target ? 11 : -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE &&
+            !result.valid && !result.aggregate.valid,
+        "one-rank factorization failure is collective");
+  CHECK(result.failure_rank == target && result.failure_local_qp == 7 &&
+            result.failure_global_qp == 11,
+        "collective failure payload identifies source rank and QP");
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace,
+      world_rank == 0 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                      : (world_rank == target
+                             ? MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE
+                             : MVMC_PFAFFIAN_STATUS_OK),
+      (world_rank == 0 || world_rank == target) ? NULL : &local,
+      qp_total, qp_start, qp_end,
+      world_rank == target ? 8 : 3,
+      world_rank == target ? 12 : 4, &result);
+  CHECK(status == (world_size == 1
+                       ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                       : MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE),
+        "collective status uses fixed severity order");
+  if (world_size > 1) {
+    CHECK(result.failure_rank == target && result.failure_local_qp == 8 &&
+              result.failure_global_qp == 12,
+          "higher-severity failure payload wins deterministically");
+
+    for (severity_case = 0; severity_case < 3; ++severity_case) {
+      MVMCPfaffianStatus local_severity =
+          world_rank == 0
+              ? lower_severity[severity_case]
+              : (world_rank == target ? higher_severity[severity_case]
+                                      : MVMC_PFAFFIAN_STATUS_OK);
+      status = mvmc_classic_pfaffian_collective_aggregate(
+          workspace, local_severity,
+          local_severity == MVMC_PFAFFIAN_STATUS_OK ? &local : NULL,
+          qp_total, qp_start, qp_end,
+          20 + world_rank, 30 + world_rank, &result);
+      CHECK(status == higher_severity[severity_case] &&
+                result.failure_rank == target &&
+                result.failure_local_qp == 20 + target &&
+                result.failure_global_qp == 30 + target,
+            "every adjacent severity level has the documented order");
+    }
+  }
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT, NULL,
+      qp_total, qp_start, qp_end,
+      40 + world_rank, 50 + world_rank, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == 0 && result.failure_local_qp == 40 &&
+            result.failure_global_qp == 50,
+        "equal severity selects the lowest communicator rank");
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      qp_total, qp_start,
+      world_rank == target ? qp_total + 1 : qp_end,
+      -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == target,
+        "malformed QP ownership is rejected collectively");
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      qp_total,
+      world_rank == target ? (world_size == 1 ? 1 : 0) : qp_start,
+      qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == target,
+        "QP ownership gap or overlap is rejected collectively");
+
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      world_rank == target ? qp_total + 1 : qp_total,
+      qp_start, qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == target,
+        "inconsistent qp_total is rejected collectively");
+
+  if (world_rank == target) local.total = NAN;
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      qp_total, qp_start, qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == target,
+        "nonfinite rank-local aggregate is rejected collectively");
+
+  make_local_aggregate(qp_total, qp_start, qp_end, &local);
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      qp_total, qp_start, qp_end, -1, -1,
+      world_rank == target ? NULL : &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "rank-local null result remains a collective failure");
+  if (world_rank != target) {
+    CHECK(result.failure_rank == target,
+          "null result failure identifies the source rank");
+  }
+}
+
+static void test_passed_communicator(void) {
+#ifdef _mpi_use
+  MPI_Comm subcomm = MPI_COMM_NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *workspace = NULL;
+  MVMCClassicPfaffianCollectiveResult result;
+  MVMCProjectedAmplitudeResult local;
+  MVMCPfaffianStatus status;
+  int color = world_rank % 2;
+  int rank, size, qp_start, qp_end;
+  double complex term;
+
+  MPI_Comm_split(MPI_COMM_WORLD, color, world_rank, &subcomm);
+  MPI_Comm_rank(subcomm, &rank);
+  MPI_Comm_size(subcomm, &size);
+  status = mvmc_classic_pfaffian_collective_workspace_create(
+      subcomm, &workspace);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && workspace != NULL,
+        "collective workspace accepts passed subcommunicator");
+  rank_partition(1, rank, size, &qp_start, &qp_end);
+  memset(&local, 0, sizeof(local));
+  term = (double)(color + 1) + (double)(color + 2) * I;
+  if (qp_end > qp_start) {
+    local.total = term;
+    local.sum_abs = cabs(term);
+    local.cancellation_ratio = 1.0;
+    local.regular_count = 1;
+  }
+  local.valid = 1;
+  status = mvmc_classic_pfaffian_collective_aggregate(
+      workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      1, qp_start, qp_end, -1, -1, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK &&
+            close_complex(result.aggregate.total, term, 1.0e-15),
+        "aggregate is confined to passed subcommunicator");
+  mvmc_classic_pfaffian_collective_workspace_destroy(workspace);
+  MPI_Comm_free(&subcomm);
+#endif
+}
+
+static void set_real_pair(double *matrix, int n, int row, int column,
+                          double value) {
+  matrix[(size_t)row * (size_t)n + (size_t)column] = value;
+  matrix[(size_t)column * (size_t)n + (size_t)row] = -value;
+}
+
+static void set_complex_pair(double complex *matrix, int n, int row,
+                             int column, double complex value) {
+  matrix[(size_t)row * (size_t)n + (size_t)column] = value;
+  matrix[(size_t)column * (size_t)n + (size_t)row] = -value;
+}
+
+static void fill_real_slater(double *matrix, double scale) {
+  memset(matrix, 0, 16 * sizeof(*matrix));
+  set_real_pair(matrix, 4, 0, 1, 2.0 * scale);
+  set_real_pair(matrix, 4, 0, 2, -1.0 * scale);
+  set_real_pair(matrix, 4, 0, 3, 0.5 * scale);
+  set_real_pair(matrix, 4, 1, 2, 3.0 * scale);
+  set_real_pair(matrix, 4, 1, 3, 4.0 * scale);
+  set_real_pair(matrix, 4, 2, 3, -2.0 * scale);
+}
+
+static void fill_complex_slater(double complex *matrix,
+                                double complex scale) {
+  memset(matrix, 0, 16 * sizeof(*matrix));
+  set_complex_pair(matrix, 4, 0, 1, (1.0 + 0.5 * I) * scale);
+  set_complex_pair(matrix, 4, 0, 2, (-0.25 + 0.75 * I) * scale);
+  set_complex_pair(matrix, 4, 0, 3, (2.0 - 0.5 * I) * scale);
+  set_complex_pair(matrix, 4, 1, 2, (0.5 + 1.25 * I) * scale);
+  set_complex_pair(matrix, 4, 1, 3, (-1.0 + 0.25 * I) * scale);
+  set_complex_pair(matrix, 4, 2, 3, (1.5 - 0.75 * I) * scale);
+}
+
+static void test_real_collective_state(
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace) {
+  const int qp_total = 2;
+  const int ele_idx[4] = {1, 0, 0, 1};
+  const double complex weights[2] = {1.0, 0.5};
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveResult result;
+  const MVMCClassicPfaffianState *state;
+  double slater[32];
+  double failed_slater[32];
+  double legacy[34];
+  double complex local_weights[2];
+  MVMCPfaffianStatus status;
+  int qp_start, qp_end;
+  int target = world_size - 1;
+
+  rank_partition(qp_total, world_rank, world_size, &qp_start, &qp_end);
+  fill_real_slater(slater, 1.0);
+  fill_real_slater(slater + 16, 0.75);
+  memcpy(failed_slater, slater, sizeof(slater));
+  memcpy(local_weights, weights, sizeof(weights));
+  memset(legacy, 0, sizeof(legacy));
+  status = mvmc_classic_pfaffian_real_workspace_create(
+      2, 4, qp_total, qp_start, qp_end, &state_workspace);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && state_workspace != NULL,
+        "create rank-local real state workspace");
+
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, slater, ele_idx, local_weights,
+      0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid,
+        "real absolute proposal succeeds collectively");
+  CHECK(result.aggregate.regular_count == 2 &&
+            result.aggregate.near_singular_count == 0 &&
+            result.aggregate.singular_count == 0,
+        "real collective proposal reports regular components");
+  state = mvmc_classic_pfaffian_real_candidate(state_workspace);
+  CHECK(state != NULL && state->generation == 1,
+        "successful collective proposal leaves local candidate ready");
+  if (state_workspace != NULL) {
+    status = mvmc_classic_pfaffian_real_publish(
+        state_workspace, legacy, sizeof(legacy) / sizeof(legacy[0]));
+    CHECK(status == MVMC_PFAFFIAN_STATUS_OK &&
+              mvmc_classic_pfaffian_real_accepted(state_workspace)->generation ==
+                  1,
+          "collective proposal can be published on every rank");
+  }
+
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, slater, ele_idx, local_weights,
+      0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.aggregate.regular_count == 2,
+        "regular-to-regular proposal succeeds collectively");
+  if (state_workspace != NULL) {
+    status = mvmc_classic_pfaffian_real_publish(
+        state_workspace, legacy, sizeof(legacy) / sizeof(legacy[0]));
+    CHECK(status == MVMC_PFAFFIAN_STATUS_OK,
+          "regular-to-regular state publishes on every rank");
+  }
+
+  memset(failed_slater + 16, 0, 16 * sizeof(*failed_slater));
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, failed_slater, ele_idx,
+      local_weights, 0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.aggregate.regular_count == 1 &&
+            result.aggregate.singular_count == 1,
+        "regular-to-singular proposal remains a valid global proposal");
+  if (state_workspace != NULL) {
+    status = mvmc_classic_pfaffian_real_publish(
+        state_workspace, legacy, sizeof(legacy) / sizeof(legacy[0]));
+    CHECK(status == MVMC_PFAFFIAN_STATUS_OK,
+          "regular-to-singular state publishes on every rank");
+  }
+
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, failed_slater, ele_idx,
+      local_weights, 0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.aggregate.regular_count == 1 &&
+            result.aggregate.singular_count == 1,
+        "singular-to-singular proposal succeeds collectively");
+  if (state_workspace != NULL) {
+    status = mvmc_classic_pfaffian_real_publish(
+        state_workspace, legacy, sizeof(legacy) / sizeof(legacy[0]));
+    CHECK(status == MVMC_PFAFFIAN_STATUS_OK,
+          "singular-to-singular state publishes on every rank");
+  }
+
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, slater, ele_idx, local_weights,
+      0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.aggregate.regular_count == 2 &&
+            result.aggregate.singular_count == 0,
+        "singular-to-regular proposal succeeds collectively");
+  if (state_workspace != NULL) {
+    status = mvmc_classic_pfaffian_real_publish(
+        state_workspace, legacy, sizeof(legacy) / sizeof(legacy[0]));
+    CHECK(status == MVMC_PFAFFIAN_STATUS_OK,
+          "singular-to-regular state publishes on every rank");
+  }
+
+  if (world_rank == target) local_weights[0] = NAN;
+  status = mvmc_classic_pfaffian_real_prepare_collective(
+      state_workspace, collective_workspace, slater, ele_idx, local_weights,
+      0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == target &&
+            result.failure_global_qp == 0,
+        "one-rank real prepare failure propagates with global QP");
+  CHECK(state_workspace == NULL ||
+            mvmc_classic_pfaffian_real_candidate(state_workspace) == NULL,
+        "collective prepare failure discards every local candidate");
+  CHECK(state_workspace == NULL ||
+            mvmc_classic_pfaffian_real_accepted(state_workspace)->generation ==
+                5,
+        "collective prepare failure preserves accepted generation");
+
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_complex_collective_state(
+    MVMCClassicPfaffianCollectiveWorkspace *collective_workspace) {
+  const int qp_total = 2;
+  const int ele_idx[4] = {1, 0, 0, 1};
+  const double complex weights[2] = {1.0 + 0.25 * I, -0.5 + 0.75 * I};
+  MVMCClassicPfaffianComplexWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveResult result;
+  double complex slater[32];
+  MVMCPfaffianStatus status;
+  int qp_start, qp_end;
+
+  rank_partition(qp_total, world_rank, world_size, &qp_start, &qp_end);
+  fill_complex_slater(slater, 1.0);
+  fill_complex_slater(slater + 16, 0.5 - 0.25 * I);
+  status = mvmc_classic_pfaffian_complex_workspace_create(
+      2, 4, qp_total, qp_start, qp_end, &state_workspace);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && state_workspace != NULL,
+        "create rank-local complex state workspace");
+  status = mvmc_classic_pfaffian_complex_prepare_collective(
+      state_workspace, collective_workspace, slater, ele_idx, weights,
+      0.0, 0.0, &result);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.aggregate.regular_count == 2 &&
+            isfinite(creal(result.aggregate.total)) &&
+            isfinite(cimag(result.aggregate.total)),
+        "complex absolute proposal reduces a finite global total");
+  mvmc_classic_pfaffian_complex_discard_candidate(state_workspace);
+  mvmc_classic_pfaffian_complex_workspace_destroy(state_workspace);
+}
+
+int main(int argc, char **argv) {
+  MVMCClassicPfaffianCollectiveWorkspace *workspace = NULL;
+#ifdef _mpi_use
+  MVMCClassicPfaffianCollectiveWorkspace *invalid_workspace = NULL;
+#endif
+  MVMCPfaffianStatus status;
+  int total_failures;
+
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  status = mvmc_classic_pfaffian_collective_workspace_create(
+      MPI_COMM_NULL, &invalid_workspace);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            invalid_workspace == NULL,
+        "MPI_COMM_NULL workspace creation is rejected");
+  status = mvmc_classic_pfaffian_collective_workspace_create(
+      MPI_COMM_WORLD, &workspace);
+#else
+  (void)argc;
+  (void)argv;
+  status = mvmc_classic_pfaffian_collective_workspace_create(0, &workspace);
+#endif
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK && workspace != NULL,
+        "create world collective workspace");
+  if (workspace != NULL) {
+    test_global_aggregate(workspace);
+    test_passed_communicator();
+    test_real_collective_state(workspace);
+    test_complex_collective_state(workspace);
+  }
+  mvmc_classic_pfaffian_collective_workspace_destroy(workspace);
+
+#ifdef _mpi_use
+  MPI_Allreduce(&failure_count, &total_failures, 1, MPI_INT, MPI_SUM,
+                MPI_COMM_WORLD);
+  if (world_rank == 0 && total_failures == 0) {
+    printf("classic_pfaffian_collective_unit: PASS (%d ranks)\n", world_size);
+  }
+  MPI_Finalize();
+#else
+  total_failures = failure_count;
+  if (total_failures == 0) {
+    printf("classic_pfaffian_collective_unit: PASS (1 rank)\n");
+  }
+#endif
+  return total_failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/classic_pfaffian_legacy_ab_unit.c
+++ b/test/classic_pfaffian_legacy_ab_unit.c
@@ -1,0 +1,437 @@
+#include "classic_pfaffian_state.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int Nsite;
+extern int Ne;
+extern int Nsize;
+extern int Nsite2;
+extern int NQPFull;
+extern int NThread;
+extern int LapackLWork;
+extern double *SlaterElm_real;
+extern double *InvM_real;
+extern double *PfM_real;
+extern double complex *SlaterElm;
+extern double complex *InvM;
+extern double complex *PfM;
+
+extern int omp_get_max_threads(void);
+extern void initializeWorkSpaceAll(void);
+extern void FreeWorkSpaceAll(void);
+extern int CalculateMAll_real(const int *, int, int);
+extern int CalculateMAll_fcmp(const int *, int, int);
+extern void CalculateNewPfM2_real(int, int, double *, const int *, int, int);
+extern void CalculateNewPfM2(int, int, double complex *, const int *, int, int);
+extern void CalculateNewPfMTwo2_real(
+    int, int, int, int, double *, const int *, int, int);
+extern void CalculateNewPfMTwo2_fcmp(
+    int, int, int, int, double complex *, const int *, int, int);
+
+static int failure_count = 0;
+
+#define CHECK(condition, message)                                      \
+  do {                                                                 \
+    if (!(condition)) {                                                \
+      fprintf(stderr, "FAIL: %s (line %d)\n", (message), __LINE__);   \
+      ++failure_count;                                                 \
+    }                                                                  \
+  } while (0)
+
+static int close_complex(double complex actual, double complex expected) {
+  return cabs(actual - expected) <= 4.0e-12 * fmax(1.0, cabs(expected));
+}
+
+static void set_real_pair(double *matrix, int row, int column, double value) {
+  matrix[(size_t)row * (size_t)Nsite2 + (size_t)column] = value;
+  matrix[(size_t)column * (size_t)Nsite2 + (size_t)row] = -value;
+}
+
+static void set_complex_pair(double complex *matrix, int row, int column,
+                             double complex value) {
+  matrix[(size_t)row * (size_t)Nsite2 + (size_t)column] = value;
+  matrix[(size_t)column * (size_t)Nsite2 + (size_t)row] = -value;
+}
+
+static void fill_slater(int qp_total, int nsize) {
+  int qp;
+  memset(SlaterElm_real, 0,
+         (size_t)qp_total * (size_t)Nsite2 * (size_t)Nsite2 *
+             sizeof(*SlaterElm_real));
+  memset(SlaterElm, 0,
+         (size_t)qp_total * (size_t)Nsite2 * (size_t)Nsite2 *
+             sizeof(*SlaterElm));
+  for (qp = 0; qp < qp_total; ++qp) {
+    const double real_value = 0.75 + (double)qp;
+    const double complex complex_value =
+        (0.5 + 0.25 * I) * (1.0 + (double)qp);
+    double *real_matrix =
+        SlaterElm_real + (size_t)qp * (size_t)Nsite2 * (size_t)Nsite2;
+    double complex *complex_matrix =
+        SlaterElm + (size_t)qp * (size_t)Nsite2 * (size_t)Nsite2;
+
+    set_real_pair(real_matrix, 0, 2, real_value);
+    set_complex_pair(complex_matrix, 0, 2, complex_value);
+    if (nsize == 4) {
+      set_real_pair(real_matrix, 0, 1, 1.0 * real_value);
+      set_real_pair(real_matrix, 0, 3, 0.5 * real_value);
+      set_real_pair(real_matrix, 1, 2, 1.5 * real_value);
+      set_real_pair(real_matrix, 1, 3, -0.75 * real_value);
+      set_real_pair(real_matrix, 2, 3, 2.25 * real_value);
+      set_complex_pair(complex_matrix, 0, 1, 1.0 * complex_value);
+      set_complex_pair(complex_matrix, 0, 3, 0.5 * complex_value);
+      set_complex_pair(complex_matrix, 1, 2, 1.5 * complex_value);
+      set_complex_pair(complex_matrix, 1, 3, -0.75 * complex_value);
+      set_complex_pair(complex_matrix, 2, 3, 2.25 * complex_value);
+    }
+  }
+}
+
+static void run_ab(int qp_total, int nsize, const int *ele_idx) {
+  const double complex real_weights[4] = {1.0, 1.0, 1.0, 1.0};
+  const double complex complex_weights[4] = {1.0, 1.0, 1.0, 1.0};
+  MVMCClassicPfaffianRealWorkspace *real_workspace = NULL;
+  MVMCClassicPfaffianComplexWorkspace *complex_workspace = NULL;
+  double *real_mirror;
+  double complex *complex_mirror;
+  size_t matrix_elements = (size_t)nsize * (size_t)nsize;
+  size_t matrix_count = (size_t)qp_total * matrix_elements;
+  size_t mirror_count = (size_t)qp_total * (matrix_elements + 1);
+  size_t slater_count =
+      (size_t)qp_total * (size_t)Nsite2 * (size_t)Nsite2;
+  size_t index;
+
+  NQPFull = qp_total;
+  SlaterElm_real = (double *)calloc(slater_count, sizeof(*SlaterElm_real));
+  InvM_real = (double *)calloc(matrix_count, sizeof(*InvM_real));
+  PfM_real = (double *)calloc((size_t)qp_total, sizeof(*PfM_real));
+  SlaterElm = (double complex *)calloc(slater_count, sizeof(*SlaterElm));
+  InvM = (double complex *)calloc(matrix_count, sizeof(*InvM));
+  PfM = (double complex *)calloc((size_t)qp_total, sizeof(*PfM));
+  real_mirror = (double *)calloc(mirror_count, sizeof(*real_mirror));
+  complex_mirror = (double complex *)calloc(mirror_count,
+                                             sizeof(*complex_mirror));
+  CHECK(SlaterElm_real != NULL && InvM_real != NULL && PfM_real != NULL &&
+            SlaterElm != NULL && InvM != NULL && PfM != NULL &&
+            real_mirror != NULL && complex_mirror != NULL,
+        "allocate legacy A/B fixture");
+  if (SlaterElm_real == NULL || InvM_real == NULL || PfM_real == NULL ||
+      SlaterElm == NULL || InvM == NULL || PfM == NULL ||
+      real_mirror == NULL || complex_mirror == NULL) {
+    goto cleanup;
+  }
+  fill_slater(qp_total, nsize);
+  CHECK(CalculateMAll_real(ele_idx, 0, qp_total) == 0,
+        "execute legacy CalculateMAll_real oracle");
+  CHECK(CalculateMAll_fcmp(ele_idx, 0, qp_total) == 0,
+        "execute legacy CalculateMAll_fcmp oracle");
+
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, nsize, qp_total, 0, qp_total, &real_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create new real A/B workspace");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, SlaterElm_real, ele_idx, real_weights,
+            0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_real_publish(
+                real_workspace, real_mirror, mirror_count) ==
+                MVMC_PFAFFIAN_STATUS_OK,
+        "execute new real prepare/publish");
+  CHECK(mvmc_classic_pfaffian_complex_workspace_create(
+            2, nsize, qp_total, 0, qp_total, &complex_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create new complex A/B workspace");
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            complex_workspace, SlaterElm, ele_idx, complex_weights,
+            0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_complex_publish(
+                complex_workspace, complex_mirror, mirror_count) ==
+                MVMC_PFAFFIAN_STATUS_OK,
+        "execute new complex prepare/publish");
+
+  for (index = 0; index < matrix_count; ++index) {
+    CHECK(fabs(real_mirror[index] - InvM_real[index]) <=
+              4.0e-12 * fmax(1.0, fabs(InvM_real[index])),
+          "real new inverse mirror matches executed legacy wrapper");
+    CHECK(close_complex(complex_mirror[index], InvM[index]),
+          "complex new inverse mirror matches executed legacy wrapper");
+  }
+  for (index = 0; index < (size_t)qp_total; ++index) {
+    CHECK(fabs(real_mirror[matrix_count + index] - PfM_real[index]) <=
+              4.0e-12 * fmax(1.0, fabs(PfM_real[index])),
+          "real new PfM mirror matches executed legacy wrapper");
+    CHECK(close_complex(complex_mirror[matrix_count + index], PfM[index]),
+          "complex new PfM mirror matches executed legacy wrapper");
+  }
+
+cleanup:
+  mvmc_classic_pfaffian_real_workspace_destroy(real_workspace);
+  mvmc_classic_pfaffian_complex_workspace_destroy(complex_workspace);
+  free(complex_mirror);
+  free(real_mirror);
+  free(PfM);
+  free(InvM);
+  free(SlaterElm);
+  free(PfM_real);
+  free(InvM_real);
+  free(SlaterElm_real);
+  PfM = NULL;
+  InvM = NULL;
+  SlaterElm = NULL;
+  PfM_real = NULL;
+  InvM_real = NULL;
+  SlaterElm_real = NULL;
+}
+
+static void run_measurement_singular_blocker_negative_control(void) {
+  const int ele_idx[2] = {0, 0};
+  const double complex weights[2] = {1.0, 1.0};
+  const int qp_total = 2;
+  const size_t matrix_elements = 4;
+  const size_t matrix_count = (size_t)qp_total * matrix_elements;
+  const size_t mirror_count = (size_t)qp_total * (matrix_elements + 1);
+  const size_t slater_count =
+      (size_t)qp_total * (size_t)Nsite2 * (size_t)Nsite2;
+  MVMCClassicPfaffianRealWorkspace *real_workspace = NULL;
+  MVMCClassicPfaffianComplexWorkspace *complex_workspace = NULL;
+  const MVMCClassicPfaffianState *real_state;
+  const MVMCClassicPfaffianState *complex_state;
+  double *real_mirror = NULL;
+  double complex *complex_mirror = NULL;
+
+  NQPFull = qp_total;
+  SlaterElm_real = (double *)calloc(slater_count, sizeof(*SlaterElm_real));
+  InvM_real = (double *)calloc(matrix_count, sizeof(*InvM_real));
+  PfM_real = (double *)calloc((size_t)qp_total, sizeof(*PfM_real));
+  SlaterElm = (double complex *)calloc(slater_count, sizeof(*SlaterElm));
+  InvM = (double complex *)calloc(matrix_count, sizeof(*InvM));
+  PfM = (double complex *)calloc((size_t)qp_total, sizeof(*PfM));
+  real_mirror = (double *)calloc(mirror_count, sizeof(*real_mirror));
+  complex_mirror = (double complex *)calloc(mirror_count,
+                                             sizeof(*complex_mirror));
+  CHECK(SlaterElm_real != NULL && InvM_real != NULL && PfM_real != NULL &&
+            SlaterElm != NULL && InvM != NULL && PfM != NULL &&
+            real_mirror != NULL && complex_mirror != NULL,
+        "allocate measurement singular blocker fixture");
+  if (SlaterElm_real == NULL || InvM_real == NULL || PfM_real == NULL ||
+      SlaterElm == NULL || InvM == NULL || PfM == NULL ||
+      real_mirror == NULL || complex_mirror == NULL) {
+    goto cleanup;
+  }
+
+  /* QP 0 is regular and QP 1 is exactly singular, but the total is nonzero. */
+  set_real_pair(SlaterElm_real, 0, 2, 1.0);
+  set_complex_pair(SlaterElm, 0, 2, 1.0 + 0.25 * I);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, qp_total, 0, qp_total, &real_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_real_prepare(
+                real_workspace, SlaterElm_real, ele_idx, weights,
+                0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_real_publish(
+                real_workspace, real_mirror, mirror_count) ==
+                MVMC_PFAFFIAN_STATUS_OK,
+        "absolute real state keeps partial-singular nonzero-total sample");
+  real_state = mvmc_classic_pfaffian_real_accepted(real_workspace);
+  CHECK(real_state != NULL && real_state->valid &&
+            real_state->local_aggregate.singular_count == 1 &&
+            cabs(real_state->local_aggregate.total) > 0.0,
+        "real partial-singular sample remains a valid projected state");
+  CHECK(mvmc_classic_pfaffian_complex_workspace_create(
+            2, 2, qp_total, 0, qp_total, &complex_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_complex_prepare(
+                complex_workspace, SlaterElm, ele_idx, weights,
+                0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_complex_publish(
+                complex_workspace, complex_mirror, mirror_count) ==
+                MVMC_PFAFFIAN_STATUS_OK,
+        "absolute complex state keeps partial-singular nonzero-total sample");
+  complex_state = mvmc_classic_pfaffian_complex_accepted(complex_workspace);
+  CHECK(complex_state != NULL && complex_state->valid &&
+            complex_state->local_aggregate.singular_count == 1 &&
+            cabs(complex_state->local_aggregate.total) > 0.0,
+        "complex partial-singular sample remains a valid projected state");
+
+  CHECK(CalculateMAll_real(ele_idx, 0, qp_total) != 0,
+        "legacy real measurement rebuild rejects the valid singular sample");
+  CHECK(CalculateMAll_fcmp(ele_idx, 0, qp_total) != 0,
+        "legacy complex measurement rebuild rejects the valid singular sample");
+
+cleanup:
+  mvmc_classic_pfaffian_real_workspace_destroy(real_workspace);
+  mvmc_classic_pfaffian_complex_workspace_destroy(complex_workspace);
+  free(complex_mirror);
+  free(real_mirror);
+  free(PfM);
+  free(InvM);
+  free(SlaterElm);
+  free(PfM_real);
+  free(InvM_real);
+  free(SlaterElm_real);
+  PfM = NULL;
+  InvM = NULL;
+  SlaterElm = NULL;
+  PfM_real = NULL;
+  InvM_real = NULL;
+  SlaterElm_real = NULL;
+}
+
+static void run_actual_fast_absolute_observation(void) {
+  const int initial_idx[2] = {0, 0};
+  const int hopping_idx[2] = {1, 0};
+  const int exchange_idx[2] = {0, 1};
+  const double complex weights[4] = {1.0, 1.0, 1.0, 1.0};
+  const int qp_total = 4;
+  const size_t matrix_count = (size_t)qp_total * 4;
+  const size_t slater_count =
+      (size_t)qp_total * (size_t)Nsite2 * (size_t)Nsite2;
+  double fast_rank_one_real[4];
+  double fast_rank_two_real[4];
+  double complex fast_rank_one_complex[4];
+  double complex fast_rank_two_complex[4];
+  MVMCClassicPfaffianRealWorkspace *real_workspace = NULL;
+  MVMCClassicPfaffianComplexWorkspace *complex_workspace = NULL;
+  const MVMCClassicPfaffianState *candidate;
+  int qp;
+
+  NQPFull = qp_total;
+  SlaterElm_real = (double *)calloc(slater_count, sizeof(*SlaterElm_real));
+  InvM_real = (double *)calloc(matrix_count, sizeof(*InvM_real));
+  PfM_real = (double *)calloc((size_t)qp_total, sizeof(*PfM_real));
+  SlaterElm = (double complex *)calloc(slater_count, sizeof(*SlaterElm));
+  InvM = (double complex *)calloc(matrix_count, sizeof(*InvM));
+  PfM = (double complex *)calloc((size_t)qp_total, sizeof(*PfM));
+  CHECK(SlaterElm_real != NULL && InvM_real != NULL && PfM_real != NULL &&
+            SlaterElm != NULL && InvM != NULL && PfM != NULL,
+        "allocate actual fast/absolute observation fixture");
+  if (SlaterElm_real == NULL || InvM_real == NULL || PfM_real == NULL ||
+      SlaterElm == NULL || InvM == NULL || PfM == NULL) {
+    goto cleanup;
+  }
+  fill_slater(qp_total, 2);
+  CHECK(CalculateMAll_real(initial_idx, 0, qp_total) == 0 &&
+            CalculateMAll_fcmp(initial_idx, 0, qp_total) == 0,
+        "initialize actual legacy fast proposal cache");
+  CalculateNewPfM2_real(0, 0, fast_rank_one_real, hopping_idx, 0, qp_total);
+  CalculateNewPfM2(0, 0, fast_rank_one_complex, hopping_idx, 0, qp_total);
+  CalculateNewPfMTwo2_real(
+      0, 0, 0, 1, fast_rank_two_real, exchange_idx, 0, qp_total);
+  CalculateNewPfMTwo2_fcmp(
+      0, 0, 0, 1, fast_rank_two_complex, exchange_idx, 0, qp_total);
+
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, qp_total, 0, qp_total, &real_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_classic_pfaffian_complex_workspace_create(
+                2, 2, qp_total, 0, qp_total, &complex_workspace) ==
+                MVMC_PFAFFIAN_STATUS_OK,
+        "create actual fast/absolute observation workspaces");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, SlaterElm_real, hopping_idx, weights,
+            0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK,
+        "prepare real rank-one absolute candidate");
+  candidate = mvmc_classic_pfaffian_real_candidate(real_workspace);
+  for (qp = 0; qp < qp_total; ++qp) {
+    CHECK(candidate != NULL &&
+              fabs(fast_rank_one_real[qp] -
+                   creal(candidate->components[qp].pfaffian)) <=
+                  1.0e-11 * fmax(1.0, cabs(candidate->components[qp].pfaffian)),
+          "actual real rank-one fast Pfaffian matches absolute candidate");
+  }
+  mvmc_classic_pfaffian_real_discard_candidate(real_workspace);
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            complex_workspace, SlaterElm, hopping_idx, weights,
+            0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK,
+        "prepare complex rank-one absolute candidate");
+  candidate = mvmc_classic_pfaffian_complex_candidate(complex_workspace);
+  for (qp = 0; qp < qp_total; ++qp) {
+    CHECK(candidate != NULL &&
+              close_complex(fast_rank_one_complex[qp],
+                            candidate->components[qp].pfaffian),
+          "actual complex rank-one fast Pfaffian matches absolute candidate");
+  }
+  mvmc_classic_pfaffian_complex_discard_candidate(complex_workspace);
+
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, SlaterElm_real, exchange_idx, weights,
+            0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK,
+        "prepare real rank-two singular absolute candidate");
+  candidate = mvmc_classic_pfaffian_real_candidate(real_workspace);
+  CHECK(candidate != NULL && candidate->components[0].state ==
+            MVMC_PFAFFIAN_SINGULAR,
+        "rank-two fast observation includes a singular absolute component");
+  for (qp = 0; qp < qp_total; ++qp) {
+    CHECK(candidate != NULL &&
+              fabs(fast_rank_two_real[qp] -
+                   creal(candidate->components[qp].pfaffian)) <=
+                  1.0e-11 * fmax(1.0, cabs(candidate->components[qp].pfaffian)),
+          "actual real rank-two fast Pfaffian compares singular without skip");
+  }
+  mvmc_classic_pfaffian_real_discard_candidate(real_workspace);
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            complex_workspace, SlaterElm, exchange_idx, weights,
+            0.0, 0.0) == MVMC_PFAFFIAN_STATUS_OK,
+        "prepare complex rank-two singular absolute candidate");
+  candidate = mvmc_classic_pfaffian_complex_candidate(complex_workspace);
+  CHECK(candidate != NULL && candidate->components[0].state ==
+            MVMC_PFAFFIAN_SINGULAR,
+        "complex rank-two observation includes singular component");
+  for (qp = 0; qp < qp_total; ++qp) {
+    CHECK(candidate != NULL &&
+              close_complex(fast_rank_two_complex[qp],
+                            candidate->components[qp].pfaffian),
+          "actual complex rank-two fast Pfaffian compares singular without skip");
+  }
+
+cleanup:
+  mvmc_classic_pfaffian_real_workspace_destroy(real_workspace);
+  mvmc_classic_pfaffian_complex_workspace_destroy(complex_workspace);
+  free(PfM);
+  free(InvM);
+  free(SlaterElm);
+  free(PfM_real);
+  free(InvM_real);
+  free(SlaterElm_real);
+  PfM = NULL;
+  InvM = NULL;
+  SlaterElm = NULL;
+  PfM_real = NULL;
+  InvM_real = NULL;
+  SlaterElm_real = NULL;
+}
+
+int main(void) {
+  const int ele_idx_n2[2] = {0, 0};
+  const int ele_idx_n4[4] = {1, 0, 0, 1};
+
+  Nsite = 2;
+  Nsite2 = 4;
+  NThread = omp_get_max_threads();
+
+  Ne = 1;
+  Nsize = 2;
+  LapackLWork = 128;
+  initializeWorkSpaceAll();
+  run_ab(1, Nsize, ele_idx_n2);
+  run_ab(4, Nsize, ele_idx_n2);
+  run_measurement_singular_blocker_negative_control();
+  run_actual_fast_absolute_observation();
+  FreeWorkSpaceAll();
+
+  Ne = 2;
+  Nsize = 4;
+  LapackLWork = 128;
+  initializeWorkSpaceAll();
+  run_ab(1, Nsize, ele_idx_n4);
+  run_ab(4, Nsize, ele_idx_n4);
+  FreeWorkSpaceAll();
+  if (failure_count == 0) {
+    printf("classic Pfaffian legacy execution A/B unit: PASS\n");
+  }
+  return failure_count == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test/classic_pfaffian_legacy_matrix_tu.c
+++ b/test/classic_pfaffian_legacy_matrix_tu.c
@@ -1,0 +1,25 @@
+#include <complex.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#else
+typedef int MPI_Comm;
+#endif
+
+extern int omp_get_thread_num(void);
+
+#include "global.h"
+#include "blas_externs.h"
+
+/* Compile the legacy unity-only matrix implementation as an isolated oracle. */
+#include "../src/mVMC/matrix.c"
+
+/* Compile the actual classic rank-one/two fast proposal kernels as observers. */
+#include "../src/mVMC/pfupdate.c"
+#include "../src/mVMC/pfupdate_real.c"
+#include "../src/mVMC/pfupdate_two_fcmp.c"
+#include "../src/mVMC/pfupdate_two_real.c"

--- a/test/classic_pfaffian_sampler_unit.c
+++ b/test/classic_pfaffian_sampler_unit.c
@@ -1,0 +1,1132 @@
+#include "classic_pfaffian_sampler.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#define TEST_COMMUNICATOR MPI_COMM_WORLD
+#else
+#define TEST_COMMUNICATOR 0
+#endif
+
+static int failure_count = 0;
+static int world_rank = 0;
+static int world_size = 1;
+
+#define CHECK(condition, message)                                         \
+  do {                                                                    \
+    if (!(condition)) {                                                   \
+      fprintf(stderr, "FAIL rank %d: %s (line %d)\n", world_rank,       \
+              (message), __LINE__);                                       \
+      ++failure_count;                                                    \
+    }                                                                     \
+  } while (0)
+
+typedef struct {
+  double value;
+  int count;
+} DrawContext;
+
+typedef struct {
+  MVMCClassicProposalDecision decisions[4];
+  double uniforms[4];
+  uint64_t generations[4];
+  int draw_counts[4];
+} ProposalTrace;
+
+typedef struct {
+  uint64_t proposal_id;
+  MVMCClassicMoveKind move;
+  int index_count;
+  int indices[MVMC_CLASSIC_TRACE_INDEX_CAPACITY];
+  int uniform_draw_count;
+  double uniform;
+  double complex current_total;
+  double complex proposal_total;
+  size_t regular_count;
+  size_t near_singular_count;
+  size_t singular_count;
+  MVMCClassicProposalDecision decision;
+  uint64_t accepted_generation;
+  int ele_idx[2];
+} P2DTrajectoryRecord;
+
+typedef struct {
+  P2DTrajectoryRecord records[2];
+} P2DTrajectory;
+
+typedef struct {
+  int call_count;
+  int qp_start;
+  int inject_global_qp;
+  int inject_inverse;
+  int fail_observer;
+} AuditObserverContext;
+
+static double draw_once(void *context) {
+  DrawContext *draw = (DrawContext *)context;
+  ++draw->count;
+  return draw->value;
+}
+
+static MVMCPfaffianStatus observe_real_candidate(
+    void *context, const MVMCClassicPfaffianState *absolute_candidate,
+    const double *absolute_inverse,
+    MVMCClassicPfaffianRealObservation *observation) {
+  AuditObserverContext *audit = (AuditObserverContext *)context;
+  const size_t inverse_count = observation->component_count *
+                               observation->matrix_element_count;
+  int local_qp;
+
+  ++audit->call_count;
+  if (audit->fail_observer) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (observation->component_count != 0) {
+    memcpy(observation->components, absolute_candidate->components,
+           observation->component_count * sizeof(*observation->components));
+  }
+  if (inverse_count != 0) {
+    memcpy(observation->inverse, absolute_inverse,
+           inverse_count * sizeof(*observation->inverse));
+  }
+  local_qp = audit->inject_global_qp - audit->qp_start;
+  if (local_qp >= 0 &&
+      (size_t)local_qp < observation->component_count) {
+    if (audit->inject_inverse) {
+      observation->inverse[(size_t)local_qp *
+                           observation->matrix_element_count] = 1.0;
+    } else {
+      if (observation->components[local_qp].state ==
+          MVMC_PFAFFIAN_SINGULAR) {
+        observation->components[local_qp].state = MVMC_PFAFFIAN_REGULAR;
+        observation->components[local_qp].inverse_valid = 1;
+        observation->components[local_qp].pfaffian = 1.0;
+      } else {
+        observation->components[local_qp].pfaffian += 1.0;
+      }
+    }
+  }
+  observation->valid = 1;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static MVMCPfaffianStatus observe_complex_candidate(
+    void *context, const MVMCClassicPfaffianState *absolute_candidate,
+    const double complex *absolute_inverse,
+    MVMCClassicPfaffianComplexObservation *observation) {
+  AuditObserverContext *audit = (AuditObserverContext *)context;
+  const size_t inverse_count = observation->component_count *
+                               observation->matrix_element_count;
+
+  ++audit->call_count;
+  if (audit->fail_observer) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (observation->component_count != 0) {
+    memcpy(observation->components, absolute_candidate->components,
+           observation->component_count * sizeof(*observation->components));
+  }
+  if (inverse_count != 0) {
+    memcpy(observation->inverse, absolute_inverse,
+           inverse_count * sizeof(*observation->inverse));
+  }
+  observation->valid = 1;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static void save_p2d_trajectory(P2DTrajectory *trajectory, int index,
+                                const MVMCClassicProposalTrace *trace,
+                                const int *ele_idx) {
+  P2DTrajectoryRecord *record = &trajectory->records[index];
+  int item;
+
+  memset(record, 0, sizeof(*record));
+  record->proposal_id = trace->proposal_id;
+  record->move = trace->move;
+  record->index_count = trace->index_count;
+  for (item = 0; item < trace->index_count; ++item) {
+    record->indices[item] = trace->indices[item];
+  }
+  record->uniform_draw_count = trace->uniform_draw_count;
+  record->uniform = trace->uniform;
+  record->current_total = trace->current_total;
+  record->proposal_total = trace->proposal_total;
+  record->regular_count = trace->regular_count;
+  record->near_singular_count = trace->near_singular_count;
+  record->singular_count = trace->singular_count;
+  record->decision = trace->decision;
+  record->accepted_generation = trace->accepted_generation;
+  record->ele_idx[0] = ele_idx[0];
+  record->ele_idx[1] = ele_idx[1];
+}
+
+static void rank_partition(int qp_total, int *qp_start, int *qp_end) {
+  *qp_start = (qp_total * world_rank) / world_size;
+  *qp_end = (qp_total * (world_rank + 1)) / world_size;
+}
+
+static void set_real_pair(double *matrix, int row, int column, double value) {
+  matrix[(size_t)row * 4 + (size_t)column] = value;
+  matrix[(size_t)column * 4 + (size_t)row] = -value;
+}
+
+static void set_complex_pair(double complex *matrix, int row, int column,
+                             double complex value) {
+  matrix[(size_t)row * 4 + (size_t)column] = value;
+  matrix[(size_t)column * 4 + (size_t)row] = -value;
+}
+
+static void fill_real_slater(double *slater, int qp_total) {
+  int qp;
+  memset(slater, 0, (size_t)qp_total * 16 * sizeof(*slater));
+  for (qp = 0; qp < qp_total; ++qp) {
+    double *matrix = slater + (size_t)qp * 16;
+    const double base = (double)(qp + 1);
+    set_real_pair(matrix, 0, 2, base);
+    set_real_pair(matrix, 1, 2, 1.25 * base);
+    set_real_pair(matrix, 0, 3, qp == 0 ? 0.0 : 1.5 * base);
+    set_real_pair(matrix, 1, 3, 0.0);
+  }
+}
+
+static void fill_complex_slater(double complex *slater, int qp_total) {
+  int qp;
+  memset(slater, 0, (size_t)qp_total * 16 * sizeof(*slater));
+  for (qp = 0; qp < qp_total; ++qp) {
+    double complex *matrix = slater + (size_t)qp * 16;
+    const double complex base =
+        (double)(qp + 1) * (1.0 + 0.2 * (double)qp * I);
+    set_complex_pair(matrix, 0, 2, base);
+    set_complex_pair(matrix, 1, 2, 0.5 * base);
+    set_complex_pair(matrix, 0, 3, qp == 0 ? 0.0 : 1.25 * base);
+    set_complex_pair(matrix, 1, 3, 0.0);
+  }
+}
+
+static void save_trace(ProposalTrace *trace, int index,
+                       const MVMCClassicProposalResult *result) {
+  trace->decisions[index] = result->decision;
+  trace->uniforms[index] = result->uniform;
+  trace->generations[index] = result->accepted_generation;
+  trace->draw_counts[index] = result->uniform_draw_count;
+}
+
+static void run_real_sequence(int qp_total, ProposalTrace *trace) {
+  const int initial_idx[2] = {0, 0};
+  const int hopping_idx[2] = {1, 0};
+  const int spin_hopping_idx[2] = {1, 1};
+  const int exchange_idx[2] = {0, 1};
+  double complex weights[4] = {1.0, 0.75, -0.25, 0.5};
+  double slater[64];
+  double legacy[20];
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  DrawContext draw;
+  int qp_start, qp_end;
+  int index;
+
+  memset(trace, 0, sizeof(*trace));
+  for (index = 0; index < 20; ++index) legacy[index] = 71.0;
+  rank_partition(qp_total, &qp_start, &qp_end);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, qp_total, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create real sampler state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create real sampler collective workspace");
+  fill_real_slater(slater, qp_total);
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx, weights,
+            0.0, 0.0, legacy, (size_t)qp_total * 5, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK && sampler_state.valid,
+        "initialize real sampler from absolute state");
+
+  draw.value = 0.75;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_PAIR_HOPPING, slater, spin_hopping_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, legacy,
+            (size_t)qp_total * 5, &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED &&
+            result.proposal_total == 0.0,
+        "rank-two pair hopping from a doubly occupied site rejects zero total");
+  CHECK(draw.count == 1 && result.uniform_draw_count == 1,
+        "exact-zero pair hopping still consumes exactly one uniform");
+  save_trace(trace, 0, &result);
+
+  draw.value = 0.25;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights, 0.0, 0.0,
+            0.0, 0.0, draw_once, &draw, legacy, (size_t)qp_total * 5,
+            &result) == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_ACCEPTED,
+        "rank-one hopping accepts authoritative absolute candidate");
+  CHECK(draw.count == 1 && result.uniform_draw_count == 1,
+        "accepted hopping consumes exactly one uniform");
+  save_trace(trace, 1, &result);
+
+  draw.value = 0.5;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_SPIN_HOPPING, slater, spin_hopping_idx, weights,
+            0.0, 0.0, -INFINITY, 0.0, draw_once, &draw, legacy,
+            (size_t)qp_total * 5, &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED,
+        "spin hopping rejection preserves accepted state");
+  CHECK(result.accepted_generation == 2 && draw.count == 1,
+        "rejected rank-one move preserves generation and one draw");
+  save_trace(trace, 2, &result);
+
+  draw.value = 0.0;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, exchange_idx, weights, 0.0, 0.0,
+            0.0, 0.0, draw_once, &draw, legacy, (size_t)qp_total * 5,
+            &result) == MVMC_PFAFFIAN_STATUS_OK,
+        "rank-two exchange evaluates absolute candidate");
+  if (qp_total == 1) {
+    CHECK(result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED,
+          "single-QP singular exchange has exact-zero total");
+  } else {
+    CHECK(result.decision == MVMC_CLASSIC_PROPOSAL_ACCEPTED &&
+              sampler_state.accepted_aggregate.singular_count == 1,
+          "multi-QP singular component with nonzero total is accepted");
+  }
+  CHECK(draw.count == 1,
+        "exchange consumes one uniform even for exact-zero proposal");
+  save_trace(trace, 3, &result);
+
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            (MVMCClassicMoveKind)99, slater, initial_idx, weights, 0.0, 0.0,
+            0.0, 0.0, draw_once, &draw, legacy, (size_t)qp_total * 5,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            draw.count == 0,
+        "unsupported move fails before numerical evaluation and RNG draw");
+
+  slater[6] = NAN;
+  slater[9] = NAN;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights, 0.0, 0.0,
+            0.0, 0.0, draw_once, &draw, legacy, (size_t)qp_total * 5,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            draw.count == 0,
+        "invalid candidate fails collectively before RNG draw");
+
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void run_complex_rbm_sequence(int qp_total) {
+  const int initial_idx[2] = {0, 0};
+  const int hopping_idx[2] = {1, 0};
+  const int pair_idx[2] = {1, 1};
+  const int exchange_idx[2] = {0, 1};
+  const double complex weights[4] = {
+      1.0, 0.5 + 0.25 * I, -0.75 + 0.5 * I, 1.25 - 0.5 * I};
+  double complex slater[64];
+  double complex legacy[20];
+  MVMCClassicPfaffianComplexWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  DrawContext draw;
+  int qp_start, qp_end;
+
+  memset(legacy, 0, sizeof(legacy));
+  rank_partition(qp_total, &qp_start, &qp_end);
+  CHECK(mvmc_classic_pfaffian_complex_workspace_create(
+            2, 2, qp_total, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create complex sampler state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create complex sampler collective workspace");
+  fill_complex_slater(slater, qp_total);
+  CHECK(mvmc_classic_sampler_complex_initialize(
+            state_workspace, collective_workspace, slater, initial_idx, weights,
+            0.0, 0.0, legacy, (size_t)qp_total * 5, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize complex sampler");
+
+  draw.value = 0.75;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_complex_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_PAIR_HOPPING, slater, pair_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, legacy,
+            (size_t)qp_total * 5, &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED &&
+            result.proposal_total == 0.0 && draw.count == 1,
+        "complex pair hopping mutates both electron indices and rejects zero");
+
+  draw.value = 0.5;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_complex_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights, 0.0, 0.0,
+            0.0, 0.0, draw_once, &draw, legacy, (size_t)qp_total * 5,
+            &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED,
+        "complex proposal without RBM factor rejects");
+  CHECK(draw.count == 1, "complex rejection consumes one uniform");
+
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_complex_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights, 0.0, 0.0,
+            0.0, log(3.0), draw_once, &draw, legacy,
+            (size_t)qp_total * 5, &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_ACCEPTED,
+        "complex RBM log ratio participates in total-amplitude acceptance");
+  CHECK(draw.count == 1 && result.accepted_generation == 2,
+        "RBM smoke publishes the absolute candidate once");
+
+  draw.value = 0.0;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_complex_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_SPIN_HOPPING, slater, pair_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, legacy,
+            (size_t)qp_total * 5, &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED &&
+            draw.count == 1,
+        "complex spin hopping uses the same absolute transaction");
+
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_complex_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, exchange_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, legacy,
+            (size_t)qp_total * 5, &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            (qp_total == 1
+                 ? result.decision == MVMC_CLASSIC_PROPOSAL_REJECTED
+                 : result.decision == MVMC_CLASSIC_PROPOSAL_ACCEPTED) &&
+            draw.count == 1,
+        "complex exchange handles exact-zero and partial singularity");
+
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_complex_workspace_destroy(state_workspace);
+}
+
+static void run_p2d_real_trajectory(MVMCClassicPfaffianAuditMode mode,
+                                    P2DTrajectory *trajectory) {
+  const int initial_idx[2] = {0, 0};
+  const int singular_idx[2] = {0, 1};
+  const double complex weights[4] = {1.0, 0.75, -0.25, 0.5};
+  double slater[64];
+  double legacy[20] = {0};
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicPfaffianRealAuditWorkspace *audit_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  MVMCClassicProposalTrace trace;
+  MVMCClassicPfaffianAuditReport rebuild_report;
+  MVMCClassicProposalMetadata metadata;
+  MVMCClassicRealProposalAudit audit;
+  AuditObserverContext observer = {0, 0, -1, 0, 0};
+  DrawContext draw = {0.0, 0};
+  int qp_start, qp_end;
+
+  memset(trajectory, 0, sizeof(*trajectory));
+  rank_partition(4, &qp_start, &qp_end);
+  observer.qp_start = qp_start;
+  fill_real_slater(slater, 4);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 4, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create P2-D real trajectory state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create P2-D real trajectory collective workspace");
+  CHECK(mvmc_classic_pfaffian_real_audit_workspace_create(
+            state_workspace, mode, 1.0e-12, 1.0e-11,
+            &audit_workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create P2-D real trajectory audit workspace");
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 20, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize P2-D real trajectory");
+
+  memset(&metadata, 0, sizeof(metadata));
+  metadata.proposal_id = 100;
+  metadata.index_count = 2;
+  metadata.indices[0] = 0;
+  metadata.indices[1] = 1;
+  audit.metadata = &metadata;
+  audit.workspace = audit_workspace;
+  audit.observer = observe_real_candidate;
+  audit.observer_context = &observer;
+  audit.trace = &trace;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, singular_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_ACCEPTED && trace.valid &&
+            sampler_state.accepted_aggregate.singular_count == 1,
+        "deterministic R-to-S proposal is accepted and traced");
+  CHECK(trace.proposal_id == 100 && trace.index_count == 2 &&
+            trace.indices[0] == 0 && trace.indices[1] == 1,
+        "deterministic trace records proposal ID and indices");
+  save_p2d_trajectory(trajectory, 0, &trace, singular_idx);
+  CHECK(mvmc_classic_sampler_real_rebuild_audit(
+            state_workspace, collective_workspace, &sampler_state, slater,
+            singular_idx, weights, 0.0, 0.0, audit_workspace,
+            &rebuild_report) == MVMC_PFAFFIAN_STATUS_OK &&
+            rebuild_report.valid && rebuild_report.executed &&
+            !rebuild_report.mismatch,
+        "periodic rebuild matches accepted singular state without healing");
+
+  metadata.proposal_id = 101;
+  metadata.indices[0] = 1;
+  metadata.indices[1] = 0;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, initial_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_OK && result.valid &&
+            result.decision == MVMC_CLASSIC_PROPOSAL_ACCEPTED && trace.valid &&
+            sampler_state.accepted_aggregate.singular_count == 0,
+        "deterministic S-to-R proposal is accepted and traced");
+  save_p2d_trajectory(trajectory, 1, &trace, initial_idx);
+  CHECK(mvmc_classic_sampler_real_rebuild_audit(
+            state_workspace, collective_workspace, &sampler_state, slater,
+            initial_idx, weights, 0.0, 0.0, audit_workspace,
+            &rebuild_report) == MVMC_PFAFFIAN_STATUS_OK &&
+            rebuild_report.valid && !rebuild_report.mismatch,
+        "periodic rebuild matches recovered regular state");
+  CHECK(observer.call_count ==
+            (mode == MVMC_CLASSIC_AUDIT_OFF ? 0 : 2),
+        "audit off performs zero callbacks and always mode one per proposal");
+
+  mvmc_classic_pfaffian_real_audit_workspace_destroy(audit_workspace);
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_p2d_audit_trajectory_identity(void) {
+  P2DTrajectory audit_off;
+  P2DTrajectory audit_on;
+
+  run_p2d_real_trajectory(MVMC_CLASSIC_AUDIT_OFF, &audit_off);
+  run_p2d_real_trajectory(MVMC_CLASSIC_AUDIT_ALWAYS, &audit_on);
+  CHECK(memcmp(&audit_off, &audit_on, sizeof(audit_off)) == 0,
+        "audit off/on trajectory is byte-identical outside audit metadata");
+}
+
+static void test_p2d_guarded_fallback(void) {
+  const int initial_idx[2] = {0, 0};
+  const int singular_idx[2] = {0, 1};
+  const double complex weights[4] = {1.0, 0.75, -0.25, 0.5};
+  double slater[64];
+  double legacy[20] = {0};
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicPfaffianRealAuditWorkspace *audit_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  MVMCClassicProposalMetadata metadata = {200, 0, {0, 0, 0, 0}};
+  MVMCClassicRealProposalAudit audit;
+  AuditObserverContext observer = {0, 0, -1, 0, 0};
+  DrawContext draw = {0.0, 0};
+  int qp_start, qp_end;
+
+  rank_partition(4, &qp_start, &qp_end);
+  observer.qp_start = qp_start;
+  fill_real_slater(slater, 4);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 4, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create guarded audit state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create guarded audit collective workspace");
+  CHECK(mvmc_classic_pfaffian_real_audit_workspace_create(
+            state_workspace, MVMC_CLASSIC_AUDIT_GUARDED,
+            1.0e-12, 1.0e-11, &audit_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create guarded audit workspace");
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 20, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize guarded audit trajectory");
+  audit.metadata = &metadata;
+  audit.workspace = audit_workspace;
+  audit.observer = observe_real_candidate;
+  audit.observer_context = &observer;
+  audit.trace = NULL;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, singular_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.audit.executed && !result.audit.fallback &&
+            observer.call_count == 1,
+        "guarded audit executes from an all-regular accepted state");
+  metadata.proposal_id = 201;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, initial_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_OK &&
+            result.audit.fallback && !result.audit.executed &&
+            observer.call_count == 1 && draw.count == 1,
+        "one singular accepted component selects all-rank absolute fallback");
+
+  mvmc_classic_pfaffian_real_audit_workspace_destroy(audit_workspace);
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_p2d_audit_mismatch_and_rebuild_no_heal(void) {
+  const int initial_idx[2] = {0, 0};
+  const int singular_idx[2] = {0, 1};
+  const int wrong_rebuild_idx[2] = {1, 0};
+  const double complex weights[4] = {1.0, 0.75, -0.25, 0.5};
+  double slater[64];
+  double legacy[20] = {0};
+  double legacy_before[20];
+  double inverse_before[16];
+  MVMCAbsolutePfaffianResult components_before[4];
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicPfaffianRealAuditWorkspace *audit_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  MVMCClassicPfaffianAuditReport rebuild_report;
+  MVMCClassicPfaffianAuditReport aggregate_report;
+  MVMCProjectedAmplitudeResult wrong_aggregate;
+  MVMCClassicProposalMetadata metadata = {300, 2, {0, 1, 0, 0}};
+  MVMCClassicRealProposalAudit audit;
+  AuditObserverContext observer = {0, 0, 0, 0, 0};
+  DrawContext draw = {0.0, 0};
+  const MVMCClassicPfaffianState *accepted;
+  const double *accepted_inverse;
+  size_t local_count;
+  int qp_start, qp_end;
+
+  rank_partition(4, &qp_start, &qp_end);
+  local_count = (size_t)(qp_end - qp_start);
+  observer.qp_start = qp_start;
+  fill_real_slater(slater, 4);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 4, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create mismatch audit state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create mismatch audit collective workspace");
+  CHECK(mvmc_classic_pfaffian_real_audit_workspace_create(
+            state_workspace, MVMC_CLASSIC_AUDIT_ALWAYS,
+            1.0e-12, 1.0e-11, &audit_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create mismatch audit workspace");
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 20, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize mismatch audit state");
+  audit.metadata = &metadata;
+  audit.workspace = audit_workspace;
+  audit.observer = observe_real_candidate;
+  audit.observer_context = &observer;
+  audit.trace = NULL;
+  observer.inject_global_qp = 1;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, singular_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.audit.mismatch && result.audit.failure_global_qp == 1 &&
+            draw.count == 0,
+        "one-rank regular Pfaffian mismatch is collective before RNG");
+  observer.inject_global_qp = 0;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, singular_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.audit.mismatch && result.audit.failure_global_qp == 0 &&
+            draw.count == 0 &&
+            mvmc_classic_pfaffian_real_accepted(state_workspace)->generation ==
+                1,
+        "one-rank singular Pfaffian mismatch is collective before RNG");
+  observer.inject_inverse = 1;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, singular_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.audit.mismatch && result.audit.failure_global_qp == 0 &&
+            draw.count == 0,
+        "nonregular nonzero inverse observation is never skipped");
+
+  observer.inject_global_qp = -1;
+  observer.inject_inverse = 0;
+  observer.fail_observer = world_rank == world_size - 1;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, singular_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            result.audit.mismatch &&
+            result.audit.failure_rank == world_size - 1 && draw.count == 0,
+        "one-rank observer failure is collective before RNG");
+  observer.fail_observer = 0;
+
+  accepted = mvmc_classic_pfaffian_real_accepted(state_workspace);
+  accepted_inverse = mvmc_classic_pfaffian_real_accepted_inverse(
+      state_workspace);
+  wrong_aggregate = sampler_state.accepted_aggregate;
+  wrong_aggregate.total += 1.0;
+  CHECK(mvmc_classic_pfaffian_real_audit_compare(
+            audit_workspace, collective_workspace, accepted,
+            accepted_inverse, &wrong_aggregate, accepted,
+            accepted_inverse, &aggregate_report) ==
+                MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            aggregate_report.mismatch &&
+            aggregate_report.failure_global_qp == -1,
+        "global aggregate mismatch is detected independently of components");
+  memcpy(legacy_before, legacy, sizeof(legacy));
+  if (local_count != 0) {
+    memcpy(components_before, accepted->components,
+           local_count * sizeof(*components_before));
+    memcpy(inverse_before, accepted_inverse,
+           local_count * 4 * sizeof(*inverse_before));
+  }
+  CHECK(mvmc_classic_sampler_real_rebuild_audit(
+            state_workspace, collective_workspace, &sampler_state, slater,
+            wrong_rebuild_idx, weights, 0.0, 0.0, audit_workspace,
+            &rebuild_report) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            rebuild_report.mismatch,
+        "periodic rebuild mismatch is an error instead of silent heal");
+  accepted = mvmc_classic_pfaffian_real_accepted(state_workspace);
+  accepted_inverse = mvmc_classic_pfaffian_real_accepted_inverse(
+      state_workspace);
+  CHECK(accepted->generation == 1 &&
+            memcmp(legacy_before, legacy, sizeof(legacy)) == 0 &&
+            (local_count == 0 ||
+             (memcmp(components_before, accepted->components,
+                     local_count * sizeof(*components_before)) == 0 &&
+              memcmp(inverse_before, accepted_inverse,
+                     local_count * 4 * sizeof(*inverse_before)) == 0)),
+        "rebuild mismatch preserves accepted bytes, mirror, and generation");
+
+  metadata.index_count = MVMC_CLASSIC_TRACE_INDEX_CAPACITY + 1;
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, wrong_rebuild_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            draw.count == 0 && accepted->generation == 1,
+        "invalid trace metadata fails collectively before prepare or RNG");
+
+  mvmc_classic_pfaffian_real_audit_workspace_destroy(audit_workspace);
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_p2d_complex_audit_smoke(void) {
+  const int initial_idx[2] = {0, 0};
+  const int exchange_idx[2] = {0, 1};
+  const double complex weights[4] = {
+      1.0, 0.5 + 0.25 * I, -0.75 + 0.5 * I, 1.25 - 0.5 * I};
+  double complex slater[64];
+  double complex legacy[20] = {0};
+  MVMCClassicPfaffianComplexWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicPfaffianComplexAuditWorkspace *audit_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  MVMCClassicPfaffianAuditReport rebuild_report;
+  MVMCClassicProposalMetadata metadata = {400, 2, {0, 1, 0, 0}};
+  MVMCClassicComplexProposalAudit audit;
+  AuditObserverContext observer = {0, 0, -1, 0, 0};
+  DrawContext draw = {0.0, 0};
+  int qp_start, qp_end;
+
+  rank_partition(1, &qp_start, &qp_end);
+  observer.qp_start = qp_start;
+  fill_complex_slater(slater, 1);
+  CHECK(mvmc_classic_pfaffian_complex_workspace_create(
+            2, 2, 1, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create complex P2-D state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create complex P2-D collective workspace");
+  CHECK(mvmc_classic_pfaffian_complex_audit_workspace_create(
+            state_workspace, MVMC_CLASSIC_AUDIT_ALWAYS,
+            1.0e-12, 1.0e-11, &audit_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create complex P2-D audit workspace");
+  CHECK(mvmc_classic_sampler_complex_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 20, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize complex P2-D audit state");
+  audit.metadata = &metadata;
+  audit.workspace = audit_workspace;
+  audit.observer = observe_complex_candidate;
+  audit.observer_context = &observer;
+  audit.trace = NULL;
+  CHECK(mvmc_classic_sampler_complex_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_EXCHANGE, slater, exchange_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_OK && result.audit.executed &&
+            !result.audit.mismatch && observer.call_count == 1,
+        "complex always-audit compares every component before acceptance");
+  CHECK(mvmc_classic_sampler_complex_rebuild_audit(
+            state_workspace, collective_workspace, &sampler_state, slater,
+            initial_idx, weights, 0.0, 0.0, audit_workspace,
+            &rebuild_report) == MVMC_PFAFFIAN_STATUS_OK &&
+            !rebuild_report.mismatch,
+        "complex periodic rebuild matches accepted state with empty slices");
+
+  mvmc_classic_pfaffian_complex_audit_workspace_destroy(audit_workspace);
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_complex_workspace_destroy(state_workspace);
+}
+
+static void test_p2d_rank_divergent_audit_mode(void) {
+  const int initial_idx[2] = {0, 0};
+  const int hopping_idx[2] = {1, 0};
+  const double complex weights[4] = {1.0, 0.75, -0.25, 0.5};
+  double slater[64];
+  double legacy[20] = {0};
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicPfaffianRealAuditWorkspace *audit_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  MVMCClassicProposalMetadata metadata = {500, 0, {0, 0, 0, 0}};
+  MVMCClassicRealProposalAudit audit;
+  AuditObserverContext observer = {0, 0, -1, 0, 0};
+  DrawContext draw = {0.0, 0};
+  MVMCClassicPfaffianAuditMode local_mode;
+  int qp_start, qp_end;
+
+  if (world_size == 1) return;
+  rank_partition(4, &qp_start, &qp_end);
+  observer.qp_start = qp_start;
+  local_mode = world_rank == world_size - 1
+                   ? MVMC_CLASSIC_AUDIT_ALWAYS
+                   : MVMC_CLASSIC_AUDIT_OFF;
+  fill_real_slater(slater, 4);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 4, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create rank-divergent audit state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create rank-divergent audit collective workspace");
+  CHECK(mvmc_classic_pfaffian_real_audit_workspace_create(
+            state_workspace, local_mode, 1.0e-12, 1.0e-11,
+            &audit_workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create rank-local audit mode workspace");
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 20, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize rank-divergent audit mode fixture");
+  audit.metadata = &metadata;
+  audit.workspace = audit_workspace;
+  audit.observer = observe_real_candidate;
+  audit.observer_context = &observer;
+  audit.trace = NULL;
+  CHECK(mvmc_classic_sampler_real_propose_with_audit(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, &audit, legacy, 20,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            draw.count == 0 && observer.call_count == 0 &&
+            mvmc_classic_pfaffian_real_accepted(state_workspace)->generation ==
+                1,
+        "rank-divergent audit mode fails before prepare, callback, or RNG");
+
+  mvmc_classic_pfaffian_real_audit_workspace_destroy(audit_workspace);
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_collective_preflight_mismatch(void) {
+  MVMCClassicPfaffianCollectiveWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
+  int all_true = -1;
+
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create preflight mismatch workspace");
+  status = mvmc_classic_pfaffian_collective_preflight(
+      workspace, 1,
+      world_size > 1 && world_rank == world_size - 1
+          ? MVMC_CLASSIC_MOVE_EXCHANGE
+          : MVMC_CLASSIC_MOVE_HOPPING);
+  CHECK(status == (world_size > 1 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                                  : MVMC_PFAFFIAN_STATUS_OK),
+        "rank-divergent move kind is rejected before proposal collectives");
+  status = mvmc_classic_pfaffian_collective_preflight(
+      workspace, world_size == 1 || world_rank != world_size - 1,
+      MVMC_CLASSIC_MOVE_HOPPING);
+  CHECK(status == (world_size > 1 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                                  : MVMC_PFAFFIAN_STATUS_OK),
+        "one-rank invalid precondition is propagated before proposal");
+  status = mvmc_classic_pfaffian_collective_all_true(
+      workspace, world_size == 1 || world_rank != world_size - 1, &all_true);
+  CHECK(status == MVMC_PFAFFIAN_STATUS_OK &&
+            all_true == (world_size == 1 ? 1 : 0),
+        "optional guarded branch uses communicator-wide logical AND");
+  status = mvmc_classic_pfaffian_collective_all_true(
+      workspace, world_size > 1 && world_rank == world_size - 1 ? 2 : 1,
+      &all_true);
+  CHECK(status == (world_size > 1 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                                  : MVMC_PFAFFIAN_STATUS_OK),
+        "malformed all-true input is rejected after collective participation");
+  mvmc_classic_pfaffian_collective_workspace_destroy(workspace);
+}
+
+static void test_log_domain_metropolis_edges(void) {
+  MVMCClassicPfaffianCollectiveWorkspace *workspace = NULL;
+  MVMCClassicPfaffianMetropolisResult result;
+
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create log-domain Metropolis workspace");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 1.0, 1.0, INFINITY, 0.999, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK && result.valid && result.accepted &&
+            isinf(result.log_acceptance_ratio) &&
+            result.log_acceptance_ratio > 0.0,
+        "positive log-ratio overflow accepts without exp");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 1.0, 1.0, -INFINITY, 0.5, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK && !result.accepted,
+        "negative log-ratio overflow rejects without exp");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 1.0, 1.0, -INFINITY, 0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK && !result.accepted,
+        "u equals zero cannot accept a zero-probability log ratio");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 1.0, 1.0, 0.0, 0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK && result.accepted,
+        "u equals zero accepts a positive-probability nonzero proposal");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 1.0, 0.0, INFINITY, 0.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_OK && result.valid && !result.accepted,
+        "exact-zero proposal rejects independently of draw and log factor");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 0.0, 1.0, 0.0, 0.5, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "exact-zero current total is invalid");
+  CHECK(mvmc_classic_pfaffian_collective_metropolis(
+            workspace, 1.0, 1.0, 0.0, 1.0, &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "uniform outside [0,1) is invalid");
+  mvmc_classic_pfaffian_collective_workspace_destroy(workspace);
+}
+
+static void test_initialize_propose_preflight_mismatch(void) {
+  const int initial_idx[2] = {0, 0};
+  const int hopping_idx[2] = {1, 0};
+  const double complex weights[2] = {1.0, 1.0};
+  double slater[32];
+  double legacy[10] = {0};
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  DrawContext draw = {0.25, 0};
+  MVMCPfaffianStatus status;
+  int qp_start, qp_end;
+
+  if (world_size == 1) return;
+  rank_partition(2, &qp_start, &qp_end);
+  fill_real_slater(slater, 2);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 2, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create initialize/propose mismatch state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create initialize/propose mismatch collective workspace");
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 10, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "initialize state before branch namespace mismatch");
+
+  if (world_rank == world_size - 1) {
+    status = mvmc_classic_sampler_real_initialize(
+        state_workspace, collective_workspace, slater, initial_idx, weights,
+        0.0, 0.0, legacy, 10, &sampler_state);
+  } else {
+    status = mvmc_classic_sampler_real_propose(
+        state_workspace, collective_workspace, &sampler_state,
+        MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights,
+        0.0, 0.0, 0.0, 0.0, draw_once, &draw, legacy, 10, &result);
+  }
+  CHECK(status == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT && draw.count == 0 &&
+            mvmc_classic_pfaffian_real_accepted(state_workspace)->generation ==
+                1,
+        "initialize/propose HOPPING divergence fails before prepare or draw");
+
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_collective_mirror_preflight(void) {
+  const int initial_idx[2] = {0, 0};
+  const int hopping_idx[2] = {1, 0};
+  const double complex weights[2] = {1.0, 1.0};
+  double slater[32];
+  double legacy[10];
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  MVMCClassicProposalResult result;
+  DrawContext draw = {0.0, 0};
+  size_t local_count = 10;
+  int qp_start, qp_end;
+
+  rank_partition(2, &qp_start, &qp_end);
+  fill_real_slater(slater, 2);
+  memset(legacy, 0, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 2, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create mirror preflight state workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create mirror preflight collective workspace");
+  if (world_size == 1 || world_rank == world_size - 1) local_count = 9;
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, local_count, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT && !sampler_state.valid &&
+            !mvmc_classic_pfaffian_real_accepted(state_workspace)->valid,
+        "one-rank short initialization mirror fails before any publish");
+
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, initial_idx,
+            weights, 0.0, 0.0, legacy, 10, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "valid mirror initializes after collective preflight failure");
+  draw.count = 0;
+  CHECK(mvmc_classic_sampler_real_propose(
+            state_workspace, collective_workspace, &sampler_state,
+            MVMC_CLASSIC_MOVE_HOPPING, slater, hopping_idx, weights,
+            0.0, 0.0, 0.0, 0.0, draw_once, &draw, legacy, local_count,
+            &result) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            draw.count == 0 &&
+            mvmc_classic_pfaffian_real_accepted(state_workspace)->generation ==
+                1,
+        "one-rank short proposal mirror fails before evaluation or draw");
+
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+static void test_zero_current_initialization(void) {
+  const int ele_idx[2] = {0, 0};
+  const double complex weights[1] = {1.0};
+  double slater[16] = {0};
+  double legacy[5] = {0};
+  MVMCClassicPfaffianRealWorkspace *state_workspace = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCClassicSamplerState sampler_state;
+  int qp_start, qp_end;
+
+  rank_partition(1, &qp_start, &qp_end);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 2, 1, qp_start, qp_end, &state_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create zero-current workspace");
+  CHECK(mvmc_classic_pfaffian_collective_workspace_create(
+            TEST_COMMUNICATOR, &collective_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "create zero-current collective workspace");
+  CHECK(mvmc_classic_sampler_real_initialize(
+            state_workspace, collective_workspace, slater, ele_idx, weights,
+            0.0, 0.0, legacy, 5, &sampler_state) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT && !sampler_state.valid &&
+            !mvmc_classic_pfaffian_real_accepted(state_workspace)->valid,
+        "exact-zero current total is rejected before sampler start");
+  mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+  mvmc_classic_pfaffian_real_workspace_destroy(state_workspace);
+}
+
+int main(int argc, char **argv) {
+  ProposalTrace trace_a;
+  ProposalTrace trace_b;
+#ifdef _mpi_use
+  int global_failures = 0;
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+
+  run_real_sequence(1, &trace_a);
+  run_real_sequence(4, &trace_a);
+  run_real_sequence(4, &trace_b);
+  CHECK(memcmp(&trace_a, &trace_b, sizeof(trace_a)) == 0,
+        "fixed-input RNG A/B replay is byte-identical");
+  run_complex_rbm_sequence(1);
+  run_complex_rbm_sequence(4);
+  test_p2d_audit_trajectory_identity();
+  test_p2d_guarded_fallback();
+  test_p2d_audit_mismatch_and_rebuild_no_heal();
+  test_p2d_complex_audit_smoke();
+  test_p2d_rank_divergent_audit_mode();
+  test_zero_current_initialization();
+  test_collective_preflight_mismatch();
+  test_log_domain_metropolis_edges();
+  test_initialize_propose_preflight_mismatch();
+  test_collective_mirror_preflight();
+
+#ifdef _mpi_use
+  MPI_Allreduce(&failure_count, &global_failures, 1, MPI_INT, MPI_SUM,
+                MPI_COMM_WORLD);
+  if (world_rank == 0 && global_failures == 0) {
+    printf("classic Pfaffian sampler unit: PASS (%d ranks)\n", world_size);
+  }
+  MPI_Finalize();
+  return global_failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+#else
+  if (failure_count == 0) printf("classic Pfaffian sampler unit: PASS\n");
+  return failure_count == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+#endif
+}

--- a/test/classic_pfaffian_state_unit.c
+++ b/test/classic_pfaffian_state_unit.c
@@ -1,0 +1,653 @@
+#include "classic_pfaffian_state.h"
+
+#include <complex.h>
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failure_count = 0;
+
+#define CHECK(condition, message)                                      \
+  do {                                                                 \
+    if (!(condition)) {                                                \
+      fprintf(stderr, "FAIL: %s (line %d)\n", (message), __LINE__);   \
+      ++failure_count;                                                 \
+    }                                                                  \
+  } while (0)
+
+static int close_complex(double complex actual, double complex expected,
+                         double tolerance) {
+  return cabs(actual - expected) <= tolerance * fmax(1.0, cabs(expected));
+}
+
+static void set_real_pair(double *matrix, int n, int row, int column,
+                          double value) {
+  matrix[(size_t)row * (size_t)n + (size_t)column] = value;
+  matrix[(size_t)column * (size_t)n + (size_t)row] = -value;
+}
+
+static void set_complex_pair(double complex *matrix, int n, int row,
+                             int column, double complex value) {
+  matrix[(size_t)row * (size_t)n + (size_t)column] = value;
+  matrix[(size_t)column * (size_t)n + (size_t)row] = -value;
+}
+
+static void fill_real_slater(double *matrix, double scale) {
+  memset(matrix, 0, 16 * sizeof(*matrix));
+  set_real_pair(matrix, 4, 0, 1, 2.0 * scale);
+  set_real_pair(matrix, 4, 0, 2, -1.0 * scale);
+  set_real_pair(matrix, 4, 0, 3, 0.5 * scale);
+  set_real_pair(matrix, 4, 1, 2, 3.0 * scale);
+  set_real_pair(matrix, 4, 1, 3, 4.0 * scale);
+  set_real_pair(matrix, 4, 2, 3, -2.0 * scale);
+}
+
+static void fill_complex_slater(double complex *matrix,
+                                double complex scale) {
+  memset(matrix, 0, 16 * sizeof(*matrix));
+  set_complex_pair(matrix, 4, 0, 1, (1.0 + 0.5 * I) * scale);
+  set_complex_pair(matrix, 4, 0, 2, (-0.25 + 0.75 * I) * scale);
+  set_complex_pair(matrix, 4, 0, 3, (2.0 - 0.5 * I) * scale);
+  set_complex_pair(matrix, 4, 1, 2, (0.5 + 1.25 * I) * scale);
+  set_complex_pair(matrix, 4, 1, 3, (-1.0 + 0.25 * I) * scale);
+  set_complex_pair(matrix, 4, 2, 3, (1.5 - 0.75 * I) * scale);
+}
+
+static void selected_real_matrix(const double *slater, const int *ele_idx,
+                                 double *matrix) {
+  int row, column;
+  for (row = 0; row < 4; ++row) {
+    const int slater_row = ele_idx[row] + (row / 2) * 2;
+    for (column = 0; column < 4; ++column) {
+      const int slater_column = ele_idx[column] + (column / 2) * 2;
+      matrix[row * 4 + column] = slater[slater_row * 4 + slater_column];
+    }
+  }
+}
+
+static void selected_complex_matrix(const double complex *slater,
+                                    const int *ele_idx,
+                                    double complex *matrix) {
+  int row, column;
+  for (row = 0; row < 4; ++row) {
+    const int slater_row = ele_idx[row] + (row / 2) * 2;
+    for (column = 0; column < 4; ++column) {
+      const int slater_column = ele_idx[column] + (column / 2) * 2;
+      matrix[row * 4 + column] = slater[slater_row * 4 + slater_column];
+    }
+  }
+}
+
+static double complex pfaffian4(const double complex *matrix) {
+  return matrix[1] * matrix[11] - matrix[2] * matrix[7] +
+         matrix[3] * matrix[6];
+}
+
+static double real_pfaffian4(const double *matrix) {
+  return matrix[1] * matrix[11] - matrix[2] * matrix[7] +
+         matrix[3] * matrix[6];
+}
+
+static void check_real_inverse(const double *matrix,
+                               const double *legacy_inverse,
+                               const char *message) {
+  int row, column, inner;
+  for (row = 0; row < 4; ++row) {
+    for (column = 0; column < 4; ++column) {
+      double product = 0.0;
+      for (inner = 0; inner < 4; ++inner) {
+        product += matrix[row * 4 + inner] *
+                   legacy_inverse[inner * 4 + column];
+      }
+      if (fabs(product - (row == column ? 1.0 : 0.0)) > 2.0e-12) {
+        CHECK(0, message);
+        return;
+      }
+    }
+  }
+}
+
+static void check_complex_inverse(const double complex *matrix,
+                                  const double complex *legacy_inverse,
+                                  const char *message) {
+  int row, column, inner;
+  for (row = 0; row < 4; ++row) {
+    for (column = 0; column < 4; ++column) {
+      double complex product = 0.0;
+      for (inner = 0; inner < 4; ++inner) {
+        product += matrix[row * 4 + inner] *
+                   legacy_inverse[inner * 4 + column];
+      }
+      if (cabs(product - (row == column ? 1.0 : 0.0)) > 3.0e-12) {
+        CHECK(0, message);
+        return;
+      }
+    }
+  }
+}
+
+static void test_real_transaction_and_transitions(void) {
+  const int ele_idx[4] = {1, 0, 0, 1};
+  const double complex weights[1] = {1.0};
+  double slater[16];
+  double regular_slater[16];
+  double selected[16];
+  double legacy[17];
+  double legacy_snapshot[17];
+  MVMCClassicPfaffianRealWorkspace *workspace = NULL;
+  const MVMCClassicPfaffianState *state;
+  const double *raw_inverse;
+  size_t index;
+
+  fill_real_slater(slater, 1.0);
+  memcpy(regular_slater, slater, sizeof(slater));
+  selected_real_matrix(slater, ele_idx, selected);
+  for (index = 0; index < 17; ++index) legacy[index] = 321.0;
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 4, 1, 0, 1, &workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create real workspace");
+  CHECK(mvmc_classic_pfaffian_real_legacy_element_count(workspace) == 17,
+        "real legacy element count includes PfM tail");
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "real publish before prepare is rejected");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0 &&
+            !mvmc_classic_pfaffian_real_accepted(workspace)->valid,
+        "real publish before prepare preserves mirror and accepted state");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare initial real candidate");
+  state = mvmc_classic_pfaffian_real_candidate(workspace);
+  CHECK(state != NULL && state->valid && state->generation == 1,
+        "candidate generation one before publish");
+  CHECK(!mvmc_classic_pfaffian_real_accepted(workspace)->valid,
+        "prepare leaves accepted state invalid");
+  CHECK(close_complex(state->components[0].pfaffian,
+                      real_pfaffian4(selected), 2.0e-13),
+        "real adapter matrix Pfaffian matches independent selection");
+  CHECK(legacy[0] == 321.0 && legacy[16] == 321.0,
+        "prepare does not touch legacy mirror");
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 16) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "short real legacy allocation rejected");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0,
+        "short publish leaves legacy bytes unchanged");
+  CHECK(!mvmc_classic_pfaffian_real_accepted(workspace)->valid,
+        "short publish leaves accepted state unchanged");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish initial real candidate");
+  state = mvmc_classic_pfaffian_real_accepted(workspace);
+  raw_inverse = mvmc_classic_pfaffian_real_accepted_inverse(workspace);
+  CHECK(state->valid && state->generation == 1,
+        "real accepted generation one");
+  CHECK(close_complex(legacy[16], state->components[0].pfaffian, 1.0e-14),
+        "real PfM tail mirrors accepted Pfaffian");
+  for (index = 0; index < 16; ++index) {
+    CHECK(fabs(legacy[index] + raw_inverse[index]) < 2.0e-13,
+          "real legacy flat inverse is negative raw LAPACK inverse");
+  }
+  check_real_inverse(selected, legacy,
+                     "real row-major legacy mirror is matrix inverse");
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "real duplicate publish is rejected");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0 &&
+            mvmc_classic_pfaffian_real_accepted(workspace)->generation == 1,
+        "real duplicate publish preserves mirror and accepted generation");
+
+  fill_real_slater(slater, 0.75);
+  selected_real_matrix(slater, ele_idx, selected);
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare regular to regular transition");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish regular to regular transition");
+  CHECK(mvmc_classic_pfaffian_real_accepted(workspace)->generation == 2 &&
+            mvmc_classic_pfaffian_real_accepted(workspace)
+                    ->components[0]
+                    .state == MVMC_PFAFFIAN_REGULAR,
+        "real regular to regular publish increments generation");
+  check_real_inverse(selected, legacy,
+                     "real regular to regular mirror is usable");
+
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  slater[1] = NAN;
+  slater[4] = NAN;
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "nonfinite real candidate rejected");
+  CHECK(mvmc_classic_pfaffian_real_failure_local_qp(workspace) == 0 &&
+            mvmc_classic_pfaffian_real_failure_global_qp(workspace) == 0,
+        "real candidate failure reports local and global QP");
+  CHECK(mvmc_classic_pfaffian_real_candidate(workspace) == NULL,
+        "failed real candidate is not publishable");
+  CHECK(mvmc_classic_pfaffian_real_accepted(workspace)->generation == 2,
+        "failed real candidate preserves generation");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0,
+        "failed real candidate preserves legacy mirror");
+
+  memset(slater, 0, sizeof(slater));
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare regular to singular transition");
+  CHECK(mvmc_classic_pfaffian_real_candidate(workspace)
+                ->components[0]
+                .state == MVMC_PFAFFIAN_SINGULAR,
+        "real singular component classified");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish real singular state");
+  CHECK(mvmc_classic_pfaffian_real_accepted(workspace)->generation == 3,
+        "real singular publish increments generation");
+  CHECK(legacy[16] == 0.0, "real singular PfM mirror is exact zero");
+  for (index = 0; index < 16; ++index) {
+    CHECK(legacy[index] == 0.0, "real singular inverse mirror is zero");
+  }
+
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare singular to singular transition");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish singular to singular transition");
+  CHECK(mvmc_classic_pfaffian_real_accepted(workspace)->generation == 4 &&
+            mvmc_classic_pfaffian_real_accepted(workspace)
+                    ->components[0]
+                    .state == MVMC_PFAFFIAN_SINGULAR,
+        "real singular to singular publish remains inverse-free");
+
+  memcpy(slater, regular_slater, sizeof(slater));
+  selected_real_matrix(slater, ele_idx, selected);
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare singular to regular transition");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish singular to regular transition");
+  CHECK(mvmc_classic_pfaffian_real_accepted(workspace)->generation == 5 &&
+            mvmc_classic_pfaffian_real_accepted(workspace)
+                    ->components[0]
+                    .state == MVMC_PFAFFIAN_REGULAR,
+        "real singular to regular rebuild restores inverse state");
+  check_real_inverse(selected, legacy,
+                     "real singular to regular mirror is usable");
+
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 2.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare forced near-singular state");
+  CHECK(mvmc_classic_pfaffian_real_candidate(workspace)
+                ->components[0]
+                .state == MVMC_PFAFFIAN_NEAR_SINGULAR,
+        "large pivot tolerance produces near-singular state");
+  mvmc_classic_pfaffian_real_discard_candidate(workspace);
+  CHECK(mvmc_classic_pfaffian_real_candidate(workspace) == NULL &&
+            mvmc_classic_pfaffian_real_accepted(workspace)->generation == 5,
+        "discard preserves accepted real state and generation");
+
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 2.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare near-singular candidate for publish");
+  state = mvmc_classic_pfaffian_real_candidate(workspace);
+  CHECK(state != NULL &&
+            state->components[0].state == MVMC_PFAFFIAN_NEAR_SINGULAR &&
+            isfinite(creal(state->components[0].pfaffian)) &&
+            state->components[0].pfaffian != 0.0,
+        "near-singular publish candidate has finite nonzero Pfaffian");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish regular to near-singular transition");
+  state = mvmc_classic_pfaffian_real_accepted(workspace);
+  CHECK(state->generation == 6 &&
+            state->components[0].state == MVMC_PFAFFIAN_NEAR_SINGULAR &&
+            close_complex(legacy[16], state->components[0].pfaffian,
+                          2.0e-13),
+        "near-singular publish preserves finite Pfaffian and generation");
+  for (index = 0; index < 16; ++index) {
+    CHECK(legacy[index] == 0.0,
+          "near-singular publish zeroes legacy inverse mirror");
+  }
+
+  mvmc_classic_pfaffian_real_workspace_destroy(workspace);
+}
+
+static void test_real_multiqup_and_alias_boundary(void) {
+  const int ele_idx[4] = {1, 0, 0, 1};
+  const double complex weights[4] = {1.0, 2.0, 3.0, 4.0};
+  double slater[64];
+  double selected[16];
+  double legacy[68];
+  double complex expected_total = 0.0;
+  MVMCClassicPfaffianRealWorkspace *workspace = NULL;
+  const MVMCClassicPfaffianState *candidate;
+  int qp;
+  size_t index;
+
+  for (qp = 0; qp < 4; ++qp) {
+    if (qp == 2) {
+      memset(slater + qp * 16, 0, 16 * sizeof(*slater));
+    } else {
+      fill_real_slater(slater + qp * 16, (double)(qp + 1));
+    }
+  }
+  for (index = 0; index < 68; ++index) legacy[index] = 777.0;
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 4, 4, 1, 4, &workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create real NQP4 local slice");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare real NQP4 local slice");
+  candidate = mvmc_classic_pfaffian_real_candidate(workspace);
+  for (qp = 1; qp < 4; ++qp) {
+    expected_total += weights[qp] * candidate->components[qp - 1].pfaffian;
+  }
+  CHECK(close_complex(candidate->local_aggregate.total, expected_total,
+                      2.0e-13),
+        "real slice aggregate uses global QP weights");
+  CHECK(candidate->local_aggregate.singular_count == 1 &&
+            cabs(candidate->local_aggregate.total) > 0.0,
+        "one singular component preserves finite nonzero total");
+  CHECK(mvmc_classic_pfaffian_real_publish(workspace, legacy, 68) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish real NQP4 local slice");
+  for (index = 48; index < 64; ++index) {
+    CHECK(legacy[index] == 777.0,
+          "real publish leaves unused inverse capacity unchanged");
+  }
+  CHECK(legacy[67] == 777.0,
+        "real publish leaves unused PfM tail capacity unchanged");
+  for (qp = 0; qp < 3; ++qp) {
+    if (qp == 1) {
+      for (index = 0; index < 16; ++index) {
+        CHECK(legacy[qp * 16 + index] == 0.0,
+              "singular local QP inverse mirror is zero");
+      }
+    } else {
+      selected_real_matrix(slater + (qp + 1) * 16, ele_idx, selected);
+      check_real_inverse(selected, legacy + qp * 16,
+                         "real local QP mirror uses matching global Slater");
+    }
+    CHECK(close_complex(legacy[64 + qp],
+                        mvmc_classic_pfaffian_real_accepted(workspace)
+                            ->components[qp]
+                            .pfaffian,
+                        2.0e-13),
+          "real local PfM occupies local tail slot");
+  }
+  mvmc_classic_pfaffian_real_workspace_destroy(workspace);
+}
+
+static void test_complex_multiqup(void) {
+  const int ele_idx[4] = {1, 0, 0, 1};
+  const double complex weights[4] = {
+      1.0, 0.5 + 0.25 * I, -0.75 + 0.5 * I, 1.25 - 0.5 * I};
+  double complex slater[64];
+  double complex selected[16];
+  double complex legacy[68];
+  double complex legacy_snapshot[68];
+  double complex expected_total = 0.0;
+  MVMCClassicPfaffianComplexWorkspace *workspace = NULL;
+  const MVMCClassicPfaffianState *candidate;
+  const double complex *raw_inverse;
+  int qp;
+  size_t index;
+
+  for (qp = 0; qp < 4; ++qp) {
+    fill_complex_slater(slater + qp * 16,
+                        (double)(qp + 1) + 0.1 * (double)qp * I);
+  }
+  for (index = 0; index < 68; ++index) legacy[index] = 456.0 - 2.0 * I;
+  CHECK(mvmc_classic_pfaffian_complex_workspace_create(
+            2, 4, 4, 0, 4, &workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create complex NQP4 workspace");
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_complex_publish(workspace, legacy, 68) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "complex publish before prepare is rejected");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0 &&
+            !mvmc_classic_pfaffian_complex_accepted(workspace)->valid,
+        "complex publish before prepare preserves mirror and accepted state");
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare complex NQP4 candidate");
+  candidate = mvmc_classic_pfaffian_complex_candidate(workspace);
+  for (qp = 0; qp < 4; ++qp) {
+    selected_complex_matrix(slater + qp * 16, ele_idx, selected);
+    CHECK(close_complex(candidate->components[qp].pfaffian,
+                        pfaffian4(selected), 3.0e-12),
+          "complex adapter Pfaffian matches independent matrix selection");
+    expected_total += weights[qp] * candidate->components[qp].pfaffian;
+  }
+  CHECK(close_complex(candidate->local_aggregate.total, expected_total,
+                      3.0e-12),
+        "complex aggregate includes phase and global weights");
+  CHECK(mvmc_classic_pfaffian_complex_publish(workspace, legacy, 68) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish complex NQP4 candidate");
+  raw_inverse = mvmc_classic_pfaffian_complex_accepted_inverse(workspace);
+  for (qp = 0; qp < 4; ++qp) {
+    selected_complex_matrix(slater + qp * 16, ele_idx, selected);
+    check_complex_inverse(selected, legacy + qp * 16,
+                          "complex row-major legacy mirror is inverse");
+    for (index = 0; index < 16; ++index) {
+      CHECK(cabs(legacy[qp * 16 + index] + raw_inverse[qp * 16 + index]) <
+                3.0e-12,
+            "complex legacy flat inverse is negative raw LAPACK inverse");
+    }
+    CHECK(close_complex(legacy[64 + qp],
+                        mvmc_classic_pfaffian_complex_accepted(workspace)
+                            ->components[qp]
+                            .pfaffian,
+                        3.0e-12),
+          "complex PfM tail mirrors accepted phase");
+  }
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_complex_publish(workspace, legacy, 68) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "complex duplicate publish is rejected");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0 &&
+            mvmc_classic_pfaffian_complex_accepted(workspace)->generation == 1,
+        "complex duplicate publish preserves mirror and accepted generation");
+
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  slater[2 * 16 + 1] = NAN + I;
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "complex nonfinite candidate rejected");
+  CHECK(mvmc_classic_pfaffian_complex_failure_local_qp(workspace) == 2 &&
+            mvmc_classic_pfaffian_complex_failure_global_qp(workspace) == 2,
+        "complex failure reports local and global QP");
+  CHECK(mvmc_classic_pfaffian_complex_accepted(workspace)->generation == 1 &&
+            memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0,
+        "complex failure preserves accepted generation and mirror");
+
+  memset(slater, 0, sizeof(slater));
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare complex regular to singular transition");
+  CHECK(mvmc_classic_pfaffian_complex_candidate(workspace)
+                ->local_aggregate.singular_count == 4,
+        "all complex components become singular");
+  CHECK(mvmc_classic_pfaffian_complex_publish(workspace, legacy, 68) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish complex singular state");
+  CHECK(mvmc_classic_pfaffian_complex_accepted(workspace)->generation == 2,
+        "complex singular publish increments generation");
+  for (index = 0; index < 68; ++index) {
+    CHECK(legacy[index] == 0.0,
+          "complex singular state zeroes local mirrors and PfM tail");
+  }
+
+  for (qp = 0; qp < 4; ++qp) {
+    fill_complex_slater(slater + qp * 16,
+                        (double)(qp + 1) + 0.1 * (double)qp * I);
+  }
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "prepare complex singular to regular transition");
+  CHECK(mvmc_classic_pfaffian_complex_publish(workspace, legacy, 68) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "publish complex singular to regular transition");
+  CHECK(mvmc_classic_pfaffian_complex_accepted(workspace)->generation == 3 &&
+            mvmc_classic_pfaffian_complex_accepted(workspace)
+                    ->local_aggregate.regular_count == 4,
+        "complex singular to regular rebuild restores all components");
+  mvmc_classic_pfaffian_complex_workspace_destroy(workspace);
+}
+
+static void test_exact_total_cancellation(void) {
+  const int ele_idx[4] = {1, 0, 0, 1};
+  const double complex weights[2] = {1.0, -1.0};
+  double slater[32];
+  MVMCClassicPfaffianRealWorkspace *workspace = NULL;
+  const MVMCClassicPfaffianState *candidate;
+
+  fill_real_slater(slater, 1.0);
+  fill_real_slater(slater + 16, 1.0);
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 4, 2, 0, 2, &workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "create exact-cancellation workspace");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "exact-cancellation candidate remains numerically valid");
+  candidate = mvmc_classic_pfaffian_real_candidate(workspace);
+  CHECK(candidate != NULL && candidate->local_aggregate.valid &&
+            candidate->local_aggregate.total == 0.0 &&
+            candidate->local_aggregate.sum_abs > 0.0 &&
+            candidate->local_aggregate.regular_count == 2,
+        "regular components can produce exact-zero projected total");
+  mvmc_classic_pfaffian_real_discard_candidate(workspace);
+  CHECK(!mvmc_classic_pfaffian_real_accepted(workspace)->valid,
+        "discarded zero-total proposal is not published");
+  mvmc_classic_pfaffian_real_workspace_destroy(workspace);
+}
+
+static void test_empty_slice_and_invalid_inputs(void) {
+  const int ele_idx[4] = {0, 1, 0, 1};
+  const int negative_ele_idx[4] = {-1, 1, 0, 1};
+  const int high_ele_idx[4] = {2, 1, 0, 1};
+  double slater[16];
+  double complex complex_slater[16];
+  double complex weights[1] = {1.0};
+  double legacy[17];
+  double legacy_snapshot[17];
+  MVMCClassicPfaffianRealWorkspace *real_workspace = NULL;
+  MVMCClassicPfaffianComplexWorkspace *complex_workspace = NULL;
+  size_t index;
+
+  fill_real_slater(slater, 1.0);
+  fill_complex_slater(complex_slater, 1.0);
+  for (index = 0; index < 17; ++index) legacy[index] = 99.0;
+  memcpy(legacy_snapshot, legacy, sizeof(legacy));
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 4, 1, 1, 1, &real_workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "empty local slice workspace is valid");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "empty local slice prepare succeeds");
+  CHECK(mvmc_classic_pfaffian_real_candidate(real_workspace)
+                ->local_aggregate.valid &&
+            mvmc_classic_pfaffian_real_candidate(real_workspace)
+                    ->local_aggregate.total == 0.0,
+        "empty slice contributes a valid neutral aggregate");
+  CHECK(mvmc_classic_pfaffian_real_publish(real_workspace, legacy, 17) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "empty local slice publish succeeds");
+  CHECK(memcmp(legacy, legacy_snapshot, sizeof(legacy)) == 0,
+        "empty slice publish does not touch legacy allocation");
+  CHECK(mvmc_classic_pfaffian_real_accepted(real_workspace)->generation == 1,
+        "empty rank follows global generation");
+  mvmc_classic_pfaffian_real_workspace_destroy(real_workspace);
+
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 3, 1, 0, 1, &real_workspace) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "odd nsize rejected");
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 4, 1, 1, 0, &real_workspace) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "reversed QP range rejected");
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            INT_MAX / 2 + 1, 4, 1, 0, 1, &real_workspace) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "nsite doubling overflow rejected");
+  CHECK(mvmc_classic_pfaffian_real_workspace_create(
+            2, 4, 1, 0, 1, &real_workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "real invalid-weight workspace create");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, slater, negative_ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "negative electron index rejected before Slater access");
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, slater, high_ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "electron index at nsite rejected before Slater access");
+  CHECK(!mvmc_classic_pfaffian_real_accepted(real_workspace)->valid &&
+            mvmc_classic_pfaffian_real_candidate(real_workspace) == NULL,
+        "invalid electron indices leave real state unpublished");
+  weights[0] = 1.0 + 1.0e-30 * I;
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "real path rejects imaginary QP weight");
+  weights[0] = DBL_MAX;
+  CHECK(mvmc_classic_pfaffian_real_prepare(
+            real_workspace, slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "real path rejects a nonfinite weighted component");
+  CHECK(mvmc_classic_pfaffian_real_failure_local_qp(real_workspace) == 0 &&
+            mvmc_classic_pfaffian_real_failure_global_qp(real_workspace) == 0,
+        "weighted-component overflow reports local and global QP");
+  mvmc_classic_pfaffian_real_workspace_destroy(real_workspace);
+
+  weights[0] = NAN + I;
+  CHECK(mvmc_classic_pfaffian_complex_workspace_create(
+            2, 4, 1, 0, 1, &complex_workspace) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "complex invalid-weight workspace create");
+  CHECK(mvmc_classic_pfaffian_complex_prepare(
+            complex_workspace, complex_slater, ele_idx, weights, 0.0, 0.0) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "complex path rejects nonfinite QP weight");
+  CHECK(mvmc_classic_pfaffian_complex_failure_global_qp(
+            complex_workspace) == 0,
+        "complex invalid weight reports global QP");
+  mvmc_classic_pfaffian_complex_workspace_destroy(complex_workspace);
+}
+
+int main(void) {
+  test_real_transaction_and_transitions();
+  test_real_multiqup_and_alias_boundary();
+  test_complex_multiqup();
+  test_exact_total_cancellation();
+  test_empty_slice_and_invalid_inputs();
+
+  if (failure_count != 0) {
+    fprintf(stderr, "classic Pfaffian state unit: %d failure(s)\n",
+            failure_count);
+    return 1;
+  }
+  printf("classic Pfaffian state unit checks passed\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- Add reusable real/complex absolute Pfaffian state workspaces and transactional accepted/candidate publication.
- Add passed-communicator MPI aggregation and collective Metropolis decisions.
- Add a Testing-only classic sampler reference with guarded/always fast-path audit, deterministic traces, and periodic rebuild checks.
- Add real/complex, NQP=1/4, MPI rank=1/2/4, singular-transition, and legacy fast-kernel A/B coverage.

## Motivation

A projected amplitude can remain finite and nonzero even when one Pfaffian component is singular. The legacy inverse-based update path cannot represent that state safely, and the current measurement rebuild rejects such a sample. This change establishes an absolute, singular-aware reference state and correctness gates without enabling the production sampler path.

## Validation

- P2-A through P2-D review gates are closed; outstanding must-fix and should-fix findings: 0.
- Post-rebase focused build and tests: 11/11 PASS; 427 CTest cases registered.
- Full macOS CTest: 399/424; all 25 failures match the known environment-specific set and signatures, with 0 new failures.
- Apple ASan/UBSan, Linux GCC/OpenMPI OMP=1/4, MPI rank=1/2/4, strict-warning, and static-analyzer gates: PASS.
- Testing=OFF `vmc.out`: sampler/audit sources, symbols, and P2-D-specific strings are absent.

## Scope

The production sampler path remains disabled. Singular-aware measurement handling and the Fugaku-equivalent strict floating-point gate must close before production enablement.