### PR TITLE
Add absolute Krylov reference and feasibility profiling

### DIFF
--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -31,7 +31,7 @@ if(Testing)
   # Keep fault injection, reference samplers, and audits out of production.
   target_sources(vmc.out PRIVATE classic_pfaffian_sampler.c
       classic_pfaffian_audit.c krylov_fock_reference.c
-      classic_krylov_amplitude.c)
+      classic_krylov_amplitude.c classic_krylov_model.c)
   target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION
       MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
       MVMC_ENABLE_PFAFFIAN_STATE_AUDIT

--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -27,12 +27,13 @@ add_executable(vmcdry.out vmcdry.c)
 target_link_libraries(vmcdry.out StdFace_mvmc m)
 add_executable(vmc.out ${SOURCES_vmcmain} ${SOURCES_sfmt})
 if(Testing)
-  # Keep fault injection, reference sampler, and audit out of production.
+  # Keep fault injection, reference samplers, and audits out of production.
   target_sources(vmc.out PRIVATE classic_pfaffian_sampler.c
-      classic_pfaffian_audit.c)
+      classic_pfaffian_audit.c krylov_fock_reference.c)
   target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION
       MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
-      MVMC_ENABLE_PFAFFIAN_STATE_AUDIT)
+      MVMC_ENABLE_PFAFFIAN_STATE_AUDIT
+      MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
 endif(Testing)
 target_link_libraries(vmc.out StdFace_mvmc m)
 target_link_libraries(vmc.out pfapack)

--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -11,7 +11,8 @@ include_directories("${STDFACE_DIR}/src")
 add_definitions(-DMEXP=19937)
 
 set(SOURCES_vmcmain
-        vmcmain.c absolute_pfaffian.c classic_pfaffian_state.c
+        vmcmain.c absolute_pfaffian.c classic_pfaffian_matrix.c
+        classic_pfaffian_state.c
         classic_pfaffian_collective.c
         physcal_lanczos.c physcal_lanczos2.c
         lanczos2_contract.c splitloop.c
@@ -29,7 +30,8 @@ add_executable(vmc.out ${SOURCES_vmcmain} ${SOURCES_sfmt})
 if(Testing)
   # Keep fault injection, reference samplers, and audits out of production.
   target_sources(vmc.out PRIVATE classic_pfaffian_sampler.c
-      classic_pfaffian_audit.c krylov_fock_reference.c)
+      classic_pfaffian_audit.c krylov_fock_reference.c
+      classic_krylov_amplitude.c)
   target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION
       MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
       MVMC_ENABLE_PFAFFIAN_STATE_AUDIT

--- a/src/mVMC/absolute_pfaffian.c
+++ b/src/mVMC/absolute_pfaffian.c
@@ -55,6 +55,24 @@ struct MVMCAbsolutePfaffianComplexWorkspace {
   double complex *inverse_work;
 };
 
+struct MVMCAbsolutePfaffianRealValueWorkspace {
+  int n;
+  size_t matrix_count;
+  int factor_lwork;
+  int *pivots;
+  double *factor;
+  double *factor_work;
+};
+
+struct MVMCAbsolutePfaffianComplexValueWorkspace {
+  int n;
+  size_t matrix_count;
+  int factor_lwork;
+  int *pivots;
+  double complex *factor;
+  double complex *factor_work;
+};
+
 static void initialize_result(MVMCAbsolutePfaffianResult *result,
                               uint64_t generation) {
   result->state = MVMC_PFAFFIAN_INVALID;
@@ -65,6 +83,14 @@ static void initialize_result(MVMCAbsolutePfaffianResult *result,
   result->matrix_scale = NAN;
   result->scaled_min_pivot = NAN;
   result->inverse_residual = NAN;
+  result->pfaffian = 0.0;
+}
+
+static void initialize_value_result(MVMCAbsolutePfaffianValueResult *result) {
+  result->state = MVMC_PFAFFIAN_VALUE_INVALID;
+  result->factor_info = 0;
+  result->matrix_scale = NAN;
+  result->scaled_min_pivot = NAN;
   result->pfaffian = 0.0;
 }
 
@@ -249,6 +275,144 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_workspace_create(
   return MVMC_PFAFFIAN_STATUS_OK;
 }
 
+void mvmc_absolute_pfaffian_real_value_workspace_destroy(
+    MVMCAbsolutePfaffianRealValueWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->factor_work);
+  free(workspace->factor);
+  free(workspace->pivots);
+  free(workspace);
+}
+
+size_t mvmc_absolute_pfaffian_real_value_workspace_bytes(
+    const MVMCAbsolutePfaffianRealValueWorkspace *workspace) {
+  if (workspace == NULL) return 0;
+  return sizeof(*workspace) +
+         (size_t)workspace->n * sizeof(*workspace->pivots) +
+         workspace->matrix_count * sizeof(*workspace->factor) +
+         (size_t)workspace->factor_lwork * sizeof(*workspace->factor_work);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_value_workspace_create(
+    int n, MVMCAbsolutePfaffianRealValueWorkspace **workspace) {
+  MVMCAbsolutePfaffianRealValueWorkspace *created = NULL;
+  double factor_query = 0.0;
+  int info = 0;
+  int query_lwork = -1;
+  int index;
+  size_t matrix_count;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (n <= 0 || (n % 2) != 0 ||
+      !checked_square_size(n, sizeof(double), &matrix_count) ||
+      (size_t)n > SIZE_MAX / sizeof(int)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCAbsolutePfaffianRealValueWorkspace *)calloc(
+      1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  created->n = n;
+  created->matrix_count = matrix_count;
+  created->pivots = (int *)malloc((size_t)n * sizeof(*created->pivots));
+  created->factor =
+      (double *)calloc(created->matrix_count, sizeof(*created->factor));
+  if (created->pivots == NULL || created->factor == NULL) {
+    mvmc_absolute_pfaffian_real_value_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  for (index = 0; index < n; ++index) created->pivots[index] = index + 1;
+  M_DSKTRF("U", "P", &n, created->factor, &n, created->pivots,
+           &factor_query, &query_lwork, &info);
+  if (info != 0 ||
+      !valid_real_lwork_query(factor_query, &created->factor_lwork) ||
+      (size_t)created->factor_lwork >
+          SIZE_MAX / sizeof(*created->factor_work)) {
+    mvmc_absolute_pfaffian_real_value_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  created->factor_work = (double *)malloc(
+      (size_t)created->factor_lwork * sizeof(*created->factor_work));
+  if (created->factor_work == NULL) {
+    mvmc_absolute_pfaffian_real_value_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+void mvmc_absolute_pfaffian_complex_value_workspace_destroy(
+    MVMCAbsolutePfaffianComplexValueWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->factor_work);
+  free(workspace->factor);
+  free(workspace->pivots);
+  free(workspace);
+}
+
+size_t mvmc_absolute_pfaffian_complex_value_workspace_bytes(
+    const MVMCAbsolutePfaffianComplexValueWorkspace *workspace) {
+  if (workspace == NULL) return 0;
+  return sizeof(*workspace) +
+         (size_t)workspace->n * sizeof(*workspace->pivots) +
+         workspace->matrix_count * sizeof(*workspace->factor) +
+         (size_t)workspace->factor_lwork * sizeof(*workspace->factor_work);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value_workspace_create(
+    int n, MVMCAbsolutePfaffianComplexValueWorkspace **workspace) {
+  MVMCAbsolutePfaffianComplexValueWorkspace *created = NULL;
+  double complex factor_query = 0.0;
+  int info = 0;
+  int query_lwork = -1;
+  int index;
+  size_t matrix_count;
+
+  if (workspace == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (n <= 0 || (n % 2) != 0 ||
+      !checked_square_size(n, sizeof(double complex), &matrix_count) ||
+      (size_t)n > SIZE_MAX / sizeof(int)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCAbsolutePfaffianComplexValueWorkspace *)calloc(
+      1, sizeof(*created));
+  if (created == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  created->n = n;
+  created->matrix_count = matrix_count;
+  created->pivots = (int *)malloc((size_t)n * sizeof(*created->pivots));
+  created->factor = (double complex *)calloc(
+      created->matrix_count, sizeof(*created->factor));
+  if (created->pivots == NULL || created->factor == NULL) {
+    mvmc_absolute_pfaffian_complex_value_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  for (index = 0; index < n; ++index) created->pivots[index] = index + 1;
+  M_ZSKTRF("U", "P", &n, created->factor, &n, created->pivots,
+           &factor_query, &query_lwork, &info);
+  if (info != 0 ||
+      !valid_complex_lwork_query(factor_query, &created->factor_lwork) ||
+      (size_t)created->factor_lwork >
+          SIZE_MAX / sizeof(*created->factor_work)) {
+    mvmc_absolute_pfaffian_complex_value_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  created->factor_work = (double complex *)malloc(
+      (size_t)created->factor_lwork * sizeof(*created->factor_work));
+  if (created->factor_work == NULL) {
+    mvmc_absolute_pfaffian_complex_value_workspace_destroy(created);
+    return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  }
+  *workspace = created;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
 static int real_matrix_properties(const double *matrix, int n, int lda,
                                   double *scale) {
   int column, row;
@@ -377,6 +541,111 @@ static double effective_residual_tolerance(double tolerance, int n) {
   return 256.0 * DBL_EPSILON * (double)n;
 }
 
+static MVMCPfaffianStatus factorize_real_value(
+    const double *matrix, int n, int lda, double *factor, int *pivots,
+    double *factor_work, int factor_lwork, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result) {
+  double pfaffian = 0.0;
+  double min_pivot = INFINITY;
+  int column, row, info = 0;
+
+  info = real_matrix_properties(matrix, n, lda, &result->matrix_scale);
+  if (info < 0) {
+    result->state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+  M_DSKTRF("U", "P", &n, factor, &n, pivots, factor_work,
+           &factor_lwork, &info);
+  result->factor_info = info;
+  if (info < 0) return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+    result->scaled_min_pivot = 0.0;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  utu2pfa_d(n, factor, n, pivots, &pfaffian);
+  if (!isfinite(pfaffian)) {
+    result->state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  result->pfaffian = pfaffian;
+  for (row = 0; row < n; row += 2) {
+    min_pivot = fmin(
+        min_pivot, fabs(factor[row + (size_t)(row + 1) * (size_t)n]));
+  }
+  result->scaled_min_pivot =
+      min_pivot / fmax(result->matrix_scale, DBL_MIN);
+  if (!isfinite(result->scaled_min_pivot)) {
+    result->state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+  } else if (result->scaled_min_pivot <
+             effective_pivot_tolerance(scaled_pivot_tolerance, n)) {
+    result->state = MVMC_PFAFFIAN_VALUE_NEAR_PIVOT;
+  } else {
+    result->state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  }
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static MVMCPfaffianStatus factorize_complex_value(
+    const double complex *matrix, int n, int lda, double complex *factor,
+    int *pivots, double complex *factor_work, int factor_lwork,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result) {
+  double complex pfaffian = 0.0;
+  double min_pivot = INFINITY;
+  int column, row, info = 0;
+
+  info = complex_matrix_properties(matrix, n, lda, &result->matrix_scale);
+  if (info < 0) {
+    result->state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  for (column = 0; column < n; ++column) {
+    for (row = 0; row < n; ++row) {
+      factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+  M_ZSKTRF("U", "P", &n, factor, &n, pivots, factor_work,
+           &factor_lwork, &info);
+  result->factor_info = info;
+  if (info < 0) return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  if (info > 0) {
+    result->state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+    result->scaled_min_pivot = 0.0;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  utu2pfa_z(n, factor, n, pivots, &pfaffian);
+  if (!isfinite(creal(pfaffian)) || !isfinite(cimag(pfaffian))) {
+    result->state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  result->pfaffian = pfaffian;
+  for (row = 0; row < n; row += 2) {
+    min_pivot = fmin(
+        min_pivot, cabs(factor[row + (size_t)(row + 1) * (size_t)n]));
+  }
+  result->scaled_min_pivot =
+      min_pivot / fmax(result->matrix_scale, DBL_MIN);
+  if (!isfinite(result->scaled_min_pivot)) {
+    result->state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+  } else if (result->scaled_min_pivot <
+             effective_pivot_tolerance(scaled_pivot_tolerance, n)) {
+    result->state = MVMC_PFAFFIAN_VALUE_NEAR_PIVOT;
+  } else {
+    result->state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  }
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
 int mvmc_absolute_pfaffian_strict_fp_enabled(void) {
 #ifdef __FAST_MATH__
   return 0;
@@ -400,8 +669,7 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real_with_workspace(
   int *pivots = workspace == NULL ? NULL : workspace->pivots;
   size_t matrix_count;
   int column, row, info = 0, lwork;
-  double pfaffian = 0.0;
-  double min_pivot = INFINITY;
+  MVMCAbsolutePfaffianValueResult value_result;
   MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
 
   if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
@@ -418,54 +686,29 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_real_with_workspace(
       workspace->matrix_count != matrix_count) {
     return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   }
-  info = real_matrix_properties(matrix, n, lda, &result->matrix_scale);
-  if (info < 0) {
+  initialize_value_result(&value_result);
+  status = factorize_real_value(
+      matrix, n, lda, factor, pivots, factor_work,
+      workspace->factor_lwork, scaled_pivot_tolerance, &value_result);
+  result->factor_info = value_result.factor_info;
+  result->matrix_scale = value_result.matrix_scale;
+  result->scaled_min_pivot = value_result.scaled_min_pivot;
+  result->pfaffian = value_result.pfaffian;
+  if (status != MVMC_PFAFFIAN_STATUS_OK) goto cleanup;
+  if (value_result.state == MVMC_PFAFFIAN_VALUE_NONFINITE) {
     result->state = MVMC_PFAFFIAN_NONFINITE;
-    return MVMC_PFAFFIAN_STATUS_OK;
-  }
-  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
-
-  for (column = 0; column < n; ++column) {
-    for (row = 0; row < n; ++row) {
-      factor[row + (size_t)column * (size_t)n] =
-          matrix[row + (size_t)column * (size_t)lda];
-    }
-  }
-
-  lwork = workspace->factor_lwork;
-  M_DSKTRF("U", "P", &n, factor, &n, pivots, factor_work, &lwork, &info);
-  result->factor_info = info;
-  if (info < 0) {
-    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
     goto cleanup;
   }
-  if (info > 0) {
+  if (value_result.state == MVMC_PFAFFIAN_VALUE_SINGULAR) {
     result->state = MVMC_PFAFFIAN_SINGULAR;
-    result->scaled_min_pivot = 0.0;
-    result->pfaffian = 0.0;
     goto cleanup;
   }
-
-  utu2pfa_d(n, factor, n, pivots, &pfaffian);
-  if (!isfinite(pfaffian)) {
-    result->state = MVMC_PFAFFIAN_NONFINITE;
-    goto cleanup;
-  }
-  result->pfaffian = pfaffian;
-  for (row = 0; row < n; row += 2) {
-    min_pivot = fmin(min_pivot,
-                     fabs(factor[row + (size_t)(row + 1) * (size_t)n]));
-  }
-  result->scaled_min_pivot =
-      min_pivot / fmax(result->matrix_scale, DBL_MIN);
-
-  if (!isfinite(result->scaled_min_pivot)) {
-    result->state = MVMC_PFAFFIAN_NONFINITE;
-    goto cleanup;
-  }
-  if (result->scaled_min_pivot <
-      effective_pivot_tolerance(scaled_pivot_tolerance, n)) {
+  if (value_result.state == MVMC_PFAFFIAN_VALUE_NEAR_PIVOT) {
     result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  if (value_result.state != MVMC_PFAFFIAN_VALUE_WELL_PIVOTED) {
+    status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
     goto cleanup;
   }
 
@@ -571,8 +814,7 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_with_workspace(
   int *pivots = workspace == NULL ? NULL : workspace->pivots;
   size_t matrix_count;
   int column, row, info = 0, lwork;
-  double complex pfaffian = 0.0;
-  double min_pivot = INFINITY;
+  MVMCAbsolutePfaffianValueResult value_result;
   MVMCPfaffianStatus status = MVMC_PFAFFIAN_STATUS_OK;
 
   if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
@@ -589,55 +831,29 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_with_workspace(
       workspace->matrix_count != matrix_count) {
     return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   }
-  info = complex_matrix_properties(matrix, n, lda, &result->matrix_scale);
-  if (info < 0) {
+  initialize_value_result(&value_result);
+  status = factorize_complex_value(
+      matrix, n, lda, factor, pivots, factor_work,
+      workspace->factor_lwork, scaled_pivot_tolerance, &value_result);
+  result->factor_info = value_result.factor_info;
+  result->matrix_scale = value_result.matrix_scale;
+  result->scaled_min_pivot = value_result.scaled_min_pivot;
+  result->pfaffian = value_result.pfaffian;
+  if (status != MVMC_PFAFFIAN_STATUS_OK) goto cleanup;
+  if (value_result.state == MVMC_PFAFFIAN_VALUE_NONFINITE) {
     result->state = MVMC_PFAFFIAN_NONFINITE;
-    return MVMC_PFAFFIAN_STATUS_OK;
-  }
-  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
-
-  for (column = 0; column < n; ++column) {
-    for (row = 0; row < n; ++row) {
-      factor[row + (size_t)column * (size_t)n] =
-          matrix[row + (size_t)column * (size_t)lda];
-    }
-  }
-
-  lwork = workspace->factor_lwork;
-  M_ZSKTRF("U", "P", &n, factor, &n, pivots, factor_work, &lwork, &info);
-  result->factor_info = info;
-  if (info < 0) {
-    status = MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
     goto cleanup;
   }
-  if (info > 0) {
+  if (value_result.state == MVMC_PFAFFIAN_VALUE_SINGULAR) {
     result->state = MVMC_PFAFFIAN_SINGULAR;
-    result->scaled_min_pivot = 0.0;
-    result->pfaffian = 0.0;
     goto cleanup;
   }
-
-  utu2pfa_z(n, factor, n, pivots, &pfaffian);
-  if (!isfinite(creal(pfaffian)) || !isfinite(cimag(pfaffian))) {
-    result->state = MVMC_PFAFFIAN_NONFINITE;
-    goto cleanup;
-  }
-  result->pfaffian = pfaffian;
-  for (row = 0; row < n; row += 2) {
-    min_pivot = fmin(
-        min_pivot,
-        cabs(factor[row + (size_t)(row + 1) * (size_t)n]));
-  }
-  result->scaled_min_pivot =
-      min_pivot / fmax(result->matrix_scale, DBL_MIN);
-
-  if (!isfinite(result->scaled_min_pivot)) {
-    result->state = MVMC_PFAFFIAN_NONFINITE;
-    goto cleanup;
-  }
-  if (result->scaled_min_pivot <
-      effective_pivot_tolerance(scaled_pivot_tolerance, n)) {
+  if (value_result.state == MVMC_PFAFFIAN_VALUE_NEAR_PIVOT) {
     result->state = MVMC_PFAFFIAN_NEAR_SINGULAR;
+    goto cleanup;
+  }
+  if (value_result.state != MVMC_PFAFFIAN_VALUE_WELL_PIVOTED) {
+    status = MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
     goto cleanup;
   }
 
@@ -723,6 +939,109 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
         result);
   }
   mvmc_absolute_pfaffian_complex_workspace_destroy(workspace);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_value_with_workspace(
+    MVMCAbsolutePfaffianRealValueWorkspace *workspace,
+    const double *matrix, int n, int lda, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result) {
+  size_t matrix_count;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_value_result(result);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (workspace == NULL || workspace->n != n || matrix == NULL ||
+      n <= 0 || (n % 2) != 0 || lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count) ||
+      workspace->matrix_count != matrix_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return factorize_real_value(
+      matrix, n, lda, workspace->factor, workspace->pivots,
+      workspace->factor_work, workspace->factor_lwork,
+      scaled_pivot_tolerance, result);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value_with_workspace(
+    MVMCAbsolutePfaffianComplexValueWorkspace *workspace,
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result) {
+  size_t matrix_count;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_value_result(result);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (workspace == NULL || workspace->n != n || matrix == NULL ||
+      n <= 0 || (n % 2) != 0 || lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count) ||
+      workspace->matrix_count != matrix_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return factorize_complex_value(
+      matrix, n, lda, workspace->factor, workspace->pivots,
+      workspace->factor_work, workspace->factor_lwork,
+      scaled_pivot_tolerance, result);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_value(
+    const double *matrix, int n, int lda, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result) {
+  MVMCAbsolutePfaffianRealValueWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
+  size_t matrix_count;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_value_result(result);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (matrix == NULL || n <= 0 || (n % 2) != 0 || lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status = mvmc_absolute_pfaffian_real_value_workspace_create(n, &workspace);
+  if (status == MVMC_PFAFFIAN_STATUS_OK) {
+    status = mvmc_absolute_pfaffian_real_value_with_workspace(
+        workspace, matrix, n, lda, scaled_pivot_tolerance, result);
+  }
+  mvmc_absolute_pfaffian_real_value_workspace_destroy(workspace);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value(
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result) {
+  MVMCAbsolutePfaffianComplexValueWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
+  size_t matrix_count;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  initialize_value_result(result);
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (matrix == NULL || n <= 0 || (n % 2) != 0 || lda < n ||
+      !isfinite(scaled_pivot_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  status =
+      mvmc_absolute_pfaffian_complex_value_workspace_create(n, &workspace);
+  if (status == MVMC_PFAFFIAN_STATUS_OK) {
+    status = mvmc_absolute_pfaffian_complex_value_with_workspace(
+        workspace, matrix, n, lda, scaled_pivot_tolerance, result);
+  }
+  mvmc_absolute_pfaffian_complex_value_workspace_destroy(workspace);
   return status;
 }
 
@@ -819,6 +1138,87 @@ MVMCPfaffianStatus mvmc_projected_amplitude(
   return MVMC_PFAFFIAN_STATUS_OK;
 }
 
+MVMCPfaffianStatus mvmc_projected_amplitude_values(
+    const MVMCAbsolutePfaffianValueResult *components,
+    const double complex *weights, size_t component_count,
+    MVMCProjectedAmplitudeResult *result) {
+  size_t index;
+  double real_sum = 0.0, real_compensation = 0.0;
+  double imag_sum = 0.0, imag_compensation = 0.0;
+  double abs_sum = 0.0, abs_compensation = 0.0;
+  MVMCProjectedAmplitudeResult accumulated;
+
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  memset(result, 0, sizeof(*result));
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (components == NULL || weights == NULL || component_count == 0) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  memset(&accumulated, 0, sizeof(accumulated));
+  for (index = 0; index < component_count; ++index) {
+    double complex term;
+    double value, corrected, updated;
+
+    if (!isfinite(creal(weights[index])) ||
+        !isfinite(cimag(weights[index])) ||
+        !isfinite(creal(components[index].pfaffian)) ||
+        !isfinite(cimag(components[index].pfaffian)) ||
+        components[index].state == MVMC_PFAFFIAN_VALUE_NONFINITE ||
+        components[index].state == MVMC_PFAFFIAN_VALUE_INVALID) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    switch (components[index].state) {
+      case MVMC_PFAFFIAN_VALUE_WELL_PIVOTED:
+        ++accumulated.regular_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_NEAR_PIVOT:
+        ++accumulated.near_singular_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_SINGULAR:
+        if (components[index].pfaffian != 0.0) {
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+        ++accumulated.singular_count;
+        break;
+      default:
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    term = weights[index] * components[index].pfaffian;
+    if (!isfinite(creal(term)) || !isfinite(cimag(term))) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    value = cabs(term);
+    corrected = value - abs_compensation;
+    updated = abs_sum + corrected;
+    if (!isfinite(updated)) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    abs_compensation = (updated - abs_sum) - corrected;
+    abs_sum = updated;
+
+    value = creal(term);
+    corrected = value - real_compensation;
+    updated = real_sum + corrected;
+    if (!isfinite(updated)) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    real_compensation = (updated - real_sum) - corrected;
+    real_sum = updated;
+
+    value = cimag(term);
+    corrected = value - imag_compensation;
+    updated = imag_sum + corrected;
+    if (!isfinite(updated)) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    imag_compensation = (updated - imag_sum) - corrected;
+    imag_sum = updated;
+  }
+  accumulated.total = real_sum + I * imag_sum;
+  accumulated.sum_abs = abs_sum;
+  accumulated.cancellation_ratio =
+      abs_sum == 0.0 ? 0.0 : fmin(1.0, cabs(accumulated.total) / abs_sum);
+  accumulated.valid = 1;
+  *result = accumulated;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
 MVMCPfaffianStatus mvmc_projected_amplitude_slice(
     const MVMCAbsolutePfaffianResult *local_components,
     size_t local_component_count, const double complex *global_weights,
@@ -838,6 +1238,31 @@ MVMCPfaffianStatus mvmc_projected_amplitude_slice(
       local_component_count, result);
 }
 
+MVMCPfaffianStatus mvmc_projected_amplitude_value_slice(
+    const MVMCAbsolutePfaffianValueResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCProjectedAmplitudeResult *result) {
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  memset(result, 0, sizeof(*result));
+  if (!mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (qp_total <= 0 || qp_start < 0 || qp_end < qp_start ||
+      qp_end > qp_total ||
+      (size_t)(qp_end - qp_start) != local_component_count ||
+      global_weights == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (local_component_count == 0) {
+    result->valid = 1;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  return mvmc_projected_amplitude_values(
+      local_components, global_weights + qp_start,
+      local_component_count, result);
+}
+
 const char *mvmc_pfaffian_state_name(MVMCPfaffianState state) {
   switch (state) {
     case MVMC_PFAFFIAN_REGULAR:
@@ -849,6 +1274,22 @@ const char *mvmc_pfaffian_state_name(MVMCPfaffianState state) {
     case MVMC_PFAFFIAN_NONFINITE:
       return "NONFINITE";
     case MVMC_PFAFFIAN_INVALID:
+      return "INVALID";
+  }
+  return "INVALID";
+}
+
+const char *mvmc_pfaffian_value_state_name(MVMCPfaffianValueState state) {
+  switch (state) {
+    case MVMC_PFAFFIAN_VALUE_WELL_PIVOTED:
+      return "WELL_PIVOTED";
+    case MVMC_PFAFFIAN_VALUE_NEAR_PIVOT:
+      return "NEAR_PIVOT";
+    case MVMC_PFAFFIAN_VALUE_SINGULAR:
+      return "SINGULAR";
+    case MVMC_PFAFFIAN_VALUE_NONFINITE:
+      return "NONFINITE";
+    case MVMC_PFAFFIAN_VALUE_INVALID:
       return "INVALID";
   }
   return "INVALID";

--- a/src/mVMC/classic_krylov_amplitude.c
+++ b/src/mVMC/classic_krylov_amplitude.c
@@ -1,0 +1,1057 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_krylov_amplitude.h"
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+
+#include "classic_pfaffian_matrix.h"
+
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+  size_t site_count;
+  size_t up_electron_count;
+  size_t down_electron_count;
+  size_t orbital_count;
+  size_t word_count;
+  int pure_spin;
+  int nsize;
+  int qp_total;
+  int qp_start;
+  int qp_end;
+  size_t local_qp_count;
+  size_t slater_matrix_count;
+  size_t matrix_count;
+  double scaled_pivot_tolerance;
+  MVMCClassicKrylovProjectionKind projection_kind;
+  double projection_parameter;
+  double complex *global_weights;
+  int *ele_idx;
+  int *ele_num;
+  MVMCAbsolutePfaffianValueResult *components;
+  MVMCAbsolutePfaffianValueResult *global_components;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace;
+} MVMCClassicKrylovAmplitudeCommon;
+
+struct MVMCClassicKrylovRealAmplitudeWorkspace {
+  MVMCClassicKrylovAmplitudeCommon common;
+  double *slater_elm;
+  double *matrix;
+  MVMCAbsolutePfaffianRealValueWorkspace *value_workspace;
+};
+
+struct MVMCClassicKrylovComplexAmplitudeWorkspace {
+  MVMCClassicKrylovAmplitudeCommon common;
+  double complex *slater_elm;
+  double complex *matrix;
+  MVMCAbsolutePfaffianComplexValueWorkspace *value_workspace;
+};
+
+static int checked_multiply(size_t left, size_t right, size_t *product) {
+  if (product == NULL || (left != 0 && right > SIZE_MAX / left)) return 0;
+  *product = left * right;
+  return 1;
+}
+
+static int checked_add(size_t left, size_t right, size_t *sum) {
+  if (sum == NULL || right > SIZE_MAX - left) return 0;
+  *sum = left + right;
+  return 1;
+}
+
+static MVMCKrylovStatus map_create_status(MVMCPfaffianStatus status) {
+  switch (status) {
+    case MVMC_PFAFFIAN_STATUS_OK:
+      return MVMC_KRYLOV_STATUS_OK;
+    case MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE:
+      return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+    case MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT:
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    case MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE:
+    case MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE:
+      return MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+  }
+  return MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+}
+
+static int valid_jastrow_binding(const int *const *binding,
+                                  size_t site_count, int class_count) {
+  size_t row, column;
+
+  if (class_count == 0) return 1;
+  if (binding == NULL) return 0;
+  for (row = 0; row < site_count; ++row) {
+    if (binding[row] == NULL) return 0;
+    for (column = 0; column < site_count; ++column) {
+      const int value = binding[row][column];
+      if (row == column) {
+        if (value != -1) return 0;
+      } else if (value < 0 || value >= class_count ||
+                 binding[column] == NULL ||
+                 binding[column][row] != value) {
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+static int valid_doublon_holon_binding(const int *const *binding,
+                                       size_t site_count, int class_count,
+                                       size_t neighbors_per_site) {
+  int class_index;
+  size_t value_index, value_count;
+
+  if (class_count == 0) return 1;
+  if (binding == NULL ||
+      !checked_multiply(site_count, neighbors_per_site, &value_count)) {
+    return 0;
+  }
+  for (class_index = 0; class_index < class_count; ++class_index) {
+    if (binding[class_index] == NULL) return 0;
+    for (value_index = 0; value_index < value_count; ++value_index) {
+      const int value = binding[class_index][value_index];
+      if (value < 0 || (size_t)value >= site_count) return 0;
+    }
+  }
+  return 1;
+}
+
+static MVMCKrylovStatus initialize_common(
+    const MVMCClassicKrylovAmplitudeLayout *layout,
+    const double complex *global_weights,
+    MVMCClassicKrylovAmplitudeCommon *common) {
+  size_t nsize, orbital_count, word_count, matrix_count;
+  size_t slater_dimension, slater_matrix_count;
+  size_t expected_nproj;
+  int index;
+  int qp;
+
+  if (layout == NULL || common == NULL || global_weights == NULL ||
+      layout->site_count == 0 || layout->site_count > (size_t)INT_MAX / 2 ||
+      layout->up_electron_count == 0 ||
+      layout->up_electron_count != layout->down_electron_count ||
+      layout->up_electron_count > layout->site_count ||
+      layout->up_electron_count > (size_t)INT_MAX / 2 ||
+      (layout->pure_spin != 0 && layout->pure_spin != 1) ||
+      (layout->pure_spin &&
+       layout->up_electron_count + layout->down_electron_count !=
+           layout->site_count) ||
+      (layout->qp_total != 1 && layout->qp_total != 4) ||
+      layout->qp_start < 0 ||
+      layout->qp_end < layout->qp_start ||
+      layout->qp_end > layout->qp_total ||
+      !isfinite(layout->scaled_pivot_tolerance) ||
+      layout->nproj < 0 || layout->ngutzwiller_idx < 0 ||
+      layout->njastrow_idx < 0 || layout->nspin_jastrow_idx < 0 ||
+      layout->ndoublon_holon_2site_idx < 0 ||
+      layout->ndoublon_holon_4site_idx < 0) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (layout->unsupported_features != 0) {
+    return MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL;
+  }
+  expected_nproj = (size_t)layout->ngutzwiller_idx;
+  if ((size_t)layout->njastrow_idx > SIZE_MAX - expected_nproj) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  expected_nproj += (size_t)layout->njastrow_idx;
+  if ((size_t)layout->nspin_jastrow_idx > SIZE_MAX - expected_nproj) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  expected_nproj += (size_t)layout->nspin_jastrow_idx;
+  if ((size_t)layout->ndoublon_holon_2site_idx >
+          (SIZE_MAX - expected_nproj) / 6) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  expected_nproj += 6 * (size_t)layout->ndoublon_holon_2site_idx;
+  if ((size_t)layout->ndoublon_holon_4site_idx >
+          (SIZE_MAX - expected_nproj) / 10) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  expected_nproj += 10 * (size_t)layout->ndoublon_holon_4site_idx;
+  if (expected_nproj > (size_t)INT_MAX ||
+      (int)expected_nproj != layout->nproj) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (layout->ngutzwiller_idx != 0) {
+    if (layout->gutzwiller_idx == NULL ||
+        layout->projection_parameters == NULL) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+    for (index = 0; index < (int)layout->site_count; ++index) {
+      if (layout->gutzwiller_idx[index] < 0 ||
+          layout->gutzwiller_idx[index] >= layout->ngutzwiller_idx) {
+        return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+      }
+    }
+  }
+  for (index = 0; index < layout->nproj; ++index) {
+    if (layout->projection_parameters == NULL ||
+        !isfinite(creal(layout->projection_parameters[index])) ||
+        !isfinite(cimag(layout->projection_parameters[index])) ||
+        cimag(layout->projection_parameters[index]) != 0.0) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if (!valid_jastrow_binding(layout->jastrow_idx, layout->site_count,
+                              layout->njastrow_idx) ||
+      !valid_jastrow_binding(layout->spin_jastrow_idx, layout->site_count,
+                              layout->nspin_jastrow_idx) ||
+      !valid_doublon_holon_binding(layout->doublon_holon_2site_idx,
+                                    layout->site_count,
+                                    layout->ndoublon_holon_2site_idx, 2) ||
+      !valid_doublon_holon_binding(layout->doublon_holon_4site_idx,
+                                    layout->site_count,
+                                    layout->ndoublon_holon_4site_idx, 4)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (layout->njastrow_idx != 0 || layout->nspin_jastrow_idx != 0 ||
+      layout->ndoublon_holon_2site_idx != 0 ||
+      layout->ndoublon_holon_4site_idx != 0 ||
+      layout->ngutzwiller_idx > 1) {
+    return MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL;
+  }
+  if (layout->ngutzwiller_idx == 1) {
+    for (index = 0; index < (int)layout->site_count; ++index) {
+      if (layout->gutzwiller_idx[index] != 0) {
+        return MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL;
+      }
+    }
+  }
+  nsize = layout->up_electron_count + layout->down_electron_count;
+  if (nsize > (size_t)INT_MAX ||
+      !checked_multiply(layout->site_count, 2, &orbital_count) ||
+      orbital_count > SIZE_MAX - 63 ||
+      !checked_multiply(nsize, nsize, &matrix_count) ||
+      !checked_multiply(layout->site_count, 2, &slater_dimension) ||
+      !checked_multiply(slater_dimension, slater_dimension,
+                        &slater_matrix_count)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  word_count = (orbital_count + 63) / 64;
+  for (qp = 0; qp < layout->qp_total; ++qp) {
+    if (!isfinite(creal(global_weights[qp])) ||
+        !isfinite(cimag(global_weights[qp]))) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  common->site_count = layout->site_count;
+  common->up_electron_count = layout->up_electron_count;
+  common->down_electron_count = layout->down_electron_count;
+  common->orbital_count = orbital_count;
+  common->word_count = word_count;
+  common->pure_spin = layout->pure_spin;
+  common->nsize = (int)nsize;
+  common->qp_total = layout->qp_total;
+  common->qp_start = layout->qp_start;
+  common->qp_end = layout->qp_end;
+  common->local_qp_count = (size_t)(layout->qp_end - layout->qp_start);
+  common->slater_matrix_count = slater_matrix_count;
+  common->matrix_count = matrix_count;
+  common->scaled_pivot_tolerance = layout->scaled_pivot_tolerance;
+  common->projection_kind = layout->ngutzwiller_idx == 0
+                                ? MVMC_CLASSIC_KRYLOV_PROJECTION_NONE
+                                : MVMC_CLASSIC_KRYLOV_PROJECTION_GUTZWILLER_ONLY;
+  common->projection_parameter =
+      layout->ngutzwiller_idx == 0
+          ? 0.0 : creal(layout->projection_parameters[0]);
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static int allocate_common(MVMCClassicKrylovAmplitudeCommon *common) {
+  if (common == NULL || common->nsize <= 0) return 0;
+  common->ele_idx = (int *)calloc((size_t)common->nsize,
+                                  sizeof(*common->ele_idx));
+  common->ele_num = (int *)calloc(common->orbital_count,
+                                  sizeof(*common->ele_num));
+  common->global_weights = (double complex *)calloc(
+      (size_t)common->qp_total, sizeof(*common->global_weights));
+  if (common->local_qp_count != 0) {
+    common->components = (MVMCAbsolutePfaffianValueResult *)calloc(
+        common->local_qp_count, sizeof(*common->components));
+  }
+  common->global_components = (MVMCAbsolutePfaffianValueResult *)calloc(
+      (size_t)common->qp_total, sizeof(*common->global_components));
+  return common->ele_idx != NULL && common->ele_num != NULL &&
+         common->global_weights != NULL &&
+         common->global_components != NULL &&
+         (common->local_qp_count == 0 || common->components != NULL);
+}
+
+static void destroy_common(MVMCClassicKrylovAmplitudeCommon *common) {
+  if (common == NULL) return;
+  mvmc_classic_pfaffian_collective_workspace_destroy(
+      common->collective_workspace);
+  free(common->global_components);
+  free(common->components);
+  free(common->global_weights);
+  free(common->ele_num);
+  free(common->ele_idx);
+}
+
+static MVMCPfaffianStatus audit_static_binding(
+    MVMCClassicKrylovAmplitudeCommon *common, int scalar_kind,
+    const void *slater, size_t slater_bytes,
+    const double complex *global_weights) {
+  uint64_t metadata[9];
+  uint64_t tolerance_bits = 0;
+  uint64_t projection_bits = 0;
+  MVMCPfaffianStatus status;
+  int all_equal = 0;
+
+  memcpy(&tolerance_bits, &common->scaled_pivot_tolerance,
+         sizeof(tolerance_bits));
+  memcpy(&projection_bits, &common->projection_parameter,
+         sizeof(projection_bits));
+  metadata[0] = (uint64_t)common->site_count;
+  metadata[1] = (uint64_t)common->up_electron_count;
+  metadata[2] = (uint64_t)common->down_electron_count;
+  metadata[3] = (uint64_t)common->pure_spin;
+  metadata[4] = (uint64_t)common->qp_total;
+  metadata[5] = (uint64_t)common->projection_kind;
+  metadata[6] = (uint64_t)scalar_kind;
+  metadata[7] = tolerance_bits;
+  metadata[8] = projection_bits;
+  status = mvmc_classic_pfaffian_collective_all_equal_u64(
+      common->collective_workspace, metadata,
+      sizeof(metadata) / sizeof(metadata[0]), &all_equal);
+  if (status != MVMC_PFAFFIAN_STATUS_OK || !all_equal) {
+    return status == MVMC_PFAFFIAN_STATUS_OK
+               ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT : status;
+  }
+  status = mvmc_classic_pfaffian_collective_all_equal_bytes(
+      common->collective_workspace, global_weights,
+      (size_t)common->qp_total * sizeof(*global_weights), &all_equal);
+  if (status != MVMC_PFAFFIAN_STATUS_OK || !all_equal) {
+    return status == MVMC_PFAFFIAN_STATUS_OK
+               ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT : status;
+  }
+  status = mvmc_classic_pfaffian_collective_all_equal_bytes(
+      common->collective_workspace, slater, slater_bytes, &all_equal);
+  if (status != MVMC_PFAFFIAN_STATUS_OK || !all_equal) {
+    return status == MVMC_PFAFFIAN_STATUS_OK
+               ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT : status;
+  }
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static MVMCPfaffianStatus audit_qp_partition(
+    MVMCClassicKrylovAmplitudeCommon *common) {
+  MVMCProjectedAmplitudeResult local;
+  MVMCClassicPfaffianCollectiveResult collective;
+
+  memset(&local, 0, sizeof(local));
+  local.valid = 1;
+  local.regular_count = common->local_qp_count;
+  return mvmc_classic_pfaffian_collective_aggregate(
+      common->collective_workspace, MVMC_PFAFFIAN_STATUS_OK, &local,
+      common->qp_total, common->qp_start, common->qp_end, -1, -1,
+      &collective);
+}
+
+static int build_occupation(MVMCClassicKrylovAmplitudeCommon *common,
+                            const uint64_t *words, size_t word_count) {
+  size_t orbital;
+  size_t up_count = 0;
+  size_t down_count = 0;
+
+  if (common == NULL || words == NULL || word_count != common->word_count) {
+    return 0;
+  }
+  if ((common->orbital_count % 64) != 0 &&
+      (words[word_count - 1] >> (common->orbital_count % 64)) != 0) {
+    return 0;
+  }
+  memset(common->ele_num, 0,
+         common->orbital_count * sizeof(*common->ele_num));
+  for (orbital = 0; orbital < common->orbital_count; ++orbital) {
+    const int occupied =
+        (int)((words[orbital / 64] >> (orbital % 64)) & UINT64_C(1));
+    common->ele_num[orbital] = occupied;
+    if (!occupied) continue;
+    if (orbital < common->site_count) {
+      if (up_count >= common->up_electron_count) return 0;
+      common->ele_idx[up_count++] = (int)orbital;
+    } else {
+      if (down_count >= common->down_electron_count) return 0;
+      common->ele_idx[common->up_electron_count + down_count++] =
+          (int)(orbital - common->site_count);
+    }
+  }
+  if (up_count != common->up_electron_count ||
+      down_count != common->down_electron_count) {
+    return 0;
+  }
+  if (common->pure_spin) {
+    size_t site;
+    for (site = 0; site < common->site_count; ++site) {
+      if (common->ele_num[site] +
+              common->ele_num[common->site_count + site] != 1) {
+        return 0;
+      }
+    }
+  }
+  return 1;
+}
+
+static MVMCKrylovStatus projection_log_value(
+    MVMCClassicKrylovAmplitudeCommon *common, double *log_value) {
+  size_t site;
+  size_t double_occupancy = 0;
+
+  *log_value = 0.0;
+  if (common->projection_kind == MVMC_CLASSIC_KRYLOV_PROJECTION_NONE) {
+    return MVMC_KRYLOV_STATUS_OK;
+  }
+  for (site = 0; site < common->site_count; ++site) {
+    double_occupancy +=
+        (size_t)(common->ele_num[site] *
+                 common->ele_num[common->site_count + site]);
+  }
+  *log_value = common->projection_parameter * (double)double_occupancy;
+  return isfinite(*log_value) ? MVMC_KRYLOV_STATUS_OK
+                              : MVMC_KRYLOV_STATUS_NONFINITE;
+}
+
+static int neumaier_add(double value, double *sum, double *compensation) {
+  const double updated = *sum + value;
+
+  if (!isfinite(value) || !isfinite(updated)) return 0;
+  if (fabs(*sum) >= fabs(value)) {
+    *compensation += (*sum - updated) + value;
+  } else {
+    *compensation += (value - updated) + *sum;
+  }
+  if (!isfinite(*compensation)) return 0;
+  *sum = updated;
+  return 1;
+}
+
+static MVMCKrylovStatus deterministic_projected_amplitude(
+    const MVMCClassicKrylovAmplitudeCommon *common,
+    MVMCProjectedAmplitudeResult *result) {
+  double real_sum = 0.0, real_compensation = 0.0;
+  double imag_sum = 0.0, imag_compensation = 0.0;
+  double abs_sum = 0.0, abs_compensation = 0.0;
+  int qp;
+
+  memset(result, 0, sizeof(*result));
+  for (qp = 0; qp < common->qp_total; ++qp) {
+    const MVMCAbsolutePfaffianValueResult *component =
+        common->global_components + qp;
+    double complex term;
+    double magnitude;
+
+    if (!isfinite(creal(component->pfaffian)) ||
+        !isfinite(cimag(component->pfaffian))) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    switch (component->state) {
+      case MVMC_PFAFFIAN_VALUE_WELL_PIVOTED:
+        ++result->regular_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_NEAR_PIVOT:
+        ++result->near_singular_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_SINGULAR:
+        if (component->pfaffian != 0.0) {
+          return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+        }
+        ++result->singular_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_NONFINITE:
+        return MVMC_KRYLOV_STATUS_NONFINITE;
+      case MVMC_PFAFFIAN_VALUE_INVALID:
+        return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+      default:
+        return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+    }
+    term = common->global_weights[qp] * component->pfaffian;
+    magnitude = cabs(term);
+    if (!isfinite(creal(term)) || !isfinite(cimag(term)) ||
+        !isfinite(magnitude) ||
+        !neumaier_add(creal(term), &real_sum, &real_compensation) ||
+        !neumaier_add(cimag(term), &imag_sum, &imag_compensation) ||
+        !neumaier_add(magnitude, &abs_sum, &abs_compensation)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+  }
+  real_sum += real_compensation;
+  imag_sum += imag_compensation;
+  abs_sum += abs_compensation;
+  if (!isfinite(real_sum) || !isfinite(imag_sum) || !isfinite(abs_sum) ||
+      abs_sum < 0.0) {
+    return MVMC_KRYLOV_STATUS_NONFINITE;
+  }
+  result->total = real_sum + I * imag_sum;
+  result->sum_abs = abs_sum;
+  result->cancellation_ratio =
+      abs_sum == 0.0 ? 0.0 : fmin(1.0, cabs(result->total) / abs_sum);
+  if (!isfinite(result->cancellation_ratio)) {
+    memset(result, 0, sizeof(*result));
+    return MVMC_KRYLOV_STATUS_NONFINITE;
+  }
+  result->valid = 1;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus publish_amplitude(
+    const MVMCClassicKrylovAmplitudeCommon *common,
+    const MVMCProjectedAmplitudeResult *projected,
+    double log_projection, uint64_t global_factorization_count,
+    MVMCKrylovAmplitudeResult *result) {
+  const double projection = exp(log_projection);
+  double complex value;
+
+  if (projection == 0.0 || !isfinite(projection)) {
+    return MVMC_KRYLOV_STATUS_NONFINITE;
+  }
+  value = projection * projected->total;
+  if (!isfinite(creal(value)) || !isfinite(cimag(value))) {
+    return MVMC_KRYLOV_STATUS_NONFINITE;
+  }
+#if SIZE_MAX > UINT64_MAX
+  if (projected->regular_count > UINT64_MAX ||
+      projected->near_singular_count > UINT64_MAX ||
+      projected->singular_count > UINT64_MAX ||
+      common->local_qp_count > UINT64_MAX) {
+    return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+  }
+#endif
+  result->value = value;
+  result->total_zero = value == 0.0;
+  result->regular_component_count =
+      (uint64_t)projected->regular_count;
+  result->near_pivot_component_count =
+      (uint64_t)projected->near_singular_count;
+  result->singular_component_count =
+      (uint64_t)projected->singular_count;
+  result->local_factorization_count = (uint64_t)common->local_qp_count;
+  result->global_factorization_count = global_factorization_count;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_classic_krylov_real_amplitude_workspace_create(
+    const MVMCClassicKrylovAmplitudeLayout *layout,
+    const double *slater_elm, const double complex *global_weights,
+    MVMCClassicKrylovRealAmplitudeWorkspace **workspace) {
+  MVMCClassicKrylovRealAmplitudeWorkspace *created = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCKrylovStatus local_status = MVMC_KRYLOV_STATUS_OK;
+  int global_status = (int)MVMC_KRYLOV_STATUS_OK;
+  MVMCPfaffianStatus pf_status;
+  int local_ready = 0;
+  int all_ready = 0;
+  size_t slater_count = 0;
+  size_t slater_bytes = 0;
+  int qp;
+
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (layout == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  pf_status = mvmc_classic_pfaffian_collective_workspace_create(
+      layout->communicator, &collective_workspace);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) return map_create_status(pf_status);
+  created = (MVMCClassicKrylovRealAmplitudeWorkspace *)calloc(
+      1, sizeof(*created));
+  pf_status = mvmc_classic_pfaffian_collective_all_true(
+      collective_workspace, created != NULL, &all_ready);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_ready ||
+      created == NULL) {
+    mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+    free(created);
+    return pf_status == MVMC_PFAFFIAN_STATUS_OK
+               ? MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE
+               : map_create_status(pf_status);
+  }
+  created->common.collective_workspace = collective_workspace;
+  local_status = slater_elm == NULL
+                     ? MVMC_KRYLOV_STATUS_INVALID_ARGUMENT
+                     : initialize_common(layout, global_weights,
+                                         &created->common);
+  if (local_status == MVMC_KRYLOV_STATUS_OK) {
+    for (qp = 0; qp < layout->qp_total; ++qp) {
+      if (cimag(global_weights[qp]) != 0.0) {
+        local_status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+      }
+    }
+  }
+  if (mvmc_classic_pfaffian_collective_max_int(
+          collective_workspace, (int)local_status, &global_status) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    mvmc_classic_krylov_real_amplitude_workspace_destroy(created);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    mvmc_classic_krylov_real_amplitude_workspace_destroy(created);
+    return (MVMCKrylovStatus)global_status;
+  }
+  local_ready =
+      checked_multiply((size_t)created->common.qp_total,
+                       created->common.slater_matrix_count, &slater_count) &&
+      checked_multiply(slater_count, sizeof(*created->slater_elm),
+                       &slater_bytes) &&
+      allocate_common(&created->common);
+  if (local_ready) {
+    created->slater_elm = (double *)malloc(slater_bytes);
+    created->matrix = (double *)malloc(
+        created->common.matrix_count * sizeof(*created->matrix));
+    local_ready = created->slater_elm != NULL && created->matrix != NULL;
+  }
+  if (local_ready) {
+    pf_status = mvmc_absolute_pfaffian_real_value_workspace_create(
+        created->common.nsize, &created->value_workspace);
+    local_ready = pf_status == MVMC_PFAFFIAN_STATUS_OK;
+  }
+  pf_status = mvmc_classic_pfaffian_collective_all_true(
+      created->common.collective_workspace, local_ready, &all_ready);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_ready) {
+    mvmc_classic_krylov_real_amplitude_workspace_destroy(created);
+    return pf_status != MVMC_PFAFFIAN_STATUS_OK
+               ? map_create_status(pf_status)
+               : MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+  pf_status = audit_static_binding(
+      &created->common, 0, slater_elm, slater_bytes, global_weights);
+  if (pf_status == MVMC_PFAFFIAN_STATUS_OK) {
+    pf_status = audit_qp_partition(&created->common);
+  }
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) {
+    mvmc_classic_krylov_real_amplitude_workspace_destroy(created);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  memcpy(created->slater_elm, slater_elm, slater_bytes);
+  memcpy(created->common.global_weights, global_weights,
+         (size_t)created->common.qp_total *
+             sizeof(*created->common.global_weights));
+  *workspace = created;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+void mvmc_classic_krylov_real_amplitude_workspace_destroy(
+    MVMCClassicKrylovRealAmplitudeWorkspace *workspace) {
+  if (workspace == NULL) return;
+  mvmc_absolute_pfaffian_real_value_workspace_destroy(
+      workspace->value_workspace);
+  free(workspace->matrix);
+  free(workspace->slater_elm);
+  destroy_common(&workspace->common);
+  free(workspace);
+}
+
+size_t mvmc_classic_krylov_real_amplitude_workspace_bytes(
+    const MVMCClassicKrylovRealAmplitudeWorkspace *workspace) {
+  size_t bytes;
+  size_t item;
+
+  if (workspace == NULL) return 0;
+  bytes = sizeof(*workspace);
+#define ADD_REAL_BYTES(count, type)                                      \
+  do {                                                                    \
+    if (!checked_multiply((count), sizeof(type), &item) ||                \
+        !checked_add(bytes, item, &bytes)) return 0;                       \
+  } while (0)
+  ADD_REAL_BYTES((size_t)workspace->common.nsize, int);
+  ADD_REAL_BYTES(workspace->common.orbital_count, int);
+  ADD_REAL_BYTES((size_t)workspace->common.qp_total, double complex);
+  ADD_REAL_BYTES(workspace->common.local_qp_count,
+                 MVMCAbsolutePfaffianValueResult);
+  ADD_REAL_BYTES((size_t)workspace->common.qp_total,
+                 MVMCAbsolutePfaffianValueResult);
+  ADD_REAL_BYTES((size_t)workspace->common.qp_total *
+                     workspace->common.slater_matrix_count,
+                 double);
+  ADD_REAL_BYTES(workspace->common.matrix_count, double);
+#undef ADD_REAL_BYTES
+  if (!checked_add(bytes,
+                   mvmc_absolute_pfaffian_real_value_workspace_bytes(
+                       workspace->value_workspace),
+                   &bytes) ||
+      !checked_add(bytes,
+                   mvmc_classic_pfaffian_collective_workspace_bytes(
+                       workspace->common.collective_workspace),
+                   &bytes)) {
+    return 0;
+  }
+  return bytes;
+}
+
+MVMCKrylovStatus mvmc_classic_krylov_complex_amplitude_workspace_create(
+    const MVMCClassicKrylovAmplitudeLayout *layout,
+    const double complex *slater_elm,
+    const double complex *global_weights,
+    MVMCClassicKrylovComplexAmplitudeWorkspace **workspace) {
+  MVMCClassicKrylovComplexAmplitudeWorkspace *created = NULL;
+  MVMCClassicPfaffianCollectiveWorkspace *collective_workspace = NULL;
+  MVMCKrylovStatus local_status = MVMC_KRYLOV_STATUS_OK;
+  int global_status = (int)MVMC_KRYLOV_STATUS_OK;
+  MVMCPfaffianStatus pf_status;
+  int local_ready = 0;
+  int all_ready = 0;
+  size_t slater_count = 0;
+  size_t slater_bytes = 0;
+
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (layout == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  pf_status = mvmc_classic_pfaffian_collective_workspace_create(
+      layout->communicator, &collective_workspace);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) return map_create_status(pf_status);
+  created = (MVMCClassicKrylovComplexAmplitudeWorkspace *)calloc(
+      1, sizeof(*created));
+  pf_status = mvmc_classic_pfaffian_collective_all_true(
+      collective_workspace, created != NULL, &all_ready);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_ready ||
+      created == NULL) {
+    mvmc_classic_pfaffian_collective_workspace_destroy(collective_workspace);
+    free(created);
+    return pf_status == MVMC_PFAFFIAN_STATUS_OK
+               ? MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE
+               : map_create_status(pf_status);
+  }
+  created->common.collective_workspace = collective_workspace;
+  local_status = slater_elm == NULL
+                     ? MVMC_KRYLOV_STATUS_INVALID_ARGUMENT
+                     : initialize_common(layout, global_weights,
+                                         &created->common);
+  if (mvmc_classic_pfaffian_collective_max_int(
+          collective_workspace, (int)local_status, &global_status) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    mvmc_classic_krylov_complex_amplitude_workspace_destroy(created);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    mvmc_classic_krylov_complex_amplitude_workspace_destroy(created);
+    return (MVMCKrylovStatus)global_status;
+  }
+  local_ready =
+      checked_multiply((size_t)created->common.qp_total,
+                       created->common.slater_matrix_count, &slater_count) &&
+      checked_multiply(slater_count, sizeof(*created->slater_elm),
+                       &slater_bytes) &&
+      allocate_common(&created->common);
+  if (local_ready) {
+    created->slater_elm =
+        (double complex *)malloc(slater_bytes);
+    created->matrix = (double complex *)malloc(
+        created->common.matrix_count * sizeof(*created->matrix));
+    local_ready = created->slater_elm != NULL && created->matrix != NULL;
+  }
+  if (local_ready) {
+    pf_status = mvmc_absolute_pfaffian_complex_value_workspace_create(
+        created->common.nsize, &created->value_workspace);
+    local_ready = pf_status == MVMC_PFAFFIAN_STATUS_OK;
+  }
+  pf_status = mvmc_classic_pfaffian_collective_all_true(
+      created->common.collective_workspace, local_ready, &all_ready);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_ready) {
+    mvmc_classic_krylov_complex_amplitude_workspace_destroy(created);
+    return pf_status != MVMC_PFAFFIAN_STATUS_OK
+               ? map_create_status(pf_status)
+               : MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+  pf_status = audit_static_binding(
+      &created->common, 1, slater_elm, slater_bytes, global_weights);
+  if (pf_status == MVMC_PFAFFIAN_STATUS_OK) {
+    pf_status = audit_qp_partition(&created->common);
+  }
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) {
+    mvmc_classic_krylov_complex_amplitude_workspace_destroy(created);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  memcpy(created->slater_elm, slater_elm, slater_bytes);
+  memcpy(created->common.global_weights, global_weights,
+         (size_t)created->common.qp_total *
+             sizeof(*created->common.global_weights));
+  *workspace = created;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+void mvmc_classic_krylov_complex_amplitude_workspace_destroy(
+    MVMCClassicKrylovComplexAmplitudeWorkspace *workspace) {
+  if (workspace == NULL) return;
+  mvmc_absolute_pfaffian_complex_value_workspace_destroy(
+      workspace->value_workspace);
+  free(workspace->matrix);
+  free(workspace->slater_elm);
+  destroy_common(&workspace->common);
+  free(workspace);
+}
+
+size_t mvmc_classic_krylov_complex_amplitude_workspace_bytes(
+    const MVMCClassicKrylovComplexAmplitudeWorkspace *workspace) {
+  size_t bytes;
+  size_t item;
+
+  if (workspace == NULL) return 0;
+  bytes = sizeof(*workspace);
+#define ADD_COMPLEX_BYTES(count, type)                                   \
+  do {                                                                    \
+    if (!checked_multiply((count), sizeof(type), &item) ||                \
+        !checked_add(bytes, item, &bytes)) return 0;                       \
+  } while (0)
+  ADD_COMPLEX_BYTES((size_t)workspace->common.nsize, int);
+  ADD_COMPLEX_BYTES(workspace->common.orbital_count, int);
+  ADD_COMPLEX_BYTES((size_t)workspace->common.qp_total, double complex);
+  ADD_COMPLEX_BYTES(workspace->common.local_qp_count,
+                    MVMCAbsolutePfaffianValueResult);
+  ADD_COMPLEX_BYTES((size_t)workspace->common.qp_total,
+                    MVMCAbsolutePfaffianValueResult);
+  ADD_COMPLEX_BYTES((size_t)workspace->common.qp_total *
+                        workspace->common.slater_matrix_count,
+                    double complex);
+  ADD_COMPLEX_BYTES(workspace->common.matrix_count, double complex);
+#undef ADD_COMPLEX_BYTES
+  if (!checked_add(bytes,
+                   mvmc_absolute_pfaffian_complex_value_workspace_bytes(
+                       workspace->value_workspace),
+                   &bytes) ||
+      !checked_add(bytes,
+                   mvmc_classic_pfaffian_collective_workspace_bytes(
+                       workspace->common.collective_workspace),
+                   &bytes)) {
+    return 0;
+  }
+  return bytes;
+}
+
+MVMCKrylovStatus mvmc_classic_krylov_real_amplitude(
+    const uint64_t *configuration_words, size_t word_count,
+    void *context, MVMCKrylovAmplitudeResult *result) {
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace =
+      (MVMCClassicKrylovRealAmplitudeWorkspace *)context;
+  MVMCClassicKrylovAmplitudeCommon *common;
+  MVMCProjectedAmplitudeResult projected;
+  MVMCPfaffianStatus local_status = MVMC_PFAFFIAN_STATUS_OK;
+  MVMCPfaffianStatus pf_status;
+  MVMCKrylovStatus status = MVMC_KRYLOV_STATUS_OK;
+  double log_projection = 0.0;
+  uint64_t local_factorizations = 0;
+  uint64_t global_factorizations = 0;
+  size_t local_qp;
+  int all_equal = 0;
+  int all_valid = 0;
+  int global_status = 0;
+
+  if (result == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  memset(result, 0, sizeof(*result));
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  common = &workspace->common;
+  pf_status = mvmc_classic_pfaffian_collective_all_equal_u64(
+      common->collective_workspace, configuration_words, word_count,
+      &all_equal);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_equal) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  pf_status = mvmc_classic_pfaffian_collective_all_true(
+      common->collective_workspace,
+      build_occupation(common, configuration_words, word_count), &all_valid);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_valid) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  status = projection_log_value(common, &log_projection);
+  pf_status = mvmc_classic_pfaffian_collective_max_int(
+      common->collective_workspace, (int)status, &global_status);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    return (MVMCKrylovStatus)global_status;
+  }
+  for (local_qp = 0; local_qp < common->local_qp_count; ++local_qp) {
+    const int global_qp = common->qp_start + (int)local_qp;
+    local_status = mvmc_classic_pfaffian_build_real_matrix(
+        workspace->slater_elm +
+            (size_t)global_qp * common->slater_matrix_count,
+        (int)common->site_count, common->nsize, common->ele_idx,
+        workspace->matrix);
+    if (local_status == MVMC_PFAFFIAN_STATUS_OK) {
+      ++local_factorizations;
+      local_status = mvmc_absolute_pfaffian_real_value_with_workspace(
+          workspace->value_workspace, workspace->matrix, common->nsize,
+          common->nsize, common->scaled_pivot_tolerance,
+          &common->components[local_qp]);
+    }
+    if (local_status != MVMC_PFAFFIAN_STATUS_OK) {
+      status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+      break;
+    }
+    if (cimag(common->components[local_qp].pfaffian) != 0.0 ||
+        common->components[local_qp].state ==
+            MVMC_PFAFFIAN_VALUE_INVALID) {
+      status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+      break;
+    }
+    if (common->components[local_qp].state ==
+        MVMC_PFAFFIAN_VALUE_NONFINITE) {
+      status = MVMC_KRYLOV_STATUS_NONFINITE;
+      break;
+    }
+    if (common->components[local_qp].state !=
+            MVMC_PFAFFIAN_VALUE_WELL_PIVOTED &&
+        common->components[local_qp].state !=
+            MVMC_PFAFFIAN_VALUE_NEAR_PIVOT &&
+        common->components[local_qp].state !=
+            MVMC_PFAFFIAN_VALUE_SINGULAR) {
+      status = MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+      break;
+    }
+  }
+  if (mvmc_classic_pfaffian_collective_max_int(
+          common->collective_workspace, (int)status, &global_status) !=
+          MVMC_PFAFFIAN_STATUS_OK ||
+      mvmc_classic_pfaffian_collective_sum_u64(
+          common->collective_workspace, local_factorizations,
+          &global_factorizations) != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    return (MVMCKrylovStatus)global_status;
+  }
+  if (global_factorizations != (uint64_t)common->qp_total) {
+    return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+  }
+  pf_status = mvmc_classic_pfaffian_collective_gather_value_components(
+      common->collective_workspace, common->components,
+      common->local_qp_count, common->qp_total, common->qp_start,
+      common->qp_end, common->global_components);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  status = deterministic_projected_amplitude(common, &projected);
+  if (mvmc_classic_pfaffian_collective_max_int(
+          common->collective_workspace, (int)status, &global_status) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    return (MVMCKrylovStatus)global_status;
+  }
+  return publish_amplitude(common, &projected, log_projection,
+                           global_factorizations, result);
+}
+
+MVMCKrylovStatus mvmc_classic_krylov_complex_amplitude(
+    const uint64_t *configuration_words, size_t word_count,
+    void *context, MVMCKrylovAmplitudeResult *result) {
+  MVMCClassicKrylovComplexAmplitudeWorkspace *workspace =
+      (MVMCClassicKrylovComplexAmplitudeWorkspace *)context;
+  MVMCClassicKrylovAmplitudeCommon *common;
+  MVMCProjectedAmplitudeResult projected;
+  MVMCPfaffianStatus local_status = MVMC_PFAFFIAN_STATUS_OK;
+  MVMCPfaffianStatus pf_status;
+  MVMCKrylovStatus status = MVMC_KRYLOV_STATUS_OK;
+  double log_projection = 0.0;
+  uint64_t local_factorizations = 0;
+  uint64_t global_factorizations = 0;
+  size_t local_qp;
+  int all_equal = 0;
+  int all_valid = 0;
+  int global_status = 0;
+
+  if (result == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  memset(result, 0, sizeof(*result));
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  common = &workspace->common;
+  pf_status = mvmc_classic_pfaffian_collective_all_equal_u64(
+      common->collective_workspace, configuration_words, word_count,
+      &all_equal);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_equal) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  pf_status = mvmc_classic_pfaffian_collective_all_true(
+      common->collective_workspace,
+      build_occupation(common, configuration_words, word_count), &all_valid);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK || !all_valid) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  status = projection_log_value(common, &log_projection);
+  pf_status = mvmc_classic_pfaffian_collective_max_int(
+      common->collective_workspace, (int)status, &global_status);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    return (MVMCKrylovStatus)global_status;
+  }
+  for (local_qp = 0; local_qp < common->local_qp_count; ++local_qp) {
+    const int global_qp = common->qp_start + (int)local_qp;
+    local_status = mvmc_classic_pfaffian_build_complex_matrix(
+        workspace->slater_elm +
+            (size_t)global_qp * common->slater_matrix_count,
+        (int)common->site_count, common->nsize, common->ele_idx,
+        workspace->matrix);
+    if (local_status == MVMC_PFAFFIAN_STATUS_OK) {
+      ++local_factorizations;
+      local_status = mvmc_absolute_pfaffian_complex_value_with_workspace(
+          workspace->value_workspace, workspace->matrix, common->nsize,
+          common->nsize, common->scaled_pivot_tolerance,
+          &common->components[local_qp]);
+    }
+    if (local_status != MVMC_PFAFFIAN_STATUS_OK) {
+      status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+      break;
+    }
+    if (common->components[local_qp].state ==
+        MVMC_PFAFFIAN_VALUE_NONFINITE) {
+      status = MVMC_KRYLOV_STATUS_NONFINITE;
+      break;
+    }
+    if (common->components[local_qp].state !=
+            MVMC_PFAFFIAN_VALUE_WELL_PIVOTED &&
+        common->components[local_qp].state !=
+            MVMC_PFAFFIAN_VALUE_NEAR_PIVOT &&
+        common->components[local_qp].state !=
+            MVMC_PFAFFIAN_VALUE_SINGULAR) {
+      status = MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+      break;
+    }
+  }
+  if (mvmc_classic_pfaffian_collective_max_int(
+          common->collective_workspace, (int)status, &global_status) !=
+          MVMC_PFAFFIAN_STATUS_OK ||
+      mvmc_classic_pfaffian_collective_sum_u64(
+          common->collective_workspace, local_factorizations,
+          &global_factorizations) != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    return (MVMCKrylovStatus)global_status;
+  }
+  if (global_factorizations != (uint64_t)common->qp_total) {
+    return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+  }
+  pf_status = mvmc_classic_pfaffian_collective_gather_value_components(
+      common->collective_workspace, common->components,
+      common->local_qp_count, common->qp_total, common->qp_start,
+      common->qp_end, common->global_components);
+  if (pf_status != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  status = deterministic_projected_amplitude(common, &projected);
+  if (mvmc_classic_pfaffian_collective_max_int(
+          common->collective_workspace, (int)status, &global_status) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    return (MVMCKrylovStatus)global_status;
+  }
+  return publish_amplitude(common, &projected, log_projection,
+                           global_factorizations, result);
+}
+
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */

--- a/src/mVMC/classic_krylov_model.c
+++ b/src/mVMC/classic_krylov_model.c
@@ -1,0 +1,838 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_krylov_model.h"
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct MVMCClassicKrylovModelWorkspace {
+  MVMCKrylovFockModel model;
+  MVMCKrylovHamiltonianTerm *terms;
+  MVMCKrylovFermionOperator *operators;
+  size_t allocated_bytes;
+};
+
+typedef struct {
+  int values[12];
+} RawMetadata;
+
+typedef struct {
+  MVMCClassicKrylovTransfer *transfers;
+  MVMCClassicKrylovSiteCoupling *coulomb_intra;
+  MVMCClassicKrylovPairCoupling *coulomb_inter;
+  MVMCClassicKrylovPairCoupling *hund;
+  MVMCClassicKrylovPairCoupling *exchange;
+} RawCopies;
+
+static int checked_multiply(size_t left, size_t right, size_t *product) {
+  if (product == NULL || (left != 0 && right > SIZE_MAX / left)) return 0;
+  *product = left * right;
+  return 1;
+}
+
+static int checked_add(size_t left, size_t right, size_t *sum) {
+  if (sum == NULL || right > SIZE_MAX - left) return 0;
+  *sum = left + right;
+  return 1;
+}
+
+static int valid_site(int site, int site_count) {
+  return site >= 0 && site < site_count;
+}
+
+static int valid_real(double value) {
+  return isfinite(value);
+}
+
+static int valid_complex(double complex value) {
+  return isfinite(creal(value)) && isfinite(cimag(value));
+}
+
+static MVMCKrylovStatus validate_root_raw(
+    const MVMCClassicKrylovRawModel *raw) {
+  int spin_changing_transfer = 0;
+  int index;
+
+  if (raw == NULL || raw->site_count <= 0 ||
+      raw->site_count > INT_MAX / 2 || raw->up_electron_count <= 0 ||
+      raw->up_electron_count != raw->down_electron_count ||
+      raw->up_electron_count > raw->site_count ||
+      (raw->pure_spin != 0 && raw->pure_spin != 1) ||
+      (raw->pure_spin &&
+       raw->up_electron_count + raw->down_electron_count !=
+           raw->site_count) ||
+      raw->transfer_count < 0 || raw->coulomb_intra_count < 0 ||
+      raw->coulomb_inter_count < 0 || raw->hund_count < 0 ||
+      raw->exchange_count < 0 || raw->pair_hopping_count < 0 ||
+      raw->inter_all_count < 0 || raw->nbody_inter_all_count < 0) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if ((raw->transfer_count != 0 && raw->transfers == NULL) ||
+      (raw->coulomb_intra_count != 0 && raw->coulomb_intra == NULL) ||
+      (raw->coulomb_inter_count != 0 && raw->coulomb_inter == NULL) ||
+      (raw->hund_count != 0 && raw->hund == NULL) ||
+      (raw->exchange_count != 0 && raw->exchange == NULL)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  for (index = 0; index < raw->transfer_count; ++index) {
+    const MVMCClassicKrylovTransfer *transfer = raw->transfers + index;
+    if (!valid_site(transfer->output_site, raw->site_count) ||
+        !valid_site(transfer->input_site, raw->site_count) ||
+        (transfer->output_spin != 0 && transfer->output_spin != 1) ||
+        (transfer->input_spin != 0 && transfer->input_spin != 1) ||
+        !valid_complex(transfer->coefficient)) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+    if (transfer->output_spin != transfer->input_spin) {
+      spin_changing_transfer = 1;
+    }
+  }
+  for (index = 0; index < raw->coulomb_intra_count; ++index) {
+    if (!valid_site(raw->coulomb_intra[index].site, raw->site_count) ||
+        !valid_real(raw->coulomb_intra[index].coefficient)) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+#define VALIDATE_PAIRS(field, count)                                      \
+  do {                                                                     \
+    for (index = 0; index < (count); ++index) {                            \
+      if (!valid_site((field)[index].first_site, raw->site_count) ||       \
+          !valid_site((field)[index].second_site, raw->site_count) ||      \
+          !valid_real((field)[index].coefficient)) {                       \
+        return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;                        \
+      }                                                                    \
+    }                                                                      \
+  } while (0)
+  VALIDATE_PAIRS(raw->coulomb_inter, raw->coulomb_inter_count);
+  VALIDATE_PAIRS(raw->hund, raw->hund_count);
+  VALIDATE_PAIRS(raw->exchange, raw->exchange_count);
+#undef VALIDATE_PAIRS
+  if (spin_changing_transfer || raw->pair_hopping_count != 0 ||
+      raw->inter_all_count != 0 || raw->nbody_inter_all_count != 0 ||
+      (!raw->pure_spin && raw->exchange_count != 0) ||
+      (raw->pure_spin &&
+       (raw->transfer_count != 0 || raw->coulomb_intra_count != 0 ||
+        raw->coulomb_inter_count != 0))) {
+    return MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL;
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static void metadata_from_raw(const MVMCClassicKrylovRawModel *raw,
+                              RawMetadata *metadata) {
+  metadata->values[0] = raw->site_count;
+  metadata->values[1] = raw->up_electron_count;
+  metadata->values[2] = raw->down_electron_count;
+  metadata->values[3] = raw->pure_spin;
+  metadata->values[4] = raw->transfer_count;
+  metadata->values[5] = raw->coulomb_intra_count;
+  metadata->values[6] = raw->coulomb_inter_count;
+  metadata->values[7] = raw->hund_count;
+  metadata->values[8] = raw->exchange_count;
+  metadata->values[9] = raw->pair_hopping_count;
+  metadata->values[10] = raw->inter_all_count;
+  metadata->values[11] = raw->nbody_inter_all_count;
+}
+
+static void raw_from_metadata(const RawMetadata *metadata,
+                              MVMCClassicKrylovRawModel *raw,
+                              const RawCopies *copies) {
+  memset(raw, 0, sizeof(*raw));
+  raw->site_count = metadata->values[0];
+  raw->up_electron_count = metadata->values[1];
+  raw->down_electron_count = metadata->values[2];
+  raw->pure_spin = metadata->values[3];
+  raw->transfer_count = metadata->values[4];
+  raw->transfers = copies->transfers;
+  raw->coulomb_intra_count = metadata->values[5];
+  raw->coulomb_intra = copies->coulomb_intra;
+  raw->coulomb_inter_count = metadata->values[6];
+  raw->coulomb_inter = copies->coulomb_inter;
+  raw->hund_count = metadata->values[7];
+  raw->hund = copies->hund;
+  raw->exchange_count = metadata->values[8];
+  raw->exchange = copies->exchange;
+  raw->pair_hopping_count = metadata->values[9];
+  raw->inter_all_count = metadata->values[10];
+  raw->nbody_inter_all_count = metadata->values[11];
+}
+
+static int allocate_array(int count, size_t item_size, void **array) {
+  size_t bytes;
+  *array = NULL;
+  if (count == 0) return 1;
+  if (count < 0 || !checked_multiply((size_t)count, item_size, &bytes)) {
+    return 0;
+  }
+  *array = malloc(bytes);
+  return *array != NULL;
+}
+
+static int allocate_raw_copies(const RawMetadata *metadata,
+                               RawCopies *copies) {
+  memset(copies, 0, sizeof(*copies));
+  return allocate_array(metadata->values[4], sizeof(*copies->transfers),
+                        (void **)&copies->transfers) &&
+         allocate_array(metadata->values[5], sizeof(*copies->coulomb_intra),
+                        (void **)&copies->coulomb_intra) &&
+         allocate_array(metadata->values[6], sizeof(*copies->coulomb_inter),
+                        (void **)&copies->coulomb_inter) &&
+         allocate_array(metadata->values[7], sizeof(*copies->hund),
+                        (void **)&copies->hund) &&
+         allocate_array(metadata->values[8], sizeof(*copies->exchange),
+                        (void **)&copies->exchange);
+}
+
+static void free_raw_copies(RawCopies *copies) {
+  if (copies == NULL) return;
+  free(copies->exchange);
+  free(copies->hund);
+  free(copies->coulomb_inter);
+  free(copies->coulomb_intra);
+  free(copies->transfers);
+  memset(copies, 0, sizeof(*copies));
+}
+
+#ifdef _mpi_use
+static int broadcast_bytes(void *data, size_t bytes,
+                           MVMCClassicPfaffianCommunicator communicator) {
+  unsigned char *position = (unsigned char *)data;
+  size_t offset = 0;
+
+  while (offset < bytes) {
+    const size_t remaining = bytes - offset;
+    const int count = remaining > (size_t)INT_MAX ? INT_MAX : (int)remaining;
+    if (MPI_Bcast(position + offset, count, MPI_BYTE, 0, communicator) !=
+        MPI_SUCCESS) {
+      return 0;
+    }
+    offset += (size_t)count;
+  }
+  return 1;
+}
+#endif
+
+static int copy_or_broadcast_array(void *destination, const void *root_source,
+                                   int count, size_t item_size,
+                                   int rank,
+                                   MVMCClassicPfaffianCommunicator communicator) {
+  size_t bytes;
+  if (count == 0) return 1;
+  if (!checked_multiply((size_t)count, item_size, &bytes)) return 0;
+  if (destination == NULL) return 0;
+  if (rank == 0 && root_source == NULL) return 0;
+  if (rank == 0) memcpy(destination, root_source, bytes);
+#ifdef _mpi_use
+  return broadcast_bytes(destination, bytes, communicator);
+#else
+  (void)communicator;
+  return 1;
+#endif
+}
+
+static int transfer_key_compare(const void *left_pointer,
+                                const void *right_pointer) {
+  const MVMCClassicKrylovTransfer *left =
+      (const MVMCClassicKrylovTransfer *)left_pointer;
+  const MVMCClassicKrylovTransfer *right =
+      (const MVMCClassicKrylovTransfer *)right_pointer;
+#define CMP_FIELD(field)                  \
+  do {                                    \
+    if (left->field < right->field) return -1; \
+    if (left->field > right->field) return 1;  \
+  } while (0)
+  CMP_FIELD(output_site);
+  CMP_FIELD(output_spin);
+  CMP_FIELD(input_site);
+  CMP_FIELD(input_spin);
+#undef CMP_FIELD
+  if (creal(left->coefficient) < creal(right->coefficient)) return -1;
+  if (creal(left->coefficient) > creal(right->coefficient)) return 1;
+  if (cimag(left->coefficient) < cimag(right->coefficient)) return -1;
+  if (cimag(left->coefficient) > cimag(right->coefficient)) return 1;
+  return 0;
+}
+
+static int transfer_same_key(const MVMCClassicKrylovTransfer *left,
+                             const MVMCClassicKrylovTransfer *right) {
+  return left->output_site == right->output_site &&
+         left->output_spin == right->output_spin &&
+         left->input_site == right->input_site &&
+         left->input_spin == right->input_spin;
+}
+
+static int site_compare(const void *left_pointer, const void *right_pointer) {
+  const MVMCClassicKrylovSiteCoupling *left =
+      (const MVMCClassicKrylovSiteCoupling *)left_pointer;
+  const MVMCClassicKrylovSiteCoupling *right =
+      (const MVMCClassicKrylovSiteCoupling *)right_pointer;
+  if (left->site < right->site) return -1;
+  if (left->site > right->site) return 1;
+  if (left->coefficient < right->coefficient) return -1;
+  if (left->coefficient > right->coefficient) return 1;
+  return 0;
+}
+
+static int pair_compare(const void *left_pointer, const void *right_pointer) {
+  const MVMCClassicKrylovPairCoupling *left =
+      (const MVMCClassicKrylovPairCoupling *)left_pointer;
+  const MVMCClassicKrylovPairCoupling *right =
+      (const MVMCClassicKrylovPairCoupling *)right_pointer;
+  if (left->first_site < right->first_site) return -1;
+  if (left->first_site > right->first_site) return 1;
+  if (left->second_site < right->second_site) return -1;
+  if (left->second_site > right->second_site) return 1;
+  if (left->coefficient < right->coefficient) return -1;
+  if (left->coefficient > right->coefficient) return 1;
+  return 0;
+}
+
+static int add_real(double value, double *sum, double *compensation) {
+  const double updated = *sum + value;
+  if (!isfinite(value) || !isfinite(updated)) return 0;
+  if (fabs(*sum) >= fabs(value)) {
+    *compensation += (*sum - updated) + value;
+  } else {
+    *compensation += (value - updated) + *sum;
+  }
+  if (!isfinite(*compensation)) return 0;
+  *sum = updated;
+  return 1;
+}
+
+static MVMCKrylovStatus compact_transfers(MVMCClassicKrylovTransfer *values,
+                                          int *count) {
+  int input = 0;
+  int output = 0;
+  if (*count == 0) return MVMC_KRYLOV_STATUS_OK;
+  qsort(values, (size_t)*count, sizeof(*values), transfer_key_compare);
+  while (input < *count) {
+    const MVMCClassicKrylovTransfer key = values[input];
+    double real_sum = 0.0, real_compensation = 0.0;
+    double imag_sum = 0.0, imag_compensation = 0.0;
+    do {
+      if (!add_real(creal(values[input].coefficient), &real_sum,
+                    &real_compensation) ||
+          !add_real(cimag(values[input].coefficient), &imag_sum,
+                    &imag_compensation)) {
+        return MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      ++input;
+    } while (input < *count && transfer_same_key(&key, values + input));
+    real_sum += real_compensation;
+    imag_sum += imag_compensation;
+    if (!isfinite(real_sum) || !isfinite(imag_sum)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    if (real_sum != 0.0 || imag_sum != 0.0) {
+      values[output] = key;
+      values[output].coefficient = real_sum + I * imag_sum;
+      ++output;
+    }
+  }
+  *count = output;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus compact_sites(MVMCClassicKrylovSiteCoupling *values,
+                                      int *count) {
+  int input = 0;
+  int output = 0;
+  if (*count == 0) return MVMC_KRYLOV_STATUS_OK;
+  qsort(values, (size_t)*count, sizeof(*values), site_compare);
+  while (input < *count) {
+    const int site = values[input].site;
+    double sum = 0.0, compensation = 0.0;
+    do {
+      if (!add_real(values[input].coefficient, &sum, &compensation)) {
+        return MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      ++input;
+    } while (input < *count && values[input].site == site);
+    sum += compensation;
+    if (!isfinite(sum)) return MVMC_KRYLOV_STATUS_NONFINITE;
+    if (sum != 0.0) {
+      values[output].site = site;
+      values[output].coefficient = sum;
+      ++output;
+    }
+  }
+  *count = output;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus compact_pairs(MVMCClassicKrylovPairCoupling *values,
+                                      int *count) {
+  int index;
+  int input = 0;
+  int output = 0;
+  if (*count == 0) return MVMC_KRYLOV_STATUS_OK;
+  for (index = 0; index < *count; ++index) {
+    if (values[index].second_site < values[index].first_site) {
+      const int temporary = values[index].first_site;
+      values[index].first_site = values[index].second_site;
+      values[index].second_site = temporary;
+    }
+  }
+  qsort(values, (size_t)*count, sizeof(*values), pair_compare);
+  while (input < *count) {
+    const int first = values[input].first_site;
+    const int second = values[input].second_site;
+    double sum = 0.0, compensation = 0.0;
+    do {
+      if (!add_real(values[input].coefficient, &sum, &compensation)) {
+        return MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      ++input;
+    } while (input < *count && values[input].first_site == first &&
+             values[input].second_site == second);
+    sum += compensation;
+    if (!isfinite(sum)) return MVMC_KRYLOV_STATUS_NONFINITE;
+    if (sum != 0.0) {
+      values[output].first_site = first;
+      values[output].second_site = second;
+      values[output].coefficient = sum;
+      ++output;
+    }
+  }
+  *count = output;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static const MVMCClassicKrylovTransfer *find_transfer(
+    const MVMCClassicKrylovTransfer *values, int count,
+    int output_site, int output_spin, int input_site, int input_spin) {
+  int lower = 0;
+  int upper = count;
+  while (lower < upper) {
+    const int middle = lower + (upper - lower) / 2;
+    const MVMCClassicKrylovTransfer *candidate = values + middle;
+    int relation = 0;
+    if (candidate->output_site != output_site) {
+      relation = candidate->output_site < output_site ? -1 : 1;
+    } else if (candidate->output_spin != output_spin) {
+      relation = candidate->output_spin < output_spin ? -1 : 1;
+    } else if (candidate->input_site != input_site) {
+      relation = candidate->input_site < input_site ? -1 : 1;
+    } else if (candidate->input_spin != input_spin) {
+      relation = candidate->input_spin < input_spin ? -1 : 1;
+    } else {
+      return candidate;
+    }
+    if (relation < 0) {
+      lower = middle + 1;
+    } else {
+      upper = middle;
+    }
+  }
+  return NULL;
+}
+
+static MVMCKrylovStatus validate_hermitian_transfers(
+    const MVMCClassicKrylovTransfer *values, int count) {
+  int index;
+  for (index = 0; index < count; ++index) {
+    const MVMCClassicKrylovTransfer *value = values + index;
+    if (value->output_site == value->input_site &&
+        value->output_spin == value->input_spin) {
+      if (cimag(value->coefficient) != 0.0) {
+        return MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL;
+      }
+    } else {
+      const MVMCClassicKrylovTransfer *reverse = find_transfer(
+          values, count, value->input_site, value->input_spin,
+          value->output_site, value->output_spin);
+      if (reverse == NULL) return MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL;
+      if (value->coefficient != conj(reverse->coefficient)) {
+        return MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL;
+      }
+    }
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static int append_term(MVMCClassicKrylovModelWorkspace *workspace,
+                       size_t *term_index, size_t *operator_index,
+                       size_t term_capacity, size_t operator_capacity,
+                       double complex coefficient,
+                       MVMCClassicKrylovSourceKind source_kind,
+                       size_t source_index,
+                       const size_t *orbitals, size_t orbital_count) {
+  MVMCKrylovHamiltonianTerm *term;
+  size_t index;
+  if (orbital_count != 2 && orbital_count != 4) return 0;
+  if (workspace == NULL || workspace->terms == NULL ||
+      workspace->operators == NULL || term_index == NULL ||
+      operator_index == NULL || *term_index >= term_capacity ||
+      *operator_index > operator_capacity ||
+      orbital_count > operator_capacity - *operator_index) {
+    return 0;
+  }
+  term = workspace->terms + *term_index;
+  term->coefficient = coefficient;
+  term->operator_offset = *operator_index;
+  term->operator_count = orbital_count;
+  term->source_kind = (int)source_kind;
+  term->source_index = source_index;
+  for (index = 0; index < orbital_count; ++index) {
+    workspace->operators[*operator_index + index].kind =
+        (index % 2 == 0) ? MVMC_KRYLOV_FERMION_CREATE
+                         : MVMC_KRYLOV_FERMION_ANNIHILATE;
+    workspace->operators[*operator_index + index].orbital = orbitals[index];
+  }
+  ++*term_index;
+  *operator_index += orbital_count;
+  return 1;
+}
+
+static int append_density(MVMCClassicKrylovModelWorkspace *workspace,
+                          size_t *term_index, size_t *operator_index,
+                          size_t term_capacity, size_t operator_capacity,
+                          double coefficient,
+                          MVMCClassicKrylovSourceKind source_kind,
+                          size_t source_index,
+                          size_t first_orbital, size_t second_orbital) {
+  const size_t orbitals[4] = {first_orbital, first_orbital,
+                              second_orbital, second_orbital};
+  return append_term(workspace, term_index, operator_index,
+                     term_capacity, operator_capacity, coefficient,
+                     source_kind, source_index, orbitals, 4);
+}
+
+static MVMCKrylovStatus build_model(MVMCClassicKrylovRawModel *raw,
+                                    MVMCClassicKrylovModelWorkspace **output) {
+  MVMCClassicKrylovModelWorkspace *workspace = NULL;
+  MVMCKrylovStatus status;
+  size_t term_count = 0;
+  size_t operator_count = 0;
+  size_t term_bytes = 0;
+  size_t operator_bytes = 0;
+  size_t term_index = 0;
+  size_t operator_index = 0;
+  int transfer_count = raw->transfer_count;
+  int intra_count = raw->coulomb_intra_count;
+  int inter_count = raw->coulomb_inter_count;
+  int hund_count = raw->hund_count;
+  int exchange_count = raw->exchange_count;
+  int index;
+
+  *output = NULL;
+  status = compact_transfers((MVMCClassicKrylovTransfer *)raw->transfers,
+                             &transfer_count);
+  if (status == MVMC_KRYLOV_STATUS_OK) {
+    status = compact_sites((MVMCClassicKrylovSiteCoupling *)raw->coulomb_intra,
+                           &intra_count);
+  }
+  if (status == MVMC_KRYLOV_STATUS_OK) {
+    status = compact_pairs((MVMCClassicKrylovPairCoupling *)raw->coulomb_inter,
+                           &inter_count);
+  }
+  if (status == MVMC_KRYLOV_STATUS_OK) {
+    status = compact_pairs((MVMCClassicKrylovPairCoupling *)raw->hund,
+                           &hund_count);
+  }
+  if (status == MVMC_KRYLOV_STATUS_OK) {
+    status = compact_pairs((MVMCClassicKrylovPairCoupling *)raw->exchange,
+                           &exchange_count);
+  }
+  if (status != MVMC_KRYLOV_STATUS_OK) return status;
+  status = validate_hermitian_transfers(raw->transfers, transfer_count);
+  if (status != MVMC_KRYLOV_STATUS_OK) return status;
+
+#define ADD_TERMS(count, multiplier)                                      \
+  do {                                                                     \
+    size_t addition;                                                       \
+    if (!checked_multiply((size_t)(count), (size_t)(multiplier),           \
+                          &addition) ||                                    \
+        !checked_add(term_count, addition, &term_count)) {                 \
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;                          \
+    }                                                                      \
+  } while (0)
+  ADD_TERMS(transfer_count, 1);
+  ADD_TERMS(intra_count, 1);
+  ADD_TERMS(inter_count, 4);
+  ADD_TERMS(hund_count, 2);
+  ADD_TERMS(exchange_count, 2);
+#undef ADD_TERMS
+  if (!checked_multiply((size_t)transfer_count, 2, &operator_count)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+#define ADD_OPERATORS(count, multiplier)                                  \
+  do {                                                                     \
+    size_t addition;                                                       \
+    if (!checked_multiply((size_t)(count), (size_t)(multiplier),           \
+                          &addition) ||                                    \
+        !checked_add(operator_count, addition, &operator_count)) {         \
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;                          \
+    }                                                                      \
+  } while (0)
+  ADD_OPERATORS(intra_count, 4);
+  ADD_OPERATORS(inter_count, 16);
+  ADD_OPERATORS(hund_count, 8);
+  ADD_OPERATORS(exchange_count, 8);
+#undef ADD_OPERATORS
+  if (!checked_multiply(term_count, sizeof(*workspace->terms), &term_bytes) ||
+      !checked_multiply(operator_count, sizeof(*workspace->operators),
+                        &operator_bytes)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  workspace = (MVMCClassicKrylovModelWorkspace *)calloc(1, sizeof(*workspace));
+  if (workspace != NULL && term_count != 0) {
+    workspace->terms =
+        (MVMCKrylovHamiltonianTerm *)calloc(term_count,
+                                            sizeof(*workspace->terms));
+  }
+  if (workspace != NULL && operator_count != 0) {
+    workspace->operators =
+        (MVMCKrylovFermionOperator *)calloc(operator_count,
+                                             sizeof(*workspace->operators));
+  }
+  if (workspace == NULL || (term_count != 0 && workspace->terms == NULL) ||
+      (operator_count != 0 && workspace->operators == NULL)) {
+    mvmc_classic_krylov_model_workspace_destroy(workspace);
+    return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+#define APPEND_OR_FAIL(expression)                                        \
+  do {                                                                    \
+    if (!(expression)) {                                                  \
+      mvmc_classic_krylov_model_workspace_destroy(workspace);             \
+      return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;               \
+    }                                                                     \
+  } while (0)
+  for (index = 0; index < transfer_count; ++index) {
+    const MVMCClassicKrylovTransfer *transfer = raw->transfers + index;
+    const size_t orbitals[2] = {
+        (size_t)transfer->output_site +
+            (size_t)transfer->output_spin * (size_t)raw->site_count,
+        (size_t)transfer->input_site +
+            (size_t)transfer->input_spin * (size_t)raw->site_count};
+    APPEND_OR_FAIL(append_term(
+        workspace, &term_index, &operator_index, term_count, operator_count,
+        -transfer->coefficient, MVMC_CLASSIC_KRYLOV_SOURCE_TRANSFER,
+        (size_t)index, orbitals, 2));
+  }
+  for (index = 0; index < intra_count; ++index) {
+    const size_t site = (size_t)raw->coulomb_intra[index].site;
+    APPEND_OR_FAIL(append_density(
+        workspace, &term_index, &operator_index, term_count, operator_count,
+        raw->coulomb_intra[index].coefficient,
+        MVMC_CLASSIC_KRYLOV_SOURCE_COULOMB_INTRA, (size_t)index, site,
+        site + (size_t)raw->site_count));
+  }
+  for (index = 0; index < inter_count; ++index) {
+    int first_spin, second_spin;
+    for (first_spin = 0; first_spin < 2; ++first_spin) {
+      for (second_spin = 0; second_spin < 2; ++second_spin) {
+        APPEND_OR_FAIL(append_density(
+            workspace, &term_index, &operator_index,
+            term_count, operator_count,
+            raw->coulomb_inter[index].coefficient,
+            MVMC_CLASSIC_KRYLOV_SOURCE_COULOMB_INTER,
+            (size_t)index * 4 + (size_t)(2 * first_spin + second_spin),
+            (size_t)raw->coulomb_inter[index].first_site +
+                (size_t)first_spin * (size_t)raw->site_count,
+            (size_t)raw->coulomb_inter[index].second_site +
+                (size_t)second_spin * (size_t)raw->site_count));
+      }
+    }
+  }
+  for (index = 0; index < hund_count; ++index) {
+    int spin;
+    for (spin = 0; spin < 2; ++spin) {
+      APPEND_OR_FAIL(append_density(
+          workspace, &term_index, &operator_index,
+          term_count, operator_count,
+          -raw->hund[index].coefficient,
+          MVMC_CLASSIC_KRYLOV_SOURCE_HUND,
+          (size_t)index * 2 + (size_t)spin,
+          (size_t)raw->hund[index].first_site +
+              (size_t)spin * (size_t)raw->site_count,
+          (size_t)raw->hund[index].second_site +
+              (size_t)spin * (size_t)raw->site_count));
+    }
+  }
+  for (index = 0; index < exchange_count; ++index) {
+    const size_t first = (size_t)raw->exchange[index].first_site;
+    const size_t second = (size_t)raw->exchange[index].second_site;
+    const size_t up_first = first;
+    const size_t up_second = second;
+    const size_t down_first = first + (size_t)raw->site_count;
+    const size_t down_second = second + (size_t)raw->site_count;
+    const size_t forward[4] = {up_first, up_second,
+                               down_second, down_first};
+    const size_t reverse[4] = {up_second, up_first,
+                               down_first, down_second};
+    APPEND_OR_FAIL(append_term(
+        workspace, &term_index, &operator_index, term_count, operator_count,
+        raw->exchange[index].coefficient,
+        MVMC_CLASSIC_KRYLOV_SOURCE_EXCHANGE,
+        (size_t)index * 2, forward, 4));
+    APPEND_OR_FAIL(append_term(
+        workspace, &term_index, &operator_index, term_count, operator_count,
+        raw->exchange[index].coefficient,
+        MVMC_CLASSIC_KRYLOV_SOURCE_EXCHANGE,
+        (size_t)index * 2 + 1, reverse, 4));
+  }
+#undef APPEND_OR_FAIL
+  if (term_index != term_count || operator_index != operator_count) {
+    mvmc_classic_krylov_model_workspace_destroy(workspace);
+    return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+  }
+  workspace->model.site_count = (size_t)raw->site_count;
+  workspace->model.up_electron_count = (size_t)raw->up_electron_count;
+  workspace->model.down_electron_count = (size_t)raw->down_electron_count;
+  workspace->model.pure_spin = raw->pure_spin;
+  workspace->model.hermitian = 1;
+  workspace->model.terms = workspace->terms;
+  workspace->model.term_count = term_count;
+  workspace->model.operators = workspace->operators;
+  workspace->model.operator_count = operator_count;
+  if (!checked_add(sizeof(*workspace), term_bytes,
+                   &workspace->allocated_bytes) ||
+      !checked_add(workspace->allocated_bytes, operator_bytes,
+                   &workspace->allocated_bytes)) {
+    mvmc_classic_krylov_model_workspace_destroy(workspace);
+    return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+  }
+  *output = workspace;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_classic_krylov_model_workspace_create_from_root(
+    const MVMCClassicKrylovRawModel *raw,
+    MVMCClassicPfaffianCommunicator communicator,
+    MVMCClassicKrylovModelWorkspace **workspace) {
+  MVMCClassicKrylovRawModel local_raw;
+  MVMCClassicKrylovModelWorkspace *created = NULL;
+  RawMetadata metadata;
+  RawCopies copies;
+  MVMCKrylovStatus status = MVMC_KRYLOV_STATUS_OK;
+  int rank = 0;
+  int local_ready;
+  int all_ready;
+  int local_status;
+  int global_status;
+  int broadcast_ok = 1;
+
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  memset(&metadata, 0, sizeof(metadata));
+  memset(&copies, 0, sizeof(copies));
+#ifdef _mpi_use
+  if (communicator == MPI_COMM_NULL ||
+      MPI_Comm_rank(communicator, &rank) != MPI_SUCCESS) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  (void)communicator;
+#endif
+  if (rank == 0) {
+    status = validate_root_raw(raw);
+    if (status == MVMC_KRYLOV_STATUS_OK) metadata_from_raw(raw, &metadata);
+  }
+  local_status = (int)status;
+#ifdef _mpi_use
+  if (MPI_Bcast(&local_status, 1, MPI_INT, 0, communicator) != MPI_SUCCESS ||
+      MPI_Bcast(&metadata, (int)sizeof(metadata), MPI_BYTE, 0, communicator) !=
+          MPI_SUCCESS) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#endif
+  status = (MVMCKrylovStatus)local_status;
+  if (status != MVMC_KRYLOV_STATUS_OK) return status;
+  local_ready = allocate_raw_copies(&metadata, &copies);
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_ready, &all_ready, 1, MPI_INT, MPI_MIN,
+                    communicator) != MPI_SUCCESS) {
+    free_raw_copies(&copies);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  all_ready = local_ready;
+#endif
+  if (!all_ready) {
+    free_raw_copies(&copies);
+    return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+#define COPY_FIELD(field, count_index)                                    \
+  do {                                                                     \
+    const void *root_source = rank == 0 ? (const void *)raw->field : NULL; \
+    if (!copy_or_broadcast_array(                                          \
+            copies.field, root_source, metadata.values[count_index],       \
+            sizeof(*copies.field), rank, communicator)) {                  \
+      broadcast_ok = 0;                                                    \
+    }                                                                      \
+  } while (0)
+  COPY_FIELD(transfers, 4);
+  COPY_FIELD(coulomb_intra, 5);
+  COPY_FIELD(coulomb_inter, 6);
+  COPY_FIELD(hund, 7);
+  COPY_FIELD(exchange, 8);
+#undef COPY_FIELD
+#ifdef _mpi_use
+  if (MPI_Allreduce(&broadcast_ok, &all_ready, 1, MPI_INT, MPI_MIN,
+                    communicator) != MPI_SUCCESS) {
+    free_raw_copies(&copies);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  all_ready = broadcast_ok;
+#endif
+  if (!all_ready) {
+    free_raw_copies(&copies);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  raw_from_metadata(&metadata, &local_raw, &copies);
+  status = build_model(&local_raw, &created);
+  local_status = (int)status;
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_status, &global_status, 1, MPI_INT, MPI_MAX,
+                    communicator) != MPI_SUCCESS) {
+    mvmc_classic_krylov_model_workspace_destroy(created);
+    free_raw_copies(&copies);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  global_status = local_status;
+#endif
+  free_raw_copies(&copies);
+  if (global_status != (int)MVMC_KRYLOV_STATUS_OK) {
+    mvmc_classic_krylov_model_workspace_destroy(created);
+    return (MVMCKrylovStatus)global_status;
+  }
+  *workspace = created;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+void mvmc_classic_krylov_model_workspace_destroy(
+    MVMCClassicKrylovModelWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->operators);
+  free(workspace->terms);
+  free(workspace);
+}
+
+const MVMCKrylovFockModel *mvmc_classic_krylov_model(
+    const MVMCClassicKrylovModelWorkspace *workspace) {
+  return workspace == NULL ? NULL : &workspace->model;
+}
+
+size_t mvmc_classic_krylov_model_workspace_bytes(
+    const MVMCClassicKrylovModelWorkspace *workspace) {
+  return workspace == NULL ? 0 : workspace->allocated_bytes;
+}
+
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */

--- a/src/mVMC/classic_pfaffian_collective.c
+++ b/src/mVMC/classic_pfaffian_collective.c
@@ -192,6 +192,15 @@ void mvmc_classic_pfaffian_collective_workspace_destroy(
   free(workspace);
 }
 
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+size_t mvmc_classic_pfaffian_collective_workspace_bytes(
+    const MVMCClassicPfaffianCollectiveWorkspace *workspace) {
+  if (workspace == NULL || workspace->size <= 0) return 0;
+  return sizeof(*workspace) +
+         (size_t)workspace->size * 3 * sizeof(*workspace->ranges);
+}
+#endif
+
 MVMCPfaffianStatus mvmc_classic_pfaffian_collective_aggregate(
     MVMCClassicPfaffianCollectiveWorkspace *workspace,
     MVMCPfaffianStatus local_status,
@@ -567,7 +576,254 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_true(
   global_valid = local_valid;
   global_true = local_true;
 #endif
-  if (!global_valid) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (!global_valid || all_true == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
   *all_true = global_true;
   return MVMC_PFAFFIAN_STATUS_OK;
 }
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_equal_bytes(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    const void *local_data, size_t byte_count, int *all_equal) {
+  const unsigned char *bytes = (const unsigned char *)local_data;
+  int local_valid;
+  int global_valid;
+
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  local_valid = all_equal != NULL && (byte_count == 0 || local_data != NULL);
+#ifdef _mpi_use
+  {
+    uint64_t local_count = (uint64_t)byte_count;
+    uint64_t minimum_count = 0;
+    uint64_t maximum_count = 0;
+    unsigned char *minimum = NULL;
+    unsigned char *maximum = NULL;
+    const size_t chunk_limit = 1024 * 1024;
+    size_t buffer_size;
+    size_t offset;
+    int allocation_ok;
+    int all_allocation_ok;
+    int equal = 1;
+
+#if SIZE_MAX > UINT64_MAX
+    if (byte_count > UINT64_MAX) local_valid = 0;
+#endif
+    if (MPI_Allreduce(&local_valid, &global_valid, 1, MPI_INT, MPI_MIN,
+                      workspace->communicator) != MPI_SUCCESS ||
+        MPI_Allreduce(&local_count, &minimum_count, 1, MPI_UINT64_T, MPI_MIN,
+                      workspace->communicator) != MPI_SUCCESS ||
+        MPI_Allreduce(&local_count, &maximum_count, 1, MPI_UINT64_T, MPI_MAX,
+                      workspace->communicator) != MPI_SUCCESS) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (!global_valid || minimum_count != maximum_count) {
+      if (all_equal != NULL) *all_equal = 0;
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    buffer_size = byte_count < chunk_limit ? byte_count : chunk_limit;
+    if (buffer_size != 0) {
+      minimum = (unsigned char *)malloc(buffer_size);
+      maximum = (unsigned char *)malloc(buffer_size);
+    }
+    allocation_ok = buffer_size == 0 ||
+                    (minimum != NULL && maximum != NULL);
+    if (MPI_Allreduce(&allocation_ok, &all_allocation_ok, 1, MPI_INT, MPI_MIN,
+                      workspace->communicator) != MPI_SUCCESS) {
+      free(maximum);
+      free(minimum);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (!all_allocation_ok ||
+        (buffer_size != 0 && (minimum == NULL || maximum == NULL))) {
+      free(maximum);
+      free(minimum);
+      return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+    }
+    for (offset = 0; offset < byte_count; offset += buffer_size) {
+      const size_t remaining = byte_count - offset;
+      const int count = (int)(remaining < buffer_size ? remaining
+                                                       : buffer_size);
+      if (MPI_Allreduce(bytes + offset, minimum, count, MPI_UNSIGNED_CHAR,
+                        MPI_MIN, workspace->communicator) != MPI_SUCCESS ||
+          MPI_Allreduce(bytes + offset, maximum, count, MPI_UNSIGNED_CHAR,
+                        MPI_MAX, workspace->communicator) != MPI_SUCCESS) {
+        free(maximum);
+        free(minimum);
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+      }
+      if (memcmp(minimum, maximum, (size_t)count) != 0) equal = 0;
+    }
+    free(maximum);
+    free(minimum);
+    if (all_equal == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    *all_equal = equal;
+  }
+#else
+  global_valid = local_valid;
+  if (!global_valid || all_equal == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  (void)bytes;
+  *all_equal = 1;
+#endif
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_equal_u64(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    const uint64_t *local_values, size_t value_count, int *all_equal) {
+  int local_valid;
+  int global_valid;
+  size_t index;
+  int equal = 1;
+
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  local_valid = all_equal != NULL &&
+                (value_count == 0 || local_values != NULL);
+#ifdef _mpi_use
+  {
+    uint64_t local_count = (uint64_t)value_count;
+    uint64_t minimum_count = 0;
+    uint64_t maximum_count = 0;
+#if SIZE_MAX > UINT64_MAX
+    if (value_count > UINT64_MAX) local_valid = 0;
+#endif
+    if (MPI_Allreduce(&local_valid, &global_valid, 1, MPI_INT, MPI_MIN,
+                      workspace->communicator) != MPI_SUCCESS ||
+        MPI_Allreduce(&local_count, &minimum_count, 1, MPI_UINT64_T, MPI_MIN,
+                      workspace->communicator) != MPI_SUCCESS ||
+        MPI_Allreduce(&local_count, &maximum_count, 1, MPI_UINT64_T, MPI_MAX,
+                      workspace->communicator) != MPI_SUCCESS) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (!global_valid || minimum_count != maximum_count) {
+      if (all_equal != NULL) *all_equal = 0;
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    for (index = 0; index < value_count; ++index) {
+      uint64_t minimum = 0;
+      uint64_t maximum = 0;
+      if (MPI_Allreduce(local_values + index, &minimum, 1, MPI_UINT64_T,
+                        MPI_MIN, workspace->communicator) != MPI_SUCCESS ||
+          MPI_Allreduce(local_values + index, &maximum, 1, MPI_UINT64_T,
+                        MPI_MAX, workspace->communicator) != MPI_SUCCESS) {
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+      }
+      if (minimum != maximum) equal = 0;
+    }
+  }
+#else
+  global_valid = local_valid;
+  (void)local_values;
+  (void)value_count;
+#endif
+  if (!global_valid || all_equal == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  *all_equal = equal;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_sum_u64(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    uint64_t local_value, uint64_t *global_sum) {
+  if (workspace == NULL || workspace->ranges == NULL || global_sum == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_value, global_sum, 1, MPI_UINT64_T, MPI_SUM,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  *global_sum = local_value;
+#endif
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_max_int(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    int local_value, int *global_max) {
+  if (workspace == NULL || workspace->ranges == NULL || global_max == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_value, global_max, 1, MPI_INT, MPI_MAX,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  *global_max = local_value;
+#endif
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus
+mvmc_classic_pfaffian_collective_gather_value_components(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    const MVMCAbsolutePfaffianValueResult *local_components,
+    size_t local_component_count, int qp_total, int qp_start, int qp_end,
+    MVMCAbsolutePfaffianValueResult *global_components) {
+  int local_valid;
+  int global_valid;
+  int global_qp;
+
+  if (workspace == NULL || workspace->ranges == NULL) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  local_valid = qp_total > 0 && qp_start >= 0 && qp_end >= qp_start &&
+                qp_end <= qp_total &&
+                (size_t)(qp_end - qp_start) == local_component_count &&
+                (local_component_count == 0 || local_components != NULL) &&
+                global_components != NULL &&
+                workspace->ranges[(size_t)workspace->rank * 3] == qp_total &&
+                workspace->ranges[(size_t)workspace->rank * 3 + 1] ==
+                    qp_start &&
+                workspace->ranges[(size_t)workspace->rank * 3 + 2] == qp_end;
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_valid, &global_valid, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  global_valid = local_valid;
+#endif
+  if (!global_valid || global_components == NULL ||
+      (local_component_count != 0 && local_components == NULL)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+
+  for (global_qp = 0; global_qp < qp_total; ++global_qp) {
+    int owner = -1;
+    int rank;
+    for (rank = 0; rank < workspace->size; ++rank) {
+      const int *range = workspace->ranges + (size_t)rank * 3;
+      if (global_qp >= range[1] && global_qp < range[2]) {
+        owner = rank;
+        break;
+      }
+    }
+    if (owner < 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    if (workspace->rank == owner) {
+      const size_t local_index = (size_t)(global_qp - qp_start);
+      if (local_components != NULL) {
+        global_components[global_qp] = local_components[local_index];
+      }
+    }
+#ifdef _mpi_use
+    if (MPI_Bcast(global_components + global_qp,
+                  (int)sizeof(*global_components), MPI_BYTE, owner,
+                  workspace->communicator) != MPI_SUCCESS) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+#endif
+  }
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */

--- a/src/mVMC/classic_pfaffian_collective.c
+++ b/src/mVMC/classic_pfaffian_collective.c
@@ -678,7 +678,6 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_equal_u64(
     const uint64_t *local_values, size_t value_count, int *all_equal) {
   int local_valid;
   int global_valid;
-  size_t index;
   int equal = 1;
 
   if (workspace == NULL || workspace->ranges == NULL) {
@@ -688,6 +687,7 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_equal_u64(
                 (value_count == 0 || local_values != NULL);
 #ifdef _mpi_use
   {
+    size_t index;
     uint64_t local_count = (uint64_t)value_count;
     uint64_t minimum_count = 0;
     uint64_t maximum_count = 0;

--- a/src/mVMC/classic_pfaffian_matrix.c
+++ b/src/mVMC/classic_pfaffian_matrix.c
@@ -1,0 +1,77 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_pfaffian_matrix.h"
+
+#include <limits.h>
+#include <stddef.h>
+
+static int valid_layout(int nsite, int nsize, const int *ele_idx) {
+  int index;
+
+  if (nsite <= 0 || nsite > INT_MAX / 2 || nsize <= 0 ||
+      (nsize % 2) != 0 || nsize / 2 > nsite || ele_idx == NULL) {
+    return 0;
+  }
+  for (index = 0; index < nsize; ++index) {
+    if (ele_idx[index] < 0 || ele_idx[index] >= nsite) return 0;
+  }
+  return 1;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_build_real_matrix(
+    const double *slater, int nsite, int nsize, const int *ele_idx,
+    double *matrix) {
+  int ne;
+  int nsite2;
+  int column, row;
+
+  if (slater == NULL || matrix == NULL ||
+      !valid_layout(nsite, nsize, ele_idx)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  ne = nsize / 2;
+  nsite2 = 2 * nsite;
+  for (column = 0; column < nsize; ++column) {
+    const int slater_column = ele_idx[column] + (column / ne) * nsite;
+    for (row = 0; row < nsize; ++row) {
+      const int slater_row = ele_idx[row] + (row / ne) * nsite;
+      matrix[row + (size_t)column * (size_t)nsize] =
+          -slater[(size_t)slater_column * (size_t)nsite2 +
+                  (size_t)slater_row];
+    }
+  }
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_build_complex_matrix(
+    const double complex *slater, int nsite, int nsize,
+    const int *ele_idx, double complex *matrix) {
+  int ne;
+  int nsite2;
+  int column, row;
+
+  if (slater == NULL || matrix == NULL ||
+      !valid_layout(nsite, nsize, ele_idx)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  ne = nsize / 2;
+  nsite2 = 2 * nsite;
+  for (column = 0; column < nsize; ++column) {
+    const int slater_column = ele_idx[column] + (column / ne) * nsite;
+    for (row = 0; row < nsize; ++row) {
+      const int slater_row = ele_idx[row] + (row / ne) * nsite;
+      matrix[row + (size_t)column * (size_t)nsize] =
+          -slater[(size_t)slater_column * (size_t)nsite2 +
+                  (size_t)slater_row];
+    }
+  }
+  return MVMC_PFAFFIAN_STATUS_OK;
+}

--- a/src/mVMC/classic_pfaffian_state.c
+++ b/src/mVMC/classic_pfaffian_state.c
@@ -9,6 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 */
 
 #include "classic_pfaffian_state.h"
+#include "classic_pfaffian_matrix.h"
 
 #include <limits.h>
 #include <math.h>
@@ -319,43 +320,6 @@ void mvmc_classic_pfaffian_complex_workspace_destroy(
   free(workspace);
 }
 
-static void build_real_matrix(const MVMCClassicPfaffianLayout *layout,
-                              const double *slater, const int *ele_idx,
-                              double *matrix) {
-  const int ne = layout->nsize / 2;
-  int column, row;
-
-  for (column = 0; column < layout->nsize; ++column) {
-    const int slater_column =
-        ele_idx[column] + (column / ne) * layout->nsite;
-    for (row = 0; row < layout->nsize; ++row) {
-      const int slater_row = ele_idx[row] + (row / ne) * layout->nsite;
-      matrix[row + (size_t)column * (size_t)layout->nsize] =
-          -slater[(size_t)slater_column * (size_t)layout->nsite2 +
-                  (size_t)slater_row];
-    }
-  }
-}
-
-static void build_complex_matrix(const MVMCClassicPfaffianLayout *layout,
-                                 const double complex *slater,
-                                 const int *ele_idx,
-                                 double complex *matrix) {
-  const int ne = layout->nsize / 2;
-  int column, row;
-
-  for (column = 0; column < layout->nsize; ++column) {
-    const int slater_column =
-        ele_idx[column] + (column / ne) * layout->nsite;
-    for (row = 0; row < layout->nsize; ++row) {
-      const int slater_row = ele_idx[row] + (row / ne) * layout->nsite;
-      matrix[row + (size_t)column * (size_t)layout->nsize] =
-          -slater[(size_t)slater_column * (size_t)layout->nsite2 +
-                  (size_t)slater_row];
-    }
-  }
-}
-
 MVMCPfaffianStatus mvmc_classic_pfaffian_real_prepare(
     MVMCClassicPfaffianRealWorkspace *workspace,
     const double *slater_elm, const int *ele_idx,
@@ -398,10 +362,13 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_real_prepare(
   for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
     MVMCPfaffianStatus status;
     global_qp = layout->qp_start + (int)local_qp;
-    build_real_matrix(
-        layout,
+    status = mvmc_classic_pfaffian_build_real_matrix(
         slater_elm + (size_t)global_qp * layout->slater_matrix_count,
-        ele_idx, workspace->matrix_scratch);
+        layout->nsite, layout->nsize, ele_idx, workspace->matrix_scratch);
+    if (status != MVMC_PFAFFIAN_STATUS_OK) {
+      set_failure(layout, (int)local_qp, global_qp);
+      return status;
+    }
     status = mvmc_absolute_pfaffian_real_with_workspace(
         workspace->absolute_workspace, workspace->matrix_scratch,
         layout->nsize, layout->nsize,
@@ -489,10 +456,13 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_complex_prepare(
   for (local_qp = 0; local_qp < layout->local_qp_count; ++local_qp) {
     MVMCPfaffianStatus status;
     global_qp = layout->qp_start + (int)local_qp;
-    build_complex_matrix(
-        layout,
+    status = mvmc_classic_pfaffian_build_complex_matrix(
         slater_elm + (size_t)global_qp * layout->slater_matrix_count,
-        ele_idx, workspace->matrix_scratch);
+        layout->nsite, layout->nsize, ele_idx, workspace->matrix_scratch);
+    if (status != MVMC_PFAFFIAN_STATUS_OK) {
+      set_failure(layout, (int)local_qp, global_qp);
+      return status;
+    }
     status = mvmc_absolute_pfaffian_complex_with_workspace(
         workspace->absolute_workspace, workspace->matrix_scratch,
         layout->nsize, layout->nsize,

--- a/src/mVMC/include/absolute_pfaffian.h
+++ b/src/mVMC/include/absolute_pfaffian.h
@@ -24,6 +24,14 @@ typedef enum {
 } MVMCPfaffianState;
 
 typedef enum {
+  MVMC_PFAFFIAN_VALUE_WELL_PIVOTED = 0,
+  MVMC_PFAFFIAN_VALUE_NEAR_PIVOT,
+  MVMC_PFAFFIAN_VALUE_SINGULAR,
+  MVMC_PFAFFIAN_VALUE_NONFINITE,
+  MVMC_PFAFFIAN_VALUE_INVALID
+} MVMCPfaffianValueState;
+
+typedef enum {
   /* Keep this list contiguous and synchronize collective status severity. */
   MVMC_PFAFFIAN_STATUS_OK = 0,
   MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
@@ -45,6 +53,14 @@ typedef struct {
 } MVMCAbsolutePfaffianResult;
 
 typedef struct {
+  MVMCPfaffianValueState state;
+  int factor_info;
+  double matrix_scale;
+  double scaled_min_pivot;
+  double complex pfaffian;
+} MVMCAbsolutePfaffianValueResult;
+
+typedef struct {
   int valid;
   double complex total;
   double sum_abs;
@@ -58,6 +74,10 @@ typedef struct MVMCAbsolutePfaffianRealWorkspace
     MVMCAbsolutePfaffianRealWorkspace;
 typedef struct MVMCAbsolutePfaffianComplexWorkspace
     MVMCAbsolutePfaffianComplexWorkspace;
+typedef struct MVMCAbsolutePfaffianRealValueWorkspace
+    MVMCAbsolutePfaffianRealValueWorkspace;
+typedef struct MVMCAbsolutePfaffianComplexValueWorkspace
+    MVMCAbsolutePfaffianComplexValueWorkspace;
 
 /*
  * Reusable factorization workspaces for sampler hot paths.  Creation may
@@ -75,6 +95,26 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_workspace_create(
 void mvmc_absolute_pfaffian_complex_workspace_destroy(
     MVMCAbsolutePfaffianComplexWorkspace *workspace);
 
+/*
+ * Value-only workspaces contain the PFAPACK factorization storage but no
+ * inverse factor, inverse workspace, or inverse-residual machinery.  They
+ * are independent from the full P1 workspaces and are intended for absolute
+ * terminal-amplitude evaluation.
+ */
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_value_workspace_create(
+    int n, MVMCAbsolutePfaffianRealValueWorkspace **workspace);
+void mvmc_absolute_pfaffian_real_value_workspace_destroy(
+    MVMCAbsolutePfaffianRealValueWorkspace *workspace);
+size_t mvmc_absolute_pfaffian_real_value_workspace_bytes(
+    const MVMCAbsolutePfaffianRealValueWorkspace *workspace);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value_workspace_create(
+    int n, MVMCAbsolutePfaffianComplexValueWorkspace **workspace);
+void mvmc_absolute_pfaffian_complex_value_workspace_destroy(
+    MVMCAbsolutePfaffianComplexValueWorkspace *workspace);
+size_t mvmc_absolute_pfaffian_complex_value_workspace_bytes(
+    const MVMCAbsolutePfaffianComplexValueWorkspace *workspace);
+
 MVMCPfaffianStatus mvmc_absolute_pfaffian_real_with_workspace(
     MVMCAbsolutePfaffianRealWorkspace *workspace,
     const double *matrix, int n, int lda,
@@ -90,6 +130,18 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_with_workspace(
     uint64_t rebuild_generation,
     double scaled_pivot_tolerance, double residual_tolerance,
     MVMCAbsolutePfaffianResult *result);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_value_with_workspace(
+    MVMCAbsolutePfaffianRealValueWorkspace *workspace,
+    const double *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value_with_workspace(
+    MVMCAbsolutePfaffianComplexValueWorkspace *workspace,
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result);
 
 /*
  * Evaluate an even-dimensional skew-symmetric matrix without modifying it.
@@ -110,6 +162,16 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex(
     uint64_t rebuild_generation,
     double scaled_pivot_tolerance, double residual_tolerance,
     MVMCAbsolutePfaffianResult *result);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_value(
+    const double *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result);
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value(
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianValueResult *result);
 
 /*
  * Sum QPFullWeight[q] * PfM[q] without consulting inverse availability.
@@ -132,9 +194,21 @@ MVMCPfaffianStatus mvmc_projected_amplitude_slice(
     int qp_total, int qp_start, int qp_end,
     MVMCProjectedAmplitudeResult *result);
 
+MVMCPfaffianStatus mvmc_projected_amplitude_values(
+    const MVMCAbsolutePfaffianValueResult *components,
+    const double complex *weights, size_t component_count,
+    MVMCProjectedAmplitudeResult *result);
+
+MVMCPfaffianStatus mvmc_projected_amplitude_value_slice(
+    const MVMCAbsolutePfaffianValueResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCProjectedAmplitudeResult *result);
+
 /* False when this translation unit was compiled with fast-math semantics. */
 int mvmc_absolute_pfaffian_strict_fp_enabled(void);
 
 const char *mvmc_pfaffian_state_name(MVMCPfaffianState state);
+const char *mvmc_pfaffian_value_state_name(MVMCPfaffianValueState state);
 
 #endif /* MVMC_ABSOLUTE_PFAFFIAN_H */

--- a/src/mVMC/include/classic_krylov_amplitude.h
+++ b/src/mVMC/include/classic_krylov_amplitude.h
@@ -1,0 +1,110 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_KRYLOV_AMPLITUDE_H
+#define MVMC_CLASSIC_KRYLOV_AMPLITUDE_H
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+
+#include "classic_pfaffian_collective.h"
+#include "krylov_fock_reference.h"
+
+#include <complex.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+  MVMC_CLASSIC_KRYLOV_PROJECTION_NONE = 0,
+  MVMC_CLASSIC_KRYLOV_PROJECTION_GUTZWILLER_ONLY
+} MVMCClassicKrylovProjectionKind;
+
+#define MVMC_CLASSIC_KRYLOV_UNSUPPORTED_RBM UINT32_C(1)
+#define MVMC_CLASSIC_KRYLOV_UNSUPPORTED_BACKFLOW UINT32_C(2)
+#define MVMC_CLASSIC_KRYLOV_UNSUPPORTED_GENERAL_ORBITAL UINT32_C(4)
+#define MVMC_CLASSIC_KRYLOV_UNSUPPORTED_BLOCK_UPDATE UINT32_C(8)
+
+typedef struct {
+  size_t site_count;
+  size_t up_electron_count;
+  size_t down_electron_count;
+  int pure_spin;
+  int qp_total;
+  int qp_start;
+  int qp_end;
+  double scaled_pivot_tolerance;
+  int nproj;
+  int ngutzwiller_idx;
+  int njastrow_idx;
+  int nspin_jastrow_idx;
+  int ndoublon_holon_2site_idx;
+  int ndoublon_holon_4site_idx;
+  const int *gutzwiller_idx;
+  /*
+   * Production-shaped index bindings.  Even correlators outside the P3
+   * allowlist must provide these when their count is nonzero so malformed
+   * indices are reported as invalid before a well-formed model is reported
+   * as unsupported.  Jastrow tables are site_count-square; DH rows contain
+   * 2*site_count and 4*site_count site indices respectively.
+   */
+  const int *const *jastrow_idx;
+  const int *const *spin_jastrow_idx;
+  const int *const *doublon_holon_2site_idx;
+  const int *const *doublon_holon_4site_idx;
+  const double complex *projection_parameters;
+  uint32_t unsupported_features;
+  MVMCClassicPfaffianCommunicator communicator;
+} MVMCClassicKrylovAmplitudeLayout;
+
+typedef struct MVMCClassicKrylovRealAmplitudeWorkspace
+    MVMCClassicKrylovRealAmplitudeWorkspace;
+typedef struct MVMCClassicKrylovComplexAmplitudeWorkspace
+    MVMCClassicKrylovComplexAmplitudeWorkspace;
+
+/*
+ * Creation is collective on layout->communicator.  It verifies replicated
+ * Slater data, QP weights, and the supported projection binding exactly,
+ * then keeps an immutable private copy.  Evaluation performs no allocation
+ * and never writes production PfM/InvM, accepted sampler state, projection
+ * counts, caller buffers, or the input configuration.  Projected values are
+ * gathered and summed in global QP index order, independent of MPI rank
+ * count and partitioning.
+ */
+MVMCKrylovStatus mvmc_classic_krylov_real_amplitude_workspace_create(
+    const MVMCClassicKrylovAmplitudeLayout *layout,
+    const double *slater_elm, const double complex *global_weights,
+    MVMCClassicKrylovRealAmplitudeWorkspace **workspace);
+
+void mvmc_classic_krylov_real_amplitude_workspace_destroy(
+    MVMCClassicKrylovRealAmplitudeWorkspace *workspace);
+size_t mvmc_classic_krylov_real_amplitude_workspace_bytes(
+    const MVMCClassicKrylovRealAmplitudeWorkspace *workspace);
+
+MVMCKrylovStatus mvmc_classic_krylov_complex_amplitude_workspace_create(
+    const MVMCClassicKrylovAmplitudeLayout *layout,
+    const double complex *slater_elm,
+    const double complex *global_weights,
+    MVMCClassicKrylovComplexAmplitudeWorkspace **workspace);
+
+void mvmc_classic_krylov_complex_amplitude_workspace_destroy(
+    MVMCClassicKrylovComplexAmplitudeWorkspace *workspace);
+size_t mvmc_classic_krylov_complex_amplitude_workspace_bytes(
+    const MVMCClassicKrylovComplexAmplitudeWorkspace *workspace);
+
+MVMCKrylovStatus mvmc_classic_krylov_real_amplitude(
+    const uint64_t *configuration_words, size_t word_count,
+    void *context, MVMCKrylovAmplitudeResult *result);
+
+MVMCKrylovStatus mvmc_classic_krylov_complex_amplitude(
+    const uint64_t *configuration_words, size_t word_count,
+    void *context, MVMCKrylovAmplitudeResult *result);
+
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */
+
+#endif /* MVMC_CLASSIC_KRYLOV_AMPLITUDE_H */

--- a/src/mVMC/include/classic_krylov_model.h
+++ b/src/mVMC/include/classic_krylov_model.h
@@ -1,0 +1,99 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_KRYLOV_MODEL_H
+#define MVMC_CLASSIC_KRYLOV_MODEL_H
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+
+#include "classic_pfaffian_collective.h"
+#include "krylov_fock_reference.h"
+
+#include <complex.h>
+#include <stddef.h>
+
+typedef enum {
+  MVMC_CLASSIC_KRYLOV_SOURCE_TRANSFER = 1,
+  MVMC_CLASSIC_KRYLOV_SOURCE_COULOMB_INTRA,
+  MVMC_CLASSIC_KRYLOV_SOURCE_COULOMB_INTER,
+  MVMC_CLASSIC_KRYLOV_SOURCE_HUND,
+  MVMC_CLASSIC_KRYLOV_SOURCE_EXCHANGE
+} MVMCClassicKrylovSourceKind;
+
+typedef struct {
+  int output_site;
+  int output_spin;
+  int input_site;
+  int input_spin;
+  double complex coefficient;
+} MVMCClassicKrylovTransfer;
+
+typedef struct {
+  int site;
+  double coefficient;
+} MVMCClassicKrylovSiteCoupling;
+
+typedef struct {
+  int first_site;
+  int second_site;
+  double coefficient;
+} MVMCClassicKrylovPairCoupling;
+
+/*
+ * Counts remain signed so a root-global hook can reject malicious negative
+ * production counts before any size_t conversion.  Raw pointers are read on
+ * communicator rank 0 only; non-root callers may pass raw == NULL.
+ */
+typedef struct {
+  int site_count;
+  int up_electron_count;
+  int down_electron_count;
+  int pure_spin;
+  int transfer_count;
+  const MVMCClassicKrylovTransfer *transfers;
+  int coulomb_intra_count;
+  const MVMCClassicKrylovSiteCoupling *coulomb_intra;
+  int coulomb_inter_count;
+  const MVMCClassicKrylovPairCoupling *coulomb_inter;
+  int hund_count;
+  const MVMCClassicKrylovPairCoupling *hund;
+  int exchange_count;
+  const MVMCClassicKrylovPairCoupling *exchange;
+  int pair_hopping_count;
+  int inter_all_count;
+  int nbody_inter_all_count;
+} MVMCClassicKrylovRawModel;
+
+typedef struct MVMCClassicKrylovModelWorkspace
+    MVMCClassicKrylovModelWorkspace;
+
+/*
+ * Collective creation on communicator.  Rank 0 validates raw metadata and
+ * every referenced element before broadcasting status and checked sizes.
+ * The resulting immutable Fock model is byte-identical on every rank and
+ * does not retain a pointer to the root raw data.
+ */
+MVMCKrylovStatus mvmc_classic_krylov_model_workspace_create_from_root(
+    const MVMCClassicKrylovRawModel *raw,
+    MVMCClassicPfaffianCommunicator communicator,
+    MVMCClassicKrylovModelWorkspace **workspace);
+
+void mvmc_classic_krylov_model_workspace_destroy(
+    MVMCClassicKrylovModelWorkspace *workspace);
+
+const MVMCKrylovFockModel *mvmc_classic_krylov_model(
+    const MVMCClassicKrylovModelWorkspace *workspace);
+
+size_t mvmc_classic_krylov_model_workspace_bytes(
+    const MVMCClassicKrylovModelWorkspace *workspace);
+
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */
+
+#endif /* MVMC_CLASSIC_KRYLOV_MODEL_H */

--- a/src/mVMC/include/classic_pfaffian_collective.h
+++ b/src/mVMC/include/classic_pfaffian_collective.h
@@ -13,6 +13,9 @@ the Free Software Foundation, either version 3 of the License, or
 
 #include "classic_pfaffian_state.h"
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef _mpi_use
 #include <mpi.h>
 typedef MPI_Comm MVMCClassicPfaffianCommunicator;
@@ -52,6 +55,10 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_collective_workspace_create(
     MVMCClassicPfaffianCollectiveWorkspace **workspace);
 void mvmc_classic_pfaffian_collective_workspace_destroy(
     MVMCClassicPfaffianCollectiveWorkspace *workspace);
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+size_t mvmc_classic_pfaffian_collective_workspace_bytes(
+    const MVMCClassicPfaffianCollectiveWorkspace *workspace);
+#endif
 
 /*
  * All ranks must call in the same order with a workspace from the same
@@ -123,5 +130,37 @@ MVMCPfaffianStatus mvmc_classic_pfaffian_collective_preflight(
 MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_true(
     MVMCClassicPfaffianCollectiveWorkspace *workspace,
     int local_true, int *all_true);
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+/* Creation-time exact replicated-data audit.  This routine may allocate. */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_equal_bytes(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    const void *local_data, size_t byte_count, int *all_equal);
+
+/* Allocation-free exact audit for evaluation-time configuration words. */
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_all_equal_u64(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    const uint64_t *local_values, size_t value_count, int *all_equal);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_sum_u64(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    uint64_t local_value, uint64_t *global_sum);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_collective_max_int(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    int local_value, int *global_max);
+
+/*
+ * Gather a validated contiguous QP partition into global QP index order.
+ * No allocation is performed; global_components has qp_total elements on
+ * every rank and local_components has qp_end-qp_start elements.
+ */
+MVMCPfaffianStatus
+mvmc_classic_pfaffian_collective_gather_value_components(
+    MVMCClassicPfaffianCollectiveWorkspace *workspace,
+    const MVMCAbsolutePfaffianValueResult *local_components,
+    size_t local_component_count, int qp_total, int qp_start, int qp_end,
+    MVMCAbsolutePfaffianValueResult *global_components);
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */
 
 #endif /* MVMC_CLASSIC_PFAFFIAN_COLLECTIVE_H */

--- a/src/mVMC/include/classic_pfaffian_matrix.h
+++ b/src/mVMC/include/classic_pfaffian_matrix.h
@@ -1,0 +1,32 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_CLASSIC_PFAFFIAN_MATRIX_H
+#define MVMC_CLASSIC_PFAFFIAN_MATRIX_H
+
+#include "absolute_pfaffian.h"
+
+#include <complex.h>
+
+/*
+ * Build the classic non-FSZ nsize-by-nsize skew matrix for one QP component.
+ * Slater storage is a column-major (2*nsite)-square matrix.  The first and
+ * second nsize/2 electron indices represent up and down spin respectively.
+ * No input is modified and no allocation is performed.
+ */
+MVMCPfaffianStatus mvmc_classic_pfaffian_build_real_matrix(
+    const double *slater, int nsite, int nsize, const int *ele_idx,
+    double *matrix);
+
+MVMCPfaffianStatus mvmc_classic_pfaffian_build_complex_matrix(
+    const double complex *slater, int nsite, int nsize, const int *ele_idx,
+    double complex *matrix);
+
+#endif /* MVMC_CLASSIC_PFAFFIAN_MATRIX_H */

--- a/src/mVMC/include/krylov_fock_reference.h
+++ b/src/mVMC/include/krylov_fock_reference.h
@@ -1,0 +1,155 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_KRYLOV_FOCK_REFERENCE_H
+#define MVMC_KRYLOV_FOCK_REFERENCE_H
+
+#if defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+
+#include <complex.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define MVMC_KRYLOV_MAX_ORDER 3
+
+typedef enum {
+  MVMC_KRYLOV_STATUS_OK = 0,
+  MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+  MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+  MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL,
+  MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE,
+  MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE,
+  MVMC_KRYLOV_STATUS_NONFINITE,
+  MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+  MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE,
+  MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE
+} MVMCKrylovStatus;
+
+typedef enum {
+  MVMC_KRYLOV_FERMION_CREATE = 0,
+  MVMC_KRYLOV_FERMION_ANNIHILATE
+} MVMCKrylovFermionOperatorKind;
+
+typedef struct {
+  MVMCKrylovFermionOperatorKind kind;
+  size_t orbital;
+} MVMCKrylovFermionOperator;
+
+typedef struct {
+  double complex coefficient;
+  size_t operator_offset;
+  size_t operator_count;
+  int source_kind;
+  size_t source_index;
+} MVMCKrylovHamiltonianTerm;
+
+typedef struct {
+  size_t site_count;
+  size_t up_electron_count;
+  size_t down_electron_count;
+  int pure_spin;
+  int hermitian;
+  const MVMCKrylovHamiltonianTerm *terms;
+  size_t term_count;
+  const MVMCKrylovFermionOperator *operators;
+  size_t operator_count;
+} MVMCKrylovFockModel;
+
+typedef struct {
+  size_t max_states;
+  size_t max_transitions;
+  size_t max_amplitude_evaluations;
+  size_t max_bytes;
+  int max_order;
+} MVMCKrylovLimits;
+
+typedef struct {
+  double complex value;
+  int total_zero;
+  uint64_t regular_component_count;
+  uint64_t near_pivot_component_count;
+  uint64_t singular_component_count;
+  uint64_t local_factorization_count;
+  uint64_t global_factorization_count;
+} MVMCKrylovAmplitudeResult;
+
+typedef MVMCKrylovStatus (*MVMCKrylovAmplitudeCallback)(
+    const uint64_t *configuration_words, size_t word_count,
+    void *context, MVMCKrylovAmplitudeResult *result);
+
+typedef struct {
+  uint64_t root_evaluations;
+  int requested_order;
+  int completed_order;
+  uint64_t recursion_calls[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t unique_states[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t memo_hits[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t memo_misses[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t raw_transitions;
+  uint64_t merged_duplicate_transitions;
+  uint64_t cancelled_zero_transitions;
+  uint64_t terminal_amplitude_requests;
+  uint64_t terminal_cache_hits;
+  uint64_t regular_component_count;
+  uint64_t near_pivot_component_count;
+  uint64_t singular_component_count;
+  uint64_t total_zero_count;
+  uint64_t local_factorization_count;
+  uint64_t global_factorization_count;
+  size_t frontier_peak;
+  size_t memo_entries_peak;
+  size_t workspace_bytes;
+  double depth_wall_seconds[MVMC_KRYLOV_MAX_ORDER + 1];
+  double amplitude_wall_seconds;
+  double connectivity_wall_seconds;
+} MVMCKrylovStatistics;
+
+typedef struct {
+  MVMCKrylovStatus status;
+  int depth;
+  uint64_t configuration_hash;
+} MVMCKrylovFailure;
+
+typedef struct {
+  int valid;
+  MVMCKrylovStatus status;
+  int evaluated_order;
+  double complex value[MVMC_KRYLOV_MAX_ORDER + 1];
+  MVMCKrylovStatistics statistics;
+  MVMCKrylovFailure failure;
+} MVMCKrylovResult;
+
+typedef struct MVMCKrylovWorkspace MVMCKrylovWorkspace;
+
+size_t mvmc_krylov_fock_word_count(size_t site_count);
+
+MVMCKrylovWorkspace *mvmc_krylov_workspace_create(
+    size_t site_count, const MVMCKrylovLimits *limits,
+    MVMCKrylovStatus *status);
+
+void mvmc_krylov_workspace_destroy(MVMCKrylovWorkspace *workspace);
+
+size_t mvmc_krylov_workspace_bytes(const MVMCKrylovWorkspace *workspace);
+
+MVMCKrylovStatus mvmc_krylov_fock_validate(
+    const MVMCKrylovFockModel *model,
+    const uint64_t *configuration_words, size_t word_count);
+
+MVMCKrylovStatus mvmc_krylov_evaluate(
+    MVMCKrylovWorkspace *workspace, const MVMCKrylovFockModel *model,
+    const uint64_t *root_configuration_words, size_t root_word_count,
+    MVMCKrylovAmplitudeCallback amplitude, void *amplitude_context,
+    MVMCKrylovResult *result);
+
+const char *mvmc_krylov_status_string(MVMCKrylovStatus status);
+
+#endif /* MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE */
+
+#endif /* MVMC_KRYLOV_FOCK_REFERENCE_H */

--- a/src/mVMC/krylov_fock_reference.c
+++ b/src/mVMC/krylov_fock_reference.c
@@ -1,0 +1,893 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "krylov_fock_reference.h"
+
+#if !defined(MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+#error "krylov_fock_reference.c is Testing-only"
+#endif
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum {
+  MVMC_MEMO_EMPTY = 0,
+  MVMC_MEMO_COMPUTING,
+  MVMC_MEMO_COMPLETE
+} MVMCMemoState;
+
+typedef struct {
+  MVMCMemoState state;
+  int depth;
+  uint64_t hash;
+  double complex value;
+} MVMCMemoEntry;
+
+typedef struct {
+  size_t key_index;
+  double complex row_weight;
+  size_t term_index;
+} MVMCNeighbor;
+
+struct MVMCKrylovWorkspace {
+  size_t site_count;
+  size_t orbital_count;
+  size_t word_count;
+  MVMCKrylovLimits limits;
+  size_t allocated_bytes;
+  size_t memo_slot_count;
+  MVMCMemoEntry *memo_entries;
+  uint64_t *memo_words;
+  MVMCNeighbor *neighbors;
+  uint64_t *neighbor_words;
+  uint64_t *scratch_words;
+  size_t memo_entry_count;
+  size_t transition_used;
+};
+
+typedef struct {
+  double real_sum;
+  double real_compensation;
+  double imag_sum;
+  double imag_compensation;
+} MVMCComplexAccumulator;
+
+typedef struct {
+  MVMCKrylovWorkspace *workspace;
+  const MVMCKrylovFockModel *model;
+  MVMCKrylovAmplitudeCallback amplitude;
+  void *amplitude_context;
+  MVMCKrylovStatistics *statistics;
+  MVMCKrylovFailure *failure;
+} MVMCEvaluation;
+
+static int checked_add_size(size_t lhs, size_t rhs, size_t *result) {
+  if (result == NULL || lhs > SIZE_MAX - rhs) return 0;
+  *result = lhs + rhs;
+  return 1;
+}
+
+static int checked_multiply_size(size_t lhs, size_t rhs, size_t *result) {
+  if (result == NULL || (lhs != 0 && rhs > SIZE_MAX / lhs)) return 0;
+  *result = lhs * rhs;
+  return 1;
+}
+
+static int finite_complex(double complex value) {
+  return isfinite(creal(value)) && isfinite(cimag(value));
+}
+
+static int exact_complex_zero(double complex value) {
+  return creal(value) == 0.0 && cimag(value) == 0.0;
+}
+
+static int increment_u64(uint64_t *value) {
+  if (value == NULL || *value == UINT64_MAX) return 0;
+  ++(*value);
+  return 1;
+}
+
+static int add_u64(uint64_t *value, uint64_t increment) {
+  if (value == NULL || increment > UINT64_MAX - *value) return 0;
+  *value += increment;
+  return 1;
+}
+
+static uint64_t popcount_word(uint64_t value) {
+  uint64_t count = 0;
+  while (value != 0) {
+    value &= value - 1;
+    ++count;
+  }
+  return count;
+}
+
+static int configuration_bit(const uint64_t *words, size_t orbital) {
+  return (int)((words[orbital / 64] >> (orbital % 64)) & UINT64_C(1));
+}
+
+static void configuration_set_bit(uint64_t *words, size_t orbital, int value) {
+  const uint64_t mask = UINT64_C(1) << (orbital % 64);
+  if (value) {
+    words[orbital / 64] |= mask;
+  } else {
+    words[orbital / 64] &= ~mask;
+  }
+}
+
+static int configuration_compare(const uint64_t *lhs, const uint64_t *rhs,
+                                 size_t word_count) {
+  size_t word;
+  for (word = 0; word < word_count; ++word) {
+    if (lhs[word] < rhs[word]) return -1;
+    if (lhs[word] > rhs[word]) return 1;
+  }
+  return 0;
+}
+
+static uint64_t configuration_hash(const uint64_t *words, size_t word_count,
+                                   int depth) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  size_t word;
+  hash ^= (uint64_t)(unsigned int)depth;
+  hash *= UINT64_C(1099511628211);
+  for (word = 0; word < word_count; ++word) {
+    uint64_t value = words[word];
+    int byte;
+    for (byte = 0; byte < 8; ++byte) {
+      hash ^= value & UINT64_C(0xff);
+      hash *= UINT64_C(1099511628211);
+      value >>= 8;
+    }
+  }
+  return hash;
+}
+
+static void accumulator_add_component(double value, double *sum,
+                                      double *compensation) {
+  const double updated = *sum + value;
+  if (fabs(*sum) >= fabs(value)) {
+    *compensation += (*sum - updated) + value;
+  } else {
+    *compensation += (value - updated) + *sum;
+  }
+  *sum = updated;
+}
+
+static int accumulator_add(MVMCComplexAccumulator *accumulator,
+                           double complex value) {
+  if (accumulator == NULL || !finite_complex(value)) return 0;
+  accumulator_add_component(creal(value), &accumulator->real_sum,
+                            &accumulator->real_compensation);
+  accumulator_add_component(cimag(value), &accumulator->imag_sum,
+                            &accumulator->imag_compensation);
+  return isfinite(accumulator->real_sum) &&
+         isfinite(accumulator->real_compensation) &&
+         isfinite(accumulator->imag_sum) &&
+         isfinite(accumulator->imag_compensation);
+}
+
+static double complex accumulator_value(
+    const MVMCComplexAccumulator *accumulator) {
+  return (accumulator->real_sum + accumulator->real_compensation) +
+         I * (accumulator->imag_sum + accumulator->imag_compensation);
+}
+
+size_t mvmc_krylov_fock_word_count(size_t site_count) {
+  size_t orbital_count;
+  if (site_count == 0 || site_count > SIZE_MAX / 2) return 0;
+  orbital_count = 2 * site_count;
+  return orbital_count / 64 + (orbital_count % 64 != 0 ? 1 : 0);
+}
+
+static MVMCKrylovStatus validate_configuration(
+    const MVMCKrylovFockModel *model, const uint64_t *words,
+    size_t word_count) {
+  size_t site;
+  size_t up_count = 0;
+  size_t down_count = 0;
+  size_t required_words;
+  size_t orbital_count;
+  size_t used_bits;
+
+  if (model == NULL || words == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  required_words = mvmc_krylov_fock_word_count(model->site_count);
+  if (required_words == 0 || word_count != required_words) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  orbital_count = 2 * model->site_count;
+  used_bits = orbital_count % 64;
+  if (used_bits != 0) {
+    const uint64_t used_mask = (UINT64_C(1) << used_bits) - UINT64_C(1);
+    if ((words[word_count - 1] & ~used_mask) != 0) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  for (site = 0; site < model->site_count; ++site) {
+    const int up = configuration_bit(words, site);
+    const int down = configuration_bit(words, site + model->site_count);
+    up_count += (size_t)up;
+    down_count += (size_t)down;
+    if (model->pure_spin && up + down != 1) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if (up_count != model->up_electron_count ||
+      down_count != model->down_electron_count) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus validate_model(const MVMCKrylovFockModel *model) {
+  size_t term_index;
+  if (model == NULL || mvmc_krylov_fock_word_count(model->site_count) == 0 ||
+      model->up_electron_count > model->site_count ||
+      model->down_electron_count > model->site_count ||
+      (model->pure_spin != 0 && model->pure_spin != 1) ||
+      (model->pure_spin &&
+       (model->up_electron_count + model->down_electron_count !=
+        model->site_count)) ||
+      (model->term_count != 0 && model->terms == NULL) ||
+      (model->operator_count != 0 && model->operators == NULL)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (!model->hermitian) return MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL;
+  for (term_index = 0; term_index < model->term_count; ++term_index) {
+    const MVMCKrylovHamiltonianTerm *term = &model->terms[term_index];
+    size_t operator_index;
+    if (!finite_complex(term->coefficient)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    if ((term->operator_count != 2 && term->operator_count != 4) ||
+        term->operator_offset > model->operator_count ||
+        term->operator_count > model->operator_count - term->operator_offset) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+    for (operator_index = 0; operator_index < term->operator_count;
+         ++operator_index) {
+      const MVMCKrylovFermionOperator *operator_item =
+          &model->operators[term->operator_offset + operator_index];
+      if ((operator_item->kind != MVMC_KRYLOV_FERMION_CREATE &&
+           operator_item->kind != MVMC_KRYLOV_FERMION_ANNIHILATE) ||
+          operator_item->orbital >= 2 * model->site_count) {
+        return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+      }
+    }
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_krylov_fock_validate(
+    const MVMCKrylovFockModel *model, const uint64_t *configuration_words,
+    size_t word_count) {
+  MVMCKrylovStatus status = validate_model(model);
+  if (status != MVMC_KRYLOV_STATUS_OK) return status;
+  return validate_configuration(model, configuration_words, word_count);
+}
+
+static int workspace_allocation_bytes(size_t word_count,
+                                      const MVMCKrylovLimits *limits,
+                                      size_t *memo_slot_count,
+                                      size_t *allocated_bytes) {
+  size_t slots;
+  size_t bytes = sizeof(MVMCKrylovWorkspace);
+  size_t part;
+
+  if (word_count == 0 || limits == NULL || memo_slot_count == NULL ||
+      allocated_bytes == NULL || limits->max_states == 0 ||
+      limits->max_transitions == 0 || limits->max_amplitude_evaluations == 0 ||
+      limits->max_bytes == 0 || limits->max_order < 0 ||
+      limits->max_order > MVMC_KRYLOV_MAX_ORDER ||
+      limits->max_states > (SIZE_MAX - 1) / 2) {
+    return 0;
+  }
+  slots = 2 * limits->max_states + 1;
+  if (!checked_multiply_size(slots, sizeof(MVMCMemoEntry), &part) ||
+      !checked_add_size(bytes, part, &bytes) ||
+      !checked_multiply_size(slots, word_count, &part) ||
+      !checked_multiply_size(part, sizeof(uint64_t), &part) ||
+      !checked_add_size(bytes, part, &bytes) ||
+      !checked_multiply_size(limits->max_transitions,
+                             sizeof(MVMCNeighbor), &part) ||
+      !checked_add_size(bytes, part, &bytes) ||
+      !checked_multiply_size(limits->max_transitions, word_count, &part) ||
+      !checked_multiply_size(part, sizeof(uint64_t), &part) ||
+      !checked_add_size(bytes, part, &bytes) ||
+      !checked_multiply_size(word_count, sizeof(uint64_t), &part) ||
+      !checked_add_size(bytes, part, &bytes)) {
+    return 0;
+  }
+  *memo_slot_count = slots;
+  *allocated_bytes = bytes;
+  return 1;
+}
+
+MVMCKrylovWorkspace *mvmc_krylov_workspace_create(
+    size_t site_count, const MVMCKrylovLimits *limits,
+    MVMCKrylovStatus *status) {
+  MVMCKrylovWorkspace *workspace = NULL;
+  size_t memo_slot_count = 0;
+  size_t allocated_bytes = 0;
+  size_t word_count = mvmc_krylov_fock_word_count(site_count);
+
+  if (status != NULL) *status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  if (!workspace_allocation_bytes(word_count, limits, &memo_slot_count,
+                                  &allocated_bytes)) {
+    return NULL;
+  }
+  if (allocated_bytes > limits->max_bytes) {
+    if (status != NULL) *status = MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+    return NULL;
+  }
+  workspace = (MVMCKrylovWorkspace *)calloc(1, sizeof(*workspace));
+  if (workspace == NULL) {
+    if (status != NULL) *status = MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+    return NULL;
+  }
+  workspace->memo_entries = (MVMCMemoEntry *)calloc(
+      memo_slot_count, sizeof(*workspace->memo_entries));
+  workspace->memo_words = (uint64_t *)calloc(
+      memo_slot_count * word_count, sizeof(*workspace->memo_words));
+  workspace->neighbors = (MVMCNeighbor *)calloc(
+      limits->max_transitions, sizeof(*workspace->neighbors));
+  workspace->neighbor_words = (uint64_t *)calloc(
+      limits->max_transitions * word_count,
+      sizeof(*workspace->neighbor_words));
+  workspace->scratch_words =
+      (uint64_t *)calloc(word_count, sizeof(*workspace->scratch_words));
+  if (workspace->memo_entries == NULL || workspace->memo_words == NULL ||
+      workspace->neighbors == NULL || workspace->neighbor_words == NULL ||
+      workspace->scratch_words == NULL) {
+    mvmc_krylov_workspace_destroy(workspace);
+    if (status != NULL) *status = MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+    return NULL;
+  }
+  workspace->site_count = site_count;
+  workspace->orbital_count = 2 * site_count;
+  workspace->word_count = word_count;
+  workspace->limits = *limits;
+  workspace->allocated_bytes = allocated_bytes;
+  workspace->memo_slot_count = memo_slot_count;
+  if (status != NULL) *status = MVMC_KRYLOV_STATUS_OK;
+  return workspace;
+}
+
+void mvmc_krylov_workspace_destroy(MVMCKrylovWorkspace *workspace) {
+  if (workspace == NULL) return;
+  free(workspace->scratch_words);
+  free(workspace->neighbor_words);
+  free(workspace->neighbors);
+  free(workspace->memo_words);
+  free(workspace->memo_entries);
+  free(workspace);
+}
+
+size_t mvmc_krylov_workspace_bytes(const MVMCKrylovWorkspace *workspace) {
+  return workspace == NULL ? 0 : workspace->allocated_bytes;
+}
+
+static void reset_result(MVMCKrylovResult *result) {
+  if (result == NULL) return;
+  memset(result, 0, sizeof(*result));
+  result->status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  result->evaluated_order = -1;
+  result->statistics.requested_order = -1;
+  result->statistics.completed_order = -1;
+  result->failure.status = MVMC_KRYLOV_STATUS_OK;
+  result->failure.depth = -1;
+}
+
+static MVMCKrylovStatus record_failure(MVMCEvaluation *evaluation,
+                                      MVMCKrylovStatus status, int depth,
+                                      const uint64_t *words) {
+  if (evaluation->failure->status == MVMC_KRYLOV_STATUS_OK) {
+    evaluation->failure->status = status;
+    evaluation->failure->depth = depth;
+    evaluation->failure->configuration_hash =
+        words == NULL ? 0 : configuration_hash(
+                                  words, evaluation->workspace->word_count,
+                                  depth < 0 ? 0 : depth);
+  }
+  return status;
+}
+
+static uint64_t count_occupied_before(const uint64_t *words, size_t orbital) {
+  const size_t full_words = orbital / 64;
+  const size_t partial_bits = orbital % 64;
+  uint64_t count = 0;
+  size_t word;
+  for (word = 0; word < full_words; ++word) {
+    count += popcount_word(words[word]);
+  }
+  if (partial_bits != 0) {
+    const uint64_t mask = (UINT64_C(1) << partial_bits) - UINT64_C(1);
+    count += popcount_word(words[full_words] & mask);
+  }
+  return count;
+}
+
+static MVMCKrylovStatus apply_term(
+    const MVMCKrylovFockModel *model,
+    const MVMCKrylovHamiltonianTerm *term, const uint64_t *input,
+    size_t word_count, uint64_t *output, int *applied, int *fermion_sign) {
+  size_t reverse_index;
+  int sign = 1;
+  memcpy(output, input, word_count * sizeof(*output));
+  *applied = 0;
+  *fermion_sign = 1;
+  for (reverse_index = term->operator_count; reverse_index > 0;
+       --reverse_index) {
+    const MVMCKrylovFermionOperator *operator_item =
+        &model->operators[term->operator_offset + reverse_index - 1];
+    const int occupied = configuration_bit(output, operator_item->orbital);
+    if ((operator_item->kind == MVMC_KRYLOV_FERMION_CREATE && occupied) ||
+        (operator_item->kind == MVMC_KRYLOV_FERMION_ANNIHILATE &&
+         !occupied)) {
+      return MVMC_KRYLOV_STATUS_OK;
+    }
+    if ((count_occupied_before(output, operator_item->orbital) & UINT64_C(1)) !=
+        0) {
+      sign = -sign;
+    }
+    configuration_set_bit(
+        output, operator_item->orbital,
+        operator_item->kind == MVMC_KRYLOV_FERMION_CREATE);
+  }
+  if (validate_configuration(model, output, word_count) !=
+      MVMC_KRYLOV_STATUS_OK) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  *applied = 1;
+  *fermion_sign = sign;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static const uint64_t *neighbor_key(const MVMCKrylovWorkspace *workspace,
+                                    const MVMCNeighbor *neighbor) {
+  return workspace->neighbor_words + neighbor->key_index * workspace->word_count;
+}
+
+static uint64_t double_bits(double value) {
+  uint64_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+static int term_compare(const MVMCKrylovFockModel *model, size_t lhs_index,
+                        size_t rhs_index) {
+  const MVMCKrylovHamiltonianTerm *lhs = &model->terms[lhs_index];
+  const MVMCKrylovHamiltonianTerm *rhs = &model->terms[rhs_index];
+  size_t operator_index;
+  if (lhs->operator_count < rhs->operator_count) return -1;
+  if (lhs->operator_count > rhs->operator_count) return 1;
+  for (operator_index = 0; operator_index < lhs->operator_count;
+       ++operator_index) {
+    const MVMCKrylovFermionOperator *lhs_operator =
+        &model->operators[lhs->operator_offset + operator_index];
+    const MVMCKrylovFermionOperator *rhs_operator =
+        &model->operators[rhs->operator_offset + operator_index];
+    if (lhs_operator->kind < rhs_operator->kind) return -1;
+    if (lhs_operator->kind > rhs_operator->kind) return 1;
+    if (lhs_operator->orbital < rhs_operator->orbital) return -1;
+    if (lhs_operator->orbital > rhs_operator->orbital) return 1;
+  }
+  if (double_bits(creal(lhs->coefficient)) <
+      double_bits(creal(rhs->coefficient))) {
+    return -1;
+  }
+  if (double_bits(creal(lhs->coefficient)) >
+      double_bits(creal(rhs->coefficient))) {
+    return 1;
+  }
+  if (double_bits(cimag(lhs->coefficient)) <
+      double_bits(cimag(rhs->coefficient))) {
+    return -1;
+  }
+  if (double_bits(cimag(lhs->coefficient)) >
+      double_bits(cimag(rhs->coefficient))) {
+    return 1;
+  }
+  if (lhs->source_kind < rhs->source_kind) return -1;
+  if (lhs->source_kind > rhs->source_kind) return 1;
+  if (lhs->source_index < rhs->source_index) return -1;
+  if (lhs->source_index > rhs->source_index) return 1;
+  return 0;
+}
+
+static int neighbor_compare(const MVMCEvaluation *evaluation,
+                            const MVMCNeighbor *lhs,
+                            const MVMCNeighbor *rhs) {
+  const int key_order = configuration_compare(
+      neighbor_key(evaluation->workspace, lhs),
+      neighbor_key(evaluation->workspace, rhs),
+      evaluation->workspace->word_count);
+  if (key_order != 0) return key_order;
+  return term_compare(evaluation->model, lhs->term_index, rhs->term_index);
+}
+
+static void sort_neighbors(MVMCEvaluation *evaluation, size_t base,
+                           size_t count) {
+  size_t index;
+  for (index = 1; index < count; ++index) {
+    MVMCNeighbor value = evaluation->workspace->neighbors[base + index];
+    size_t insertion = index;
+    while (insertion > 0 &&
+           neighbor_compare(evaluation, &value,
+                            &evaluation->workspace->neighbors[
+                                base + insertion - 1]) < 0) {
+      evaluation->workspace->neighbors[base + insertion] =
+          evaluation->workspace->neighbors[base + insertion - 1];
+      --insertion;
+    }
+    evaluation->workspace->neighbors[base + insertion] = value;
+  }
+}
+
+static MVMCKrylovStatus merge_neighbors(MVMCEvaluation *evaluation,
+                                       size_t base, size_t raw_count,
+                                       size_t *merged_count) {
+  size_t read = 0;
+  size_t write = 0;
+  while (read < raw_count) {
+    MVMCComplexAccumulator accumulator;
+    MVMCNeighbor merged = evaluation->workspace->neighbors[base + read];
+    size_t next = read + 1;
+    memset(&accumulator, 0, sizeof(accumulator));
+    if (!accumulator_add(&accumulator, merged.row_weight)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    while (next < raw_count &&
+           configuration_compare(
+               neighbor_key(evaluation->workspace, &merged),
+               neighbor_key(evaluation->workspace,
+                            &evaluation->workspace->neighbors[base + next]),
+               evaluation->workspace->word_count) == 0) {
+      if (!increment_u64(
+              &evaluation->statistics->merged_duplicate_transitions)) {
+        return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+      }
+      if (!accumulator_add(
+              &accumulator,
+              evaluation->workspace->neighbors[base + next].row_weight)) {
+        return MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      ++next;
+    }
+    merged.row_weight = accumulator_value(&accumulator);
+    if (!finite_complex(merged.row_weight)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    if (exact_complex_zero(merged.row_weight)) {
+      if (!increment_u64(
+              &evaluation->statistics->cancelled_zero_transitions)) {
+        return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+      }
+    } else {
+      evaluation->workspace->neighbors[base + write] = merged;
+      ++write;
+    }
+    read = next;
+  }
+  *merged_count = write;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus memo_entry(MVMCEvaluation *evaluation, int depth,
+                                  const uint64_t *words,
+                                  MVMCMemoEntry **entry,
+                                  const uint64_t **canonical_words,
+                                  int *inserted) {
+  MVMCKrylovWorkspace *workspace = evaluation->workspace;
+  const uint64_t hash = configuration_hash(words, workspace->word_count, depth);
+  const size_t start = (size_t)(hash % workspace->memo_slot_count);
+  size_t probe;
+  for (probe = 0; probe < workspace->memo_slot_count; ++probe) {
+    const size_t slot = (start + probe) % workspace->memo_slot_count;
+    MVMCMemoEntry *candidate = &workspace->memo_entries[slot];
+    uint64_t *candidate_words =
+        workspace->memo_words + slot * workspace->word_count;
+    if (candidate->state == MVMC_MEMO_EMPTY) {
+      if (workspace->memo_entry_count >= workspace->limits.max_states) {
+        return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+      }
+      memcpy(candidate_words, words,
+             workspace->word_count * sizeof(*candidate_words));
+      candidate->state = MVMC_MEMO_COMPUTING;
+      candidate->depth = depth;
+      candidate->hash = hash;
+      candidate->value = 0.0;
+      ++workspace->memo_entry_count;
+      if (workspace->memo_entry_count >
+          evaluation->statistics->memo_entries_peak) {
+        evaluation->statistics->memo_entries_peak =
+            workspace->memo_entry_count;
+      }
+      *entry = candidate;
+      *canonical_words = candidate_words;
+      *inserted = 1;
+      return MVMC_KRYLOV_STATUS_OK;
+    }
+    if (candidate->hash == hash && candidate->depth == depth &&
+        configuration_compare(candidate_words, words, workspace->word_count) ==
+            0) {
+      *entry = candidate;
+      *canonical_words = candidate_words;
+      *inserted = 0;
+      return MVMC_KRYLOV_STATUS_OK;
+    }
+  }
+  return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+}
+
+static MVMCKrylovStatus accumulate_amplitude_statistics(
+    MVMCEvaluation *evaluation, const MVMCKrylovAmplitudeResult *amplitude) {
+  if (!add_u64(&evaluation->statistics->regular_component_count,
+               amplitude->regular_component_count) ||
+      !add_u64(&evaluation->statistics->near_pivot_component_count,
+               amplitude->near_pivot_component_count) ||
+      !add_u64(&evaluation->statistics->singular_component_count,
+               amplitude->singular_component_count) ||
+      !add_u64(&evaluation->statistics->local_factorization_count,
+               amplitude->local_factorization_count) ||
+      !add_u64(&evaluation->statistics->global_factorization_count,
+               amplitude->global_factorization_count) ||
+      (amplitude->total_zero &&
+       !increment_u64(&evaluation->statistics->total_zero_count))) {
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus evaluate_node(MVMCEvaluation *evaluation, int depth,
+                                     size_t stack_level,
+                                     const uint64_t *configuration,
+                                     double complex *value) {
+  MVMCKrylovWorkspace *workspace = evaluation->workspace;
+  MVMCMemoEntry *entry = NULL;
+  const uint64_t *canonical = NULL;
+  int inserted = 0;
+  MVMCKrylovStatus status;
+
+  if (depth < 0 || depth > MVMC_KRYLOV_MAX_ORDER ||
+      !increment_u64(&evaluation->statistics->recursion_calls[depth])) {
+    return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                          depth, configuration);
+  }
+  if (stack_level + 1 > evaluation->statistics->frontier_peak) {
+    evaluation->statistics->frontier_peak = stack_level + 1;
+  }
+  status = memo_entry(evaluation, depth, configuration, &entry, &canonical,
+                      &inserted);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    return record_failure(evaluation, status, depth, configuration);
+  }
+  if (!inserted) {
+    if (entry->state == MVMC_MEMO_COMPUTING) {
+      return record_failure(evaluation,
+                            MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE,
+                            depth, canonical);
+    }
+    if (entry->state != MVMC_MEMO_COMPLETE ||
+        !increment_u64(&evaluation->statistics->memo_hits[depth]) ||
+        (depth == 0 &&
+         !increment_u64(&evaluation->statistics->terminal_cache_hits))) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                            depth, canonical);
+    }
+    *value = entry->value;
+    return MVMC_KRYLOV_STATUS_OK;
+  }
+  if (!increment_u64(&evaluation->statistics->memo_misses[depth]) ||
+      !increment_u64(&evaluation->statistics->unique_states[depth])) {
+    return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                          depth, canonical);
+  }
+
+  if (depth == 0) {
+    MVMCKrylovAmplitudeResult amplitude;
+    if (evaluation->statistics->terminal_amplitude_requests >=
+        workspace->limits.max_amplitude_evaluations) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                            depth, canonical);
+    }
+    if (!increment_u64(
+            &evaluation->statistics->terminal_amplitude_requests)) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                            depth, canonical);
+    }
+    memset(&amplitude, 0, sizeof(amplitude));
+    status = evaluation->amplitude(canonical, workspace->word_count,
+                                   evaluation->amplitude_context, &amplitude);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      if (status >= MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+          status <= MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE) {
+        return record_failure(evaluation, status, depth, canonical);
+      }
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE,
+                            depth, canonical);
+    }
+    if (!finite_complex(amplitude.value) ||
+        (amplitude.total_zero != 0 && amplitude.total_zero != 1) ||
+        (amplitude.total_zero != exact_complex_zero(amplitude.value))) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE, depth,
+                            canonical);
+    }
+    status = accumulate_amplitude_statistics(evaluation, &amplitude);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      return record_failure(evaluation, status, depth, canonical);
+    }
+    entry->value = amplitude.value;
+  } else {
+    const size_t neighbor_base = workspace->transition_used;
+    size_t raw_count;
+    size_t merged_count;
+    size_t term_index;
+    size_t neighbor_index;
+    MVMCComplexAccumulator accumulator;
+    memset(&accumulator, 0, sizeof(accumulator));
+
+    for (term_index = 0; term_index < evaluation->model->term_count;
+         ++term_index) {
+      const MVMCKrylovHamiltonianTerm *term =
+          &evaluation->model->terms[term_index];
+      int applied;
+      int fermion_sign;
+      double complex row_weight;
+      if (exact_complex_zero(term->coefficient)) continue;
+      status = apply_term(evaluation->model, term, canonical,
+                          workspace->word_count, workspace->scratch_words,
+                          &applied, &fermion_sign);
+      if (status != MVMC_KRYLOV_STATUS_OK) {
+        return record_failure(evaluation, status, depth, canonical);
+      }
+      if (!applied) continue;
+      if (workspace->transition_used >= workspace->limits.max_transitions) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                              depth, canonical);
+      }
+      row_weight = conj(term->coefficient * (double)fermion_sign);
+      if (!finite_complex(row_weight)) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE, depth,
+                              canonical);
+      }
+      memcpy(workspace->neighbor_words +
+                 workspace->transition_used * workspace->word_count,
+             workspace->scratch_words,
+             workspace->word_count * sizeof(*workspace->scratch_words));
+      workspace->neighbors[workspace->transition_used].key_index =
+          workspace->transition_used;
+      workspace->neighbors[workspace->transition_used].row_weight = row_weight;
+      workspace->neighbors[workspace->transition_used].term_index = term_index;
+      ++workspace->transition_used;
+      if (!increment_u64(&evaluation->statistics->raw_transitions)) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                              depth, canonical);
+      }
+    }
+    raw_count = workspace->transition_used - neighbor_base;
+    sort_neighbors(evaluation, neighbor_base, raw_count);
+    status = merge_neighbors(evaluation, neighbor_base, raw_count,
+                             &merged_count);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      return record_failure(evaluation, status, depth, canonical);
+    }
+    for (neighbor_index = 0; neighbor_index < merged_count;
+         ++neighbor_index) {
+      const MVMCNeighbor neighbor =
+          workspace->neighbors[neighbor_base + neighbor_index];
+      const uint64_t *neighbor_configuration =
+          neighbor_key(workspace, &neighbor);
+      double complex child_value;
+      double complex contribution;
+      status = evaluate_node(evaluation, depth - 1, stack_level + 1,
+                             neighbor_configuration, &child_value);
+      if (status != MVMC_KRYLOV_STATUS_OK) return status;
+      contribution = neighbor.row_weight * child_value;
+      if (!finite_complex(contribution) ||
+          !accumulator_add(&accumulator, contribution)) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE, depth,
+                              canonical);
+      }
+    }
+    entry->value = accumulator_value(&accumulator);
+    if (!finite_complex(entry->value)) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE, depth,
+                            canonical);
+    }
+  }
+  entry->state = MVMC_MEMO_COMPLETE;
+  *value = entry->value;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_krylov_evaluate(
+    MVMCKrylovWorkspace *workspace, const MVMCKrylovFockModel *model,
+    const uint64_t *root_configuration_words, size_t root_word_count,
+    MVMCKrylovAmplitudeCallback amplitude, void *amplitude_context,
+    MVMCKrylovResult *result) {
+  MVMCEvaluation evaluation;
+  MVMCKrylovStatus status;
+  int order;
+
+  reset_result(result);
+  if (workspace == NULL || model == NULL || root_configuration_words == NULL ||
+      amplitude == NULL || result == NULL ||
+      model->site_count != workspace->site_count ||
+      root_word_count != workspace->word_count) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  status = mvmc_krylov_fock_validate(model, root_configuration_words,
+                                     root_word_count);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    result->status = status;
+    result->failure.status = status;
+    return status;
+  }
+  memset(workspace->memo_entries, 0,
+         workspace->memo_slot_count * sizeof(*workspace->memo_entries));
+  workspace->memo_entry_count = 0;
+  workspace->transition_used = 0;
+  result->statistics.root_evaluations = 1;
+  result->statistics.requested_order = workspace->limits.max_order;
+  result->statistics.completed_order = -1;
+  result->statistics.workspace_bytes = workspace->allocated_bytes;
+
+  evaluation.workspace = workspace;
+  evaluation.model = model;
+  evaluation.amplitude = amplitude;
+  evaluation.amplitude_context = amplitude_context;
+  evaluation.statistics = &result->statistics;
+  evaluation.failure = &result->failure;
+
+  for (order = 0; order <= workspace->limits.max_order; ++order) {
+    status = evaluate_node(&evaluation, order, 0, root_configuration_words,
+                           &result->value[order]);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      memset(result->value, 0, sizeof(result->value));
+      result->valid = 0;
+      result->status = status;
+      result->evaluated_order = -1;
+      return status;
+    }
+    result->statistics.completed_order = order;
+  }
+  result->valid = 1;
+  result->status = MVMC_KRYLOV_STATUS_OK;
+  result->evaluated_order = workspace->limits.max_order;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+const char *mvmc_krylov_status_string(MVMCKrylovStatus status) {
+  switch (status) {
+    case MVMC_KRYLOV_STATUS_OK:
+      return "ok";
+    case MVMC_KRYLOV_STATUS_INVALID_ARGUMENT:
+      return "invalid argument";
+    case MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL:
+      return "unsupported model";
+    case MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL:
+      return "non-Hermitian model";
+    case MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE:
+      return "allocation failure";
+    case MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE:
+      return "amplitude failure";
+    case MVMC_KRYLOV_STATUS_NONFINITE:
+      return "nonfinite value";
+    case MVMC_KRYLOV_STATUS_RESOURCE_LIMIT:
+      return "resource limit";
+    case MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE:
+      return "collective failure";
+    case MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE:
+      return "internal invariant failure";
+  }
+  return "unknown status";
+}

--- a/src/mVMC/krylov_fock_reference.c
+++ b/src/mVMC/krylov_fock_reference.c
@@ -745,7 +745,7 @@ static MVMCKrylovStatus evaluate_node(MVMCEvaluation *evaluation, int depth,
   } else {
     const size_t neighbor_base = workspace->transition_used;
     size_t raw_count;
-    size_t merged_count;
+    size_t merged_count = 0;
     size_t term_index;
     size_t neighbor_index;
     MVMCComplexAccumulator accumulator;

--- a/src/mVMC/krylov_fock_reference.c
+++ b/src/mVMC/krylov_fock_reference.c
@@ -17,6 +17,7 @@ the Free Software Foundation, either version 3 of the License, or
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 typedef enum {
   MVMC_MEMO_EMPTY = 0,
@@ -83,6 +84,17 @@ static int checked_multiply_size(size_t lhs, size_t rhs, size_t *result) {
 
 static int finite_complex(double complex value) {
   return isfinite(creal(value)) && isfinite(cimag(value));
+}
+
+static double wall_seconds(void) {
+  struct timespec now;
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return -1.0;
+  return (double)now.tv_sec + 1.0e-9 * (double)now.tv_nsec;
+}
+
+static double elapsed_seconds(double start) {
+  const double end = wall_seconds();
+  return start >= 0.0 && end >= start ? end - start : 0.0;
 }
 
 static int exact_complex_zero(double complex value) {
@@ -694,6 +706,7 @@ static MVMCKrylovStatus evaluate_node(MVMCEvaluation *evaluation, int depth,
 
   if (depth == 0) {
     MVMCKrylovAmplitudeResult amplitude;
+    double amplitude_start;
     if (evaluation->statistics->terminal_amplitude_requests >=
         workspace->limits.max_amplitude_evaluations) {
       return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
@@ -705,8 +718,11 @@ static MVMCKrylovStatus evaluate_node(MVMCEvaluation *evaluation, int depth,
                             depth, canonical);
     }
     memset(&amplitude, 0, sizeof(amplitude));
+    amplitude_start = wall_seconds();
     status = evaluation->amplitude(canonical, workspace->word_count,
                                    evaluation->amplitude_context, &amplitude);
+    evaluation->statistics->amplitude_wall_seconds +=
+        elapsed_seconds(amplitude_start);
     if (status != MVMC_KRYLOV_STATUS_OK) {
       if (status >= MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
           status <= MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE) {
@@ -733,8 +749,10 @@ static MVMCKrylovStatus evaluate_node(MVMCEvaluation *evaluation, int depth,
     size_t term_index;
     size_t neighbor_index;
     MVMCComplexAccumulator accumulator;
+    double connectivity_start;
     memset(&accumulator, 0, sizeof(accumulator));
 
+    connectivity_start = wall_seconds();
     for (term_index = 0; term_index < evaluation->model->term_count;
          ++term_index) {
       const MVMCKrylovHamiltonianTerm *term =
@@ -777,6 +795,8 @@ static MVMCKrylovStatus evaluate_node(MVMCEvaluation *evaluation, int depth,
     sort_neighbors(evaluation, neighbor_base, raw_count);
     status = merge_neighbors(evaluation, neighbor_base, raw_count,
                              &merged_count);
+    evaluation->statistics->connectivity_wall_seconds +=
+        elapsed_seconds(connectivity_start);
     if (status != MVMC_KRYLOV_STATUS_OK) {
       return record_failure(evaluation, status, depth, canonical);
     }
@@ -849,8 +869,11 @@ MVMCKrylovStatus mvmc_krylov_evaluate(
   evaluation.failure = &result->failure;
 
   for (order = 0; order <= workspace->limits.max_order; ++order) {
+    const double depth_start = wall_seconds();
     status = evaluate_node(&evaluation, order, 0, root_configuration_words,
                            &result->value[order]);
+    result->statistics.depth_wall_seconds[order] =
+        elapsed_seconds(depth_start);
     if (status != MVMC_KRYLOV_STATUS_OK) {
       memset(result->value, 0, sizeof(result->value));
       result->valid = 0;

--- a/src/mVMC/makefile_src
+++ b/src/mVMC/makefile_src
@@ -16,6 +16,7 @@ endif
 
 OBJS = \
 	absolute_pfaffian.o \
+	classic_pfaffian_matrix.o \
 	classic_pfaffian_state.o \
 	classic_pfaffian_collective.o \
 	physcal_lanczos.o \
@@ -26,6 +27,7 @@ OBJS = \
 
 SOURCES = \
 absolute_pfaffian.c \
+classic_pfaffian_matrix.c \
 classic_pfaffian_state.c \
 classic_pfaffian_collective.c \
 backflow.c \
@@ -88,6 +90,7 @@ workspace.c
 
 HEADERS = \
 ./include/absolute_pfaffian.h \
+./include/classic_pfaffian_matrix.h \
 ./include/classic_pfaffian_state.h \
 ./include/classic_pfaffian_collective.h \
 ./include/backflow.h \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -249,4 +249,64 @@ if(MPI_FOUND)
         PROCESSORS 4)
 endif()
 
+add_executable(classic_krylov_model_unit
+    classic_krylov_model_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_krylov_model.c)
+target_compile_definitions(classic_krylov_model_unit PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+target_include_directories(classic_krylov_model_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(classic_krylov_model_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(classic_krylov_model_unit m)
+if(MPI_FOUND)
+    target_link_libraries(classic_krylov_model_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ClassicKrylovModel_Unit
+    COMMAND classic_krylov_model_unit)
+if(MPI_FOUND)
+    add_test(NAME ClassicKrylovModel_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_krylov_model_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME ClassicKrylovModel_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_krylov_model_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(ClassicKrylovModel_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(ClassicKrylovModel_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
+
+add_executable(absolute_krylov_classic_ed_driver
+    absolute_krylov_classic_ed_driver.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_krylov_amplitude.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_krylov_model.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(absolute_krylov_classic_ed_driver PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+target_include_directories(absolute_krylov_classic_ed_driver PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(absolute_krylov_classic_ed_driver PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(absolute_krylov_classic_ed_driver pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(absolute_krylov_classic_ed_driver blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(absolute_krylov_classic_ed_driver ${MPI_C_LIBRARIES})
+endif()
+
 add_subdirectory(python)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -187,4 +187,19 @@ endif()
 add_test(NAME ClassicPfaffianLegacyExecutionAB_Unit
     COMMAND classic_pfaffian_legacy_ab_unit)
 
+add_executable(absolute_krylov_reference_unit
+    absolute_krylov_reference_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c)
+target_compile_definitions(absolute_krylov_reference_unit PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+target_include_directories(absolute_krylov_reference_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(absolute_krylov_reference_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(absolute_krylov_reference_unit m)
+add_test(NAME AbsoluteKrylovReference_Unit
+    COMMAND absolute_krylov_reference_unit)
+
 add_subdirectory(python)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,7 @@ endif()
 
 add_executable(classic_pfaffian_state_unit
     classic_pfaffian_state_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
 target_include_directories(classic_pfaffian_state_unit PRIVATE
@@ -91,6 +92,7 @@ add_test(NAME ClassicPfaffianState_Unit COMMAND classic_pfaffian_state_unit)
 add_executable(classic_pfaffian_collective_unit
     classic_pfaffian_collective_unit.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
 target_include_directories(classic_pfaffian_collective_unit PRIVATE
@@ -131,6 +133,7 @@ add_executable(classic_pfaffian_sampler_unit
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_sampler.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_audit.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
 target_compile_definitions(classic_pfaffian_sampler_unit PRIVATE
@@ -172,6 +175,7 @@ endif()
 add_executable(classic_pfaffian_legacy_ab_unit
     classic_pfaffian_legacy_ab_unit.c
     classic_pfaffian_legacy_matrix_tu.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
 target_include_directories(classic_pfaffian_legacy_ab_unit PRIVATE
@@ -201,5 +205,48 @@ endif()
 target_link_libraries(absolute_krylov_reference_unit m)
 add_test(NAME AbsoluteKrylovReference_Unit
     COMMAND absolute_krylov_reference_unit)
+
+add_executable(classic_krylov_amplitude_unit
+    classic_krylov_amplitude_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_krylov_amplitude.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(classic_krylov_amplitude_unit PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+target_include_directories(classic_krylov_amplitude_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(classic_krylov_amplitude_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(classic_krylov_amplitude_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(classic_krylov_amplitude_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(classic_krylov_amplitude_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ClassicKrylovAmplitude_Unit
+    COMMAND classic_krylov_amplitude_unit)
+if(MPI_FOUND)
+    add_test(NAME ClassicKrylovAmplitude_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_krylov_amplitude_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME ClassicKrylovAmplitude_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:classic_krylov_amplitude_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(ClassicKrylovAmplitude_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(ClassicKrylovAmplitude_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
 
 add_subdirectory(python)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -309,4 +309,52 @@ if(MPI_FOUND)
     target_link_libraries(absolute_krylov_classic_ed_driver ${MPI_C_LIBRARIES})
 endif()
 
+add_executable(absolute_krylov_profile_driver
+    absolute_krylov_profile_driver.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_krylov_amplitude.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_krylov_model.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_state.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(absolute_krylov_profile_driver PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+target_include_directories(absolute_krylov_profile_driver PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(absolute_krylov_profile_driver PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(absolute_krylov_profile_driver pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(absolute_krylov_profile_driver blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(absolute_krylov_profile_driver ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME AbsoluteKrylovProfile_Smoke
+    COMMAND absolute_krylov_profile_driver 4 1 3 1)
+add_test(NAME AbsoluteKrylovProfile_InvalidOddSite
+    COMMAND absolute_krylov_profile_driver 5 1 1 1)
+add_test(NAME AbsoluteKrylovProfile_InvalidQP
+    COMMAND absolute_krylov_profile_driver 4 2 1 1)
+add_test(NAME AbsoluteKrylovProfile_InvalidSampleCount
+    COMMAND absolute_krylov_profile_driver 4 1 37 1)
+set_tests_properties(
+    AbsoluteKrylovProfile_InvalidOddSite
+    AbsoluteKrylovProfile_InvalidQP
+    AbsoluteKrylovProfile_InvalidSampleCount
+    PROPERTIES WILL_FAIL TRUE)
+if(MPI_FOUND)
+    add_test(NAME AbsoluteKrylovProfile_ResourceLimit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                $<TARGET_FILE:absolute_krylov_profile_driver> 16 4 1 1)
+    set_tests_properties(
+        AbsoluteKrylovProfile_ResourceLimit_Rank2_mpi PROPERTIES
+        WILL_FAIL TRUE TIMEOUT 30 PROCESSORS 2
+        ENVIRONMENT "OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1")
+endif()
+
 add_subdirectory(python)

--- a/test/absolute_krylov_classic_ed_driver.c
+++ b/test/absolute_krylov_classic_ed_driver.c
@@ -193,7 +193,7 @@ static MVMCClassicKrylovAmplitudeLayout amplitude_layout(int pure_spin) {
   layout.qp_total = 1;
   layout.qp_start = rank / size;
   layout.qp_end = (rank + 1) / size;
-  layout.scaled_pivot_tolerance = 64.0;
+  layout.scaled_pivot_tolerance = 0.0;
   if (!pure_spin) {
     layout.nproj = 1;
     layout.ngutzwiller_idx = 1;

--- a/test/absolute_krylov_classic_ed_driver.c
+++ b/test/absolute_krylov_classic_ed_driver.c
@@ -1,0 +1,338 @@
+#include "classic_krylov_amplitude.h"
+#include "classic_krylov_model.h"
+#include "krylov_fock_reference.h"
+
+#include <complex.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+enum { SITE_COUNT = 4, ORBITAL_COUNT = 8 };
+
+typedef struct {
+  MVMCClassicKrylovRawModel raw;
+  MVMCClassicKrylovTransfer transfers[20];
+  MVMCClassicKrylovSiteCoupling intra[SITE_COUNT];
+  MVMCClassicKrylovPairCoupling inter[2];
+  MVMCClassicKrylovPairCoupling hund[4];
+  MVMCClassicKrylovPairCoupling exchange[4];
+} FixtureModel;
+
+static int world_rank(void) {
+#ifdef _mpi_use
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  return rank;
+#else
+  return 0;
+#endif
+}
+
+static int world_size(void) {
+#ifdef _mpi_use
+  int size = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  return size;
+#else
+  return 1;
+#endif
+}
+
+static MVMCClassicPfaffianCommunicator world_communicator(void) {
+#ifdef _mpi_use
+  return MPI_COMM_WORLD;
+#else
+  return 0;
+#endif
+}
+
+static int bit_count(unsigned int value) {
+  int count = 0;
+  while (value != 0U) {
+    count += (int)(value & 1U);
+    value >>= 1;
+  }
+  return count;
+}
+
+static void initialize_electronic_model(FixtureModel *fixture,
+                                        int complex_case) {
+  static const int bonds[4][2] = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
+  static const double intra_values[SITE_COUNT] = {0.25, -0.125, 0.375,
+                                                   -0.3125};
+  int transfer_count = 0;
+  int bond;
+  int spin;
+
+  memset(fixture, 0, sizeof(*fixture));
+  for (bond = 0; bond < 4; ++bond) {
+    const int left = bonds[bond][0];
+    const int right = bonds[bond][1];
+    const double complex hopping =
+        complex_case ? (0.75 + (0.125 + 0.0625 * (double)bond) * I)
+                     : (0.75 + 0.0 * I);
+    for (spin = 0; spin < 2; ++spin) {
+      fixture->transfers[transfer_count++] =
+          (MVMCClassicKrylovTransfer){left, spin, right, spin, hopping};
+      fixture->transfers[transfer_count++] =
+          (MVMCClassicKrylovTransfer){right, spin, left, spin,
+                                      conj(hopping)};
+    }
+  }
+  fixture->transfers[transfer_count++] =
+      (MVMCClassicKrylovTransfer){1, 0, 1, 0, 0.4375};
+  for (spin = 0; spin < SITE_COUNT; ++spin) {
+    fixture->intra[spin] =
+        (MVMCClassicKrylovSiteCoupling){spin, intra_values[spin]};
+  }
+  fixture->inter[0] = (MVMCClassicKrylovPairCoupling){0, 2, 0.1875};
+  fixture->inter[1] = (MVMCClassicKrylovPairCoupling){1, 3, -0.15625};
+  fixture->hund[0] = (MVMCClassicKrylovPairCoupling){0, 1, 0.21875};
+  fixture->hund[1] = (MVMCClassicKrylovPairCoupling){2, 3, -0.09375};
+
+  fixture->raw.site_count = SITE_COUNT;
+  fixture->raw.up_electron_count = 2;
+  fixture->raw.down_electron_count = 2;
+  fixture->raw.transfer_count = transfer_count;
+  fixture->raw.transfers = fixture->transfers;
+  fixture->raw.coulomb_intra_count = SITE_COUNT;
+  fixture->raw.coulomb_intra = fixture->intra;
+  fixture->raw.coulomb_inter_count = 2;
+  fixture->raw.coulomb_inter = fixture->inter;
+  fixture->raw.hund_count = 2;
+  fixture->raw.hund = fixture->hund;
+}
+
+static void initialize_spin_model(FixtureModel *fixture) {
+  static const double hund_values[4] = {0.375, -0.25, 0.1875, -0.125};
+  static const double exchange_values[4] = {0.625, -0.3125, 0.4375,
+                                             -0.5625};
+  int bond;
+
+  memset(fixture, 0, sizeof(*fixture));
+  for (bond = 0; bond < 4; ++bond) {
+    fixture->hund[bond] =
+        (MVMCClassicKrylovPairCoupling){bond, (bond + 1) % 4,
+                                        hund_values[bond]};
+    fixture->exchange[bond] =
+        (MVMCClassicKrylovPairCoupling){bond, (bond + 1) % 4,
+                                        exchange_values[bond]};
+  }
+  fixture->raw.site_count = SITE_COUNT;
+  fixture->raw.up_electron_count = 2;
+  fixture->raw.down_electron_count = 2;
+  fixture->raw.pure_spin = 1;
+  fixture->raw.hund_count = 4;
+  fixture->raw.hund = fixture->hund;
+  fixture->raw.exchange_count = 4;
+  fixture->raw.exchange = fixture->exchange;
+}
+
+static void set_real_pair(double *slater, int up, int down, double value) {
+  const int down_orbital = SITE_COUNT + down;
+  slater[(size_t)down_orbital * ORBITAL_COUNT + (size_t)up] = -value;
+  slater[(size_t)up * ORBITAL_COUNT + (size_t)down_orbital] = value;
+}
+
+static void set_complex_pair(double complex *slater, int up, int down,
+                             double complex value) {
+  const int down_orbital = SITE_COUNT + down;
+  slater[(size_t)down_orbital * ORBITAL_COUNT + (size_t)up] = -value;
+  slater[(size_t)up * ORBITAL_COUNT + (size_t)down_orbital] = value;
+}
+
+static void initialize_real_slater(double *slater) {
+  static const double pairs[SITE_COUNT][SITE_COUNT] = {
+      {1.5, -0.5, 1.5, 1.0},
+      {-1.5, 0.5, -1.5, -1.0},
+      {-0.5, 1.5, 1.5, 2.0},
+      {-2.0, -2.0, -1.0, 0.5}};
+  int up;
+  int down;
+  memset(slater, 0, ORBITAL_COUNT * ORBITAL_COUNT * sizeof(*slater));
+  for (up = 0; up < SITE_COUNT; ++up) {
+    for (down = 0; down < SITE_COUNT; ++down) {
+      set_real_pair(slater, up, down, pairs[up][down]);
+    }
+  }
+}
+
+static void initialize_complex_slater(double complex *slater) {
+  double complex pairs[SITE_COUNT][SITE_COUNT] = {
+      {2.0 + I, 1.0 + 1.5 * I, 0.5 - 0.5 * I, 0.5 - 1.5 * I},
+      {-2.0 - I, -1.0 - 1.5 * I, -0.5 + 0.5 * I, -0.5 + 1.5 * I},
+      {0.5 + I, 0.5 + 2.0 * I, -0.5 - 2.0 * I, -0.5 - 1.5 * I},
+      {1.5 + 1.5 * I, 0.5 + 0.5 * I, 1.5 - 1.5 * I,
+       1.5 + 1.5 * I}};
+  int up;
+  int down;
+  memset(slater, 0, ORBITAL_COUNT * ORBITAL_COUNT * sizeof(*slater));
+  for (up = 0; up < SITE_COUNT; ++up) {
+    for (down = 0; down < SITE_COUNT; ++down) {
+      set_complex_pair(slater, up, down, pairs[up][down]);
+    }
+  }
+}
+
+static MVMCClassicKrylovAmplitudeLayout amplitude_layout(int pure_spin) {
+  static const int gutzwiller_indices[SITE_COUNT] = {0, 0, 0, 0};
+  static const double complex projection_parameter[1] = {-0.27};
+  MVMCClassicKrylovAmplitudeLayout layout;
+  const int rank = world_rank();
+  const int size = world_size();
+  memset(&layout, 0, sizeof(layout));
+  layout.site_count = SITE_COUNT;
+  layout.up_electron_count = 2;
+  layout.down_electron_count = 2;
+  layout.pure_spin = pure_spin;
+  layout.qp_total = 1;
+  layout.qp_start = rank / size;
+  layout.qp_end = (rank + 1) / size;
+  layout.scaled_pivot_tolerance = 64.0;
+  if (!pure_spin) {
+    layout.nproj = 1;
+    layout.ngutzwiller_idx = 1;
+    layout.gutzwiller_idx = gutzwiller_indices;
+    layout.projection_parameters = projection_parameter;
+  }
+  layout.communicator = world_communicator();
+  return layout;
+}
+
+static MVMCKrylovLimits fixture_limits(void) {
+  MVMCKrylovLimits limits;
+  limits.max_states = 4096;
+  limits.max_transitions = 262144;
+  limits.max_amplitude_evaluations = 4096;
+  limits.max_bytes = 64 * 1024 * 1024;
+  limits.max_order = 3;
+  return limits;
+}
+
+static int evaluate_case(const char *name, int pure_spin, int complex_case) {
+  FixtureModel fixture;
+  MVMCClassicKrylovModelWorkspace *model_workspace = NULL;
+  MVMCClassicKrylovRealAmplitudeWorkspace *real_workspace = NULL;
+  MVMCClassicKrylovComplexAmplitudeWorkspace *complex_workspace = NULL;
+  MVMCKrylovWorkspace *krylov_workspace = NULL;
+  const MVMCKrylovFockModel *model;
+  MVMCKrylovAmplitudeCallback callback;
+  void *amplitude_context;
+  MVMCKrylovLimits limits = fixture_limits();
+  MVMCKrylovStatus status;
+  MVMCClassicKrylovAmplitudeLayout layout = amplitude_layout(pure_spin);
+  double real_slater[ORBITAL_COUNT * ORBITAL_COUNT];
+  double complex complex_slater[ORBITAL_COUNT * ORBITAL_COUNT];
+  const double complex weights[1] = {1.0};
+  unsigned int up_mask;
+  unsigned int down_mask;
+  const int rank = world_rank();
+  const int size = world_size();
+  int return_code = 1;
+
+  if (pure_spin) {
+    initialize_spin_model(&fixture);
+  } else {
+    initialize_electronic_model(&fixture, complex_case);
+  }
+  status = mvmc_classic_krylov_model_workspace_create_from_root(
+      rank == 0 ? &fixture.raw : NULL, world_communicator(),
+      &model_workspace);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    fprintf(stderr, "%s model create failed on rank %d: %s\n", name, rank,
+            mvmc_krylov_status_string(status));
+    goto cleanup;
+  }
+  if (complex_case) {
+    initialize_complex_slater(complex_slater);
+    status = mvmc_classic_krylov_complex_amplitude_workspace_create(
+        &layout, complex_slater, weights, &complex_workspace);
+    callback = mvmc_classic_krylov_complex_amplitude;
+    amplitude_context = complex_workspace;
+  } else {
+    initialize_real_slater(real_slater);
+    status = mvmc_classic_krylov_real_amplitude_workspace_create(
+        &layout, real_slater, weights, &real_workspace);
+    callback = mvmc_classic_krylov_real_amplitude;
+    amplitude_context = real_workspace;
+  }
+  if (status != MVMC_KRYLOV_STATUS_OK || amplitude_context == NULL) {
+    fprintf(stderr, "%s amplitude create failed on rank %d: %s\n", name,
+            rank, mvmc_krylov_status_string(status));
+    goto cleanup;
+  }
+  model = mvmc_classic_krylov_model(model_workspace);
+  krylov_workspace =
+      mvmc_krylov_workspace_create(SITE_COUNT, &limits, &status);
+  if (krylov_workspace == NULL || status != MVMC_KRYLOV_STATUS_OK) {
+    fprintf(stderr, "%s Krylov workspace create failed: %s\n", name,
+            mvmc_krylov_status_string(status));
+    goto cleanup;
+  }
+  if (rank == 0) {
+    printf("BEGIN %s rank_count %d empty_qp_ranks %d\n", name, size,
+           size - 1);
+  }
+  for (up_mask = 0; up_mask < (1U << SITE_COUNT); ++up_mask) {
+    if (bit_count(up_mask) != 2) continue;
+    for (down_mask = 0; down_mask < (1U << SITE_COUNT); ++down_mask) {
+      uint64_t configuration;
+      MVMCKrylovResult result;
+      int order;
+      if (bit_count(down_mask) != 2) continue;
+      if (pure_spin && down_mask != ((~up_mask) & 0x0fU)) continue;
+      configuration = (uint64_t)up_mask |
+                      ((uint64_t)down_mask << SITE_COUNT);
+      status = mvmc_krylov_evaluate(
+          krylov_workspace, model, &configuration, 1, callback,
+          amplitude_context, &result);
+      if (status != MVMC_KRYLOV_STATUS_OK || !result.valid ||
+          result.evaluated_order != 3) {
+        fprintf(stderr, "%s state=%" PRIu64 " failed on rank %d: %s\n",
+                name, configuration, rank,
+                mvmc_krylov_status_string(status));
+        goto cleanup;
+      }
+      if (rank == 0) {
+        printf("ROW %" PRIu64, configuration);
+        for (order = 0; order <= 3; ++order) {
+          printf(" %.17g %.17g", creal(result.value[order]),
+                 cimag(result.value[order]));
+        }
+        putchar('\n');
+      }
+    }
+  }
+  if (rank == 0) printf("END %s\n", name);
+  return_code = 0;
+
+cleanup:
+  mvmc_krylov_workspace_destroy(krylov_workspace);
+  mvmc_classic_krylov_complex_amplitude_workspace_destroy(complex_workspace);
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(real_workspace);
+  mvmc_classic_krylov_model_workspace_destroy(model_workspace);
+  return return_code;
+}
+
+int main(int argc, char **argv) {
+  int failed = 0;
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  failed |= evaluate_case("electronic_real", 0, 0);
+  failed |= evaluate_case("electronic_complex", 0, 1);
+  failed |= evaluate_case("spin_real", 1, 0);
+  failed |= evaluate_case("spin_complex", 1, 1);
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return failed ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/absolute_krylov_profile_driver.c
+++ b/test/absolute_krylov_profile_driver.c
@@ -1,0 +1,703 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "classic_krylov_amplitude.h"
+#include "classic_krylov_model.h"
+#include "krylov_fock_reference.h"
+
+#include <complex.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <time.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+enum {
+  PROFILE_SCHEMA_VERSION = 1,
+  PROFILE_MAX_SITE_COUNT = 16,
+  PROFILE_DEPTH_COUNT = MVMC_KRYLOV_MAX_ORDER + 1
+};
+
+typedef struct {
+  MVMCClassicKrylovRawModel raw;
+  MVMCClassicKrylovTransfer *transfers;
+  MVMCClassicKrylovSiteCoupling *intra;
+  MVMCClassicKrylovPairCoupling inter[2];
+  MVMCClassicKrylovPairCoupling hund[2];
+} ProfileModel;
+
+typedef enum {
+  COUNTER_ROOT_EVALUATIONS = 0,
+  COUNTER_RECURSION_0,
+  COUNTER_RECURSION_1,
+  COUNTER_RECURSION_2,
+  COUNTER_RECURSION_3,
+  COUNTER_UNIQUE_0,
+  COUNTER_UNIQUE_1,
+  COUNTER_UNIQUE_2,
+  COUNTER_UNIQUE_3,
+  COUNTER_MEMO_HITS_0,
+  COUNTER_MEMO_HITS_1,
+  COUNTER_MEMO_HITS_2,
+  COUNTER_MEMO_HITS_3,
+  COUNTER_MEMO_MISSES_0,
+  COUNTER_MEMO_MISSES_1,
+  COUNTER_MEMO_MISSES_2,
+  COUNTER_MEMO_MISSES_3,
+  COUNTER_RAW_TRANSITIONS,
+  COUNTER_MERGED_DUPLICATES,
+  COUNTER_CANCELLED_ZERO,
+  COUNTER_TERMINAL_REQUESTS,
+  COUNTER_TERMINAL_CACHE_HITS,
+  COUNTER_REGULAR_COMPONENTS,
+  COUNTER_NEAR_PIVOT_COMPONENTS,
+  COUNTER_SINGULAR_COMPONENTS,
+  COUNTER_TOTAL_ZERO,
+  COUNTER_LOCAL_FACTORIZATIONS,
+  COUNTER_GLOBAL_FACTORIZATIONS,
+  COUNTER_FRONTIER_PEAK,
+  COUNTER_MEMO_PEAK,
+  COUNTER_KRYLOV_WORKSPACE_BYTES,
+  COUNTER_MODEL_WORKSPACE_BYTES,
+  COUNTER_AMPLITUDE_WORKSPACE_BYTES,
+  COUNTER_RSS_BYTES,
+  PROFILE_COUNTER_COUNT
+} ProfileCounter;
+
+typedef enum {
+  TIME_DEPTH_0 = 0,
+  TIME_DEPTH_1,
+  TIME_DEPTH_2,
+  TIME_DEPTH_3,
+  TIME_AMPLITUDE,
+  TIME_CONNECTIVITY,
+  TIME_TOTAL,
+  PROFILE_TIME_COUNT
+} ProfileTime;
+
+static int world_rank(void) {
+#ifdef _mpi_use
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  return rank;
+#else
+  return 0;
+#endif
+}
+
+static int world_size(void) {
+#ifdef _mpi_use
+  int size = 1;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  return size;
+#else
+  return 1;
+#endif
+}
+
+static MVMCClassicPfaffianCommunicator world_communicator(void) {
+#ifdef _mpi_use
+  return MPI_COMM_WORLD;
+#else
+  return 0;
+#endif
+}
+
+static double monotonic_seconds(void) {
+  struct timespec now;
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return -1.0;
+  return (double)now.tv_sec + 1.0e-9 * (double)now.tv_nsec;
+}
+
+static double elapsed_seconds(double start) {
+  const double end = monotonic_seconds();
+  return start >= 0.0 && end >= start ? end - start : 0.0;
+}
+
+static int collective_all_ready(int local_ready) {
+#ifdef _mpi_use
+  int global_ready = 0;
+  if (MPI_Allreduce(&local_ready, &global_ready, 1, MPI_INT, MPI_MIN,
+                    MPI_COMM_WORLD) != MPI_SUCCESS) {
+    return 0;
+  }
+  return global_ready;
+#else
+  return local_ready;
+#endif
+}
+
+static uint64_t resident_set_bytes(void) {
+  struct rusage usage;
+  if (getrusage(RUSAGE_SELF, &usage) != 0 || usage.ru_maxrss < 0) return 0;
+#if defined(__APPLE__)
+  return (uint64_t)usage.ru_maxrss;
+#else
+  if ((uint64_t)usage.ru_maxrss > UINT64_MAX / UINT64_C(1024)) {
+    return UINT64_MAX;
+  }
+  return (uint64_t)usage.ru_maxrss * UINT64_C(1024);
+#endif
+}
+
+static int parse_int(const char *text, int minimum, int maximum, int *value) {
+  char *end = NULL;
+  long parsed;
+  if (text == NULL || value == NULL || *text == '\0') return 0;
+  errno = 0;
+  parsed = strtol(text, &end, 10);
+  if (errno != 0 || end == text || *end != '\0' || parsed < minimum ||
+      parsed > maximum) {
+    return 0;
+  }
+  *value = (int)parsed;
+  return 1;
+}
+
+static int popcount_u32(unsigned int value) {
+  int count = 0;
+  while (value != 0U) {
+    value &= value - 1U;
+    ++count;
+  }
+  return count;
+}
+
+static size_t fixed_masks(int site_count, unsigned int **masks) {
+  const unsigned int end = 1U << site_count;
+  const int electron_count = site_count / 2;
+  unsigned int *created;
+  unsigned int mask;
+  size_t count = 0;
+  size_t cursor = 0;
+
+  if (masks == NULL) return 0;
+  *masks = NULL;
+  for (mask = 0; mask < end; ++mask) {
+    if (popcount_u32(mask) == electron_count) ++count;
+  }
+  created = (unsigned int *)malloc(count * sizeof(*created));
+  if (created == NULL) return 0;
+  for (mask = 0; mask < end; ++mask) {
+    if (popcount_u32(mask) == electron_count) created[cursor++] = mask;
+  }
+  *masks = created;
+  return count;
+}
+
+static int initialize_model(ProfileModel *fixture, int site_count) {
+  const int transfer_count = 4 * site_count + 1;
+  int cursor = 0;
+  int bond;
+  int spin;
+
+  if (fixture == NULL) return 0;
+  memset(fixture, 0, sizeof(*fixture));
+  fixture->transfers = (MVMCClassicKrylovTransfer *)calloc(
+      (size_t)transfer_count, sizeof(*fixture->transfers));
+  fixture->intra = (MVMCClassicKrylovSiteCoupling *)calloc(
+      (size_t)site_count, sizeof(*fixture->intra));
+  if (fixture->transfers == NULL || fixture->intra == NULL) return 0;
+
+  for (bond = 0; bond < site_count; ++bond) {
+    const int left = bond;
+    const int right = (bond + 1) % site_count;
+    const double hopping = 0.75 + 0.015625 * (double)(bond % 5);
+    for (spin = 0; spin < 2; ++spin) {
+      fixture->transfers[cursor++] =
+          (MVMCClassicKrylovTransfer){left, spin, right, spin, hopping};
+      fixture->transfers[cursor++] =
+          (MVMCClassicKrylovTransfer){right, spin, left, spin, hopping};
+    }
+  }
+  fixture->transfers[cursor++] =
+      (MVMCClassicKrylovTransfer){1, 0, 1, 0, 0.21875};
+  if (cursor != transfer_count) return 0;
+  for (bond = 0; bond < site_count; ++bond) {
+    const double coefficient =
+        (bond & 1) ? -0.0625 * (double)(1 + bond % 3)
+                   : 0.09375 * (double)(1 + bond % 3);
+    fixture->intra[bond] =
+        (MVMCClassicKrylovSiteCoupling){bond, coefficient};
+  }
+  fixture->inter[0] =
+      (MVMCClassicKrylovPairCoupling){0, site_count / 2, 0.078125};
+  fixture->inter[1] = (MVMCClassicKrylovPairCoupling){
+      1, (1 + site_count / 2) % site_count, -0.046875};
+  fixture->hund[0] =
+      (MVMCClassicKrylovPairCoupling){0, 1, 0.0546875};
+  fixture->hund[1] = (MVMCClassicKrylovPairCoupling){
+      site_count / 2, site_count / 2 + 1, -0.0390625};
+
+  fixture->raw.site_count = site_count;
+  fixture->raw.up_electron_count = site_count / 2;
+  fixture->raw.down_electron_count = site_count / 2;
+  fixture->raw.transfer_count = transfer_count;
+  fixture->raw.transfers = fixture->transfers;
+  fixture->raw.coulomb_intra_count = site_count;
+  fixture->raw.coulomb_intra = fixture->intra;
+  fixture->raw.coulomb_inter_count = 2;
+  fixture->raw.coulomb_inter = fixture->inter;
+  fixture->raw.hund_count = 2;
+  fixture->raw.hund = fixture->hund;
+  return 1;
+}
+
+static void destroy_model(ProfileModel *fixture) {
+  if (fixture == NULL) return;
+  free(fixture->intra);
+  free(fixture->transfers);
+  memset(fixture, 0, sizeof(*fixture));
+}
+
+static int initialize_slater(int site_count, int qp_total, double **slater,
+                             double complex **weights) {
+  const size_t dimension = (size_t)2 * (size_t)site_count;
+  const size_t matrix_count = dimension * dimension;
+  double *created_slater;
+  double complex *created_weights;
+  int qp;
+  int up;
+  int down;
+
+  if (slater == NULL || weights == NULL) return 0;
+  *slater = NULL;
+  *weights = NULL;
+  created_slater =
+      (double *)calloc((size_t)qp_total * matrix_count, sizeof(double));
+  created_weights =
+      (double complex *)calloc((size_t)qp_total, sizeof(double complex));
+  if (created_slater == NULL || created_weights == NULL) {
+    free(created_weights);
+    free(created_slater);
+    return 0;
+  }
+  for (qp = 0; qp < qp_total; ++qp) {
+    static const double weight_values[4] = {1.0, 0.5, -0.25, 0.125};
+    created_weights[qp] = weight_values[qp];
+    for (up = 0; up < site_count; ++up) {
+      for (down = 0; down < site_count; ++down) {
+        const size_t base = (size_t)qp * matrix_count;
+        const size_t up_orbital = (size_t)up;
+        const size_t down_orbital = (size_t)site_count + (size_t)down;
+        const double value =
+            sin(0.31 * (double)(qp + 1) * (double)(up + 1) +
+                0.17 * (double)(down + 1)) +
+            0.5 * cos(0.11 * (double)(qp + 2) * (double)(up + 1) *
+                      (double)(down + 1)) +
+            (up == down ? 0.25 : 0.0);
+        created_slater[base + down_orbital * dimension + up_orbital] =
+            -value;
+        created_slater[base + up_orbital * dimension + down_orbital] =
+            value;
+      }
+    }
+  }
+  *slater = created_slater;
+  *weights = created_weights;
+  return 1;
+}
+
+static MVMCClassicKrylovAmplitudeLayout amplitude_layout(
+    int site_count, int qp_total, const int *gutzwiller_indices,
+    const double complex *projection_parameter) {
+  MVMCClassicKrylovAmplitudeLayout layout;
+  const int rank = world_rank();
+  const int size = world_size();
+  memset(&layout, 0, sizeof(layout));
+  layout.site_count = (size_t)site_count;
+  layout.up_electron_count = (size_t)(site_count / 2);
+  layout.down_electron_count = (size_t)(site_count / 2);
+  layout.qp_total = qp_total;
+  layout.qp_start = rank * qp_total / size;
+  layout.qp_end = (rank + 1) * qp_total / size;
+  layout.scaled_pivot_tolerance = 0.0;
+  layout.nproj = 1;
+  layout.ngutzwiller_idx = 1;
+  layout.gutzwiller_idx = gutzwiller_indices;
+  layout.projection_parameters = projection_parameter;
+  layout.communicator = world_communicator();
+  return layout;
+}
+
+static int checked_multiply_size(size_t left, size_t right, size_t *value) {
+  if (value == NULL || (left != 0 && right > SIZE_MAX / left)) return 0;
+  *value = left * right;
+  return 1;
+}
+
+static int profile_limits(size_t sector_size, size_t term_count,
+                          MVMCKrylovLimits *limits) {
+  size_t max_states;
+  size_t max_transitions;
+  if (limits == NULL || sector_size > (SIZE_MAX - 64) / 4) return 0;
+  max_states = 4 * sector_size + 64;
+  if (!checked_multiply_size(max_states, term_count, &max_transitions)) {
+    return 0;
+  }
+  limits->max_states = max_states;
+  limits->max_transitions = max_transitions;
+  limits->max_amplitude_evaluations = sector_size;
+  limits->max_bytes = (size_t)1024 * 1024 * 1024;
+  limits->max_order = MVMC_KRYLOV_MAX_ORDER;
+  return 1;
+}
+
+static void add_statistics(uint64_t *counters, double *times,
+                           const MVMCKrylovStatistics *statistics) {
+  int depth;
+  counters[COUNTER_ROOT_EVALUATIONS] += statistics->root_evaluations;
+  for (depth = 0; depth < PROFILE_DEPTH_COUNT; ++depth) {
+    counters[COUNTER_RECURSION_0 + depth] +=
+        statistics->recursion_calls[depth];
+    counters[COUNTER_UNIQUE_0 + depth] += statistics->unique_states[depth];
+    counters[COUNTER_MEMO_HITS_0 + depth] += statistics->memo_hits[depth];
+    counters[COUNTER_MEMO_MISSES_0 + depth] += statistics->memo_misses[depth];
+    times[TIME_DEPTH_0 + depth] += statistics->depth_wall_seconds[depth];
+  }
+  counters[COUNTER_RAW_TRANSITIONS] += statistics->raw_transitions;
+  counters[COUNTER_MERGED_DUPLICATES] +=
+      statistics->merged_duplicate_transitions;
+  counters[COUNTER_CANCELLED_ZERO] +=
+      statistics->cancelled_zero_transitions;
+  counters[COUNTER_TERMINAL_REQUESTS] +=
+      statistics->terminal_amplitude_requests;
+  counters[COUNTER_TERMINAL_CACHE_HITS] +=
+      statistics->terminal_cache_hits;
+  counters[COUNTER_REGULAR_COMPONENTS] +=
+      statistics->regular_component_count;
+  counters[COUNTER_NEAR_PIVOT_COMPONENTS] +=
+      statistics->near_pivot_component_count;
+  counters[COUNTER_SINGULAR_COMPONENTS] +=
+      statistics->singular_component_count;
+  counters[COUNTER_TOTAL_ZERO] += statistics->total_zero_count;
+  counters[COUNTER_LOCAL_FACTORIZATIONS] +=
+      statistics->local_factorization_count;
+  counters[COUNTER_GLOBAL_FACTORIZATIONS] +=
+      statistics->global_factorization_count;
+  if ((uint64_t)statistics->frontier_peak >
+      counters[COUNTER_FRONTIER_PEAK]) {
+    counters[COUNTER_FRONTIER_PEAK] = (uint64_t)statistics->frontier_peak;
+  }
+  if ((uint64_t)statistics->memo_entries_peak >
+      counters[COUNTER_MEMO_PEAK]) {
+    counters[COUNTER_MEMO_PEAK] =
+        (uint64_t)statistics->memo_entries_peak;
+  }
+  times[TIME_AMPLITUDE] += statistics->amplitude_wall_seconds;
+  times[TIME_CONNECTIVITY] += statistics->connectivity_wall_seconds;
+}
+
+static void reduce_profile(const uint64_t *local_counters,
+                           const double *local_times,
+                           uint64_t *sum_counters, uint64_t *max_counters,
+                           double *sum_times, double *max_times) {
+#ifdef _mpi_use
+  MPI_Reduce(local_counters, sum_counters, PROFILE_COUNTER_COUNT,
+             MPI_UINT64_T, MPI_SUM, 0, MPI_COMM_WORLD);
+  MPI_Reduce(local_counters, max_counters, PROFILE_COUNTER_COUNT,
+             MPI_UINT64_T, MPI_MAX, 0, MPI_COMM_WORLD);
+  MPI_Reduce(local_times, sum_times, PROFILE_TIME_COUNT, MPI_DOUBLE, MPI_SUM,
+             0, MPI_COMM_WORLD);
+  MPI_Reduce(local_times, max_times, PROFILE_TIME_COUNT, MPI_DOUBLE, MPI_MAX,
+             0, MPI_COMM_WORLD);
+  if (world_rank() == 0) {
+    sum_counters[COUNTER_REGULAR_COMPONENTS] =
+        max_counters[COUNTER_REGULAR_COMPONENTS];
+    sum_counters[COUNTER_NEAR_PIVOT_COMPONENTS] =
+        max_counters[COUNTER_NEAR_PIVOT_COMPONENTS];
+    sum_counters[COUNTER_SINGULAR_COMPONENTS] =
+        max_counters[COUNTER_SINGULAR_COMPONENTS];
+    sum_counters[COUNTER_TOTAL_ZERO] = max_counters[COUNTER_TOTAL_ZERO];
+    sum_counters[COUNTER_GLOBAL_FACTORIZATIONS] =
+        max_counters[COUNTER_GLOBAL_FACTORIZATIONS];
+  }
+#else
+  memcpy(sum_counters, local_counters,
+         PROFILE_COUNTER_COUNT * sizeof(*sum_counters));
+  memcpy(max_counters, local_counters,
+         PROFILE_COUNTER_COUNT * sizeof(*max_counters));
+  memcpy(sum_times, local_times, PROFILE_TIME_COUNT * sizeof(*sum_times));
+  memcpy(max_times, local_times, PROFILE_TIME_COUNT * sizeof(*max_times));
+#endif
+}
+
+static void print_resource(const char *scope, const uint64_t *counter,
+                           const double *time) {
+  printf("RESOURCE scope=%s roots=%" PRIu64, scope,
+         counter[COUNTER_ROOT_EVALUATIONS]);
+  printf(" recursion=%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64,
+         counter[COUNTER_RECURSION_0], counter[COUNTER_RECURSION_1],
+         counter[COUNTER_RECURSION_2], counter[COUNTER_RECURSION_3]);
+  printf(" unique=%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64,
+         counter[COUNTER_UNIQUE_0], counter[COUNTER_UNIQUE_1],
+         counter[COUNTER_UNIQUE_2], counter[COUNTER_UNIQUE_3]);
+  printf(" memo_hits=%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64,
+         counter[COUNTER_MEMO_HITS_0], counter[COUNTER_MEMO_HITS_1],
+         counter[COUNTER_MEMO_HITS_2], counter[COUNTER_MEMO_HITS_3]);
+  printf(" memo_misses=%" PRIu64 ",%" PRIu64 ",%" PRIu64 ",%" PRIu64,
+         counter[COUNTER_MEMO_MISSES_0], counter[COUNTER_MEMO_MISSES_1],
+         counter[COUNTER_MEMO_MISSES_2], counter[COUNTER_MEMO_MISSES_3]);
+  printf(" raw_transitions=%" PRIu64 " merged_duplicates=%" PRIu64,
+         counter[COUNTER_RAW_TRANSITIONS],
+         counter[COUNTER_MERGED_DUPLICATES]);
+  printf(" cancelled_zero=%" PRIu64 " terminal_requests=%" PRIu64,
+         counter[COUNTER_CANCELLED_ZERO],
+         counter[COUNTER_TERMINAL_REQUESTS]);
+  printf(" terminal_cache_hits=%" PRIu64,
+         counter[COUNTER_TERMINAL_CACHE_HITS]);
+  printf(" regular_logical=%" PRIu64 " near_pivot_logical=%" PRIu64,
+         counter[COUNTER_REGULAR_COMPONENTS],
+         counter[COUNTER_NEAR_PIVOT_COMPONENTS]);
+  printf(" singular_logical=%" PRIu64 " total_zero_logical=%" PRIu64,
+         counter[COUNTER_SINGULAR_COMPONENTS], counter[COUNTER_TOTAL_ZERO]);
+  printf(" local_factorizations=%" PRIu64,
+         counter[COUNTER_LOCAL_FACTORIZATIONS]);
+  printf(" global_factorizations_logical=%" PRIu64,
+         counter[COUNTER_GLOBAL_FACTORIZATIONS]);
+  printf(" frontier_peak=%" PRIu64 " memo_peak=%" PRIu64,
+         counter[COUNTER_FRONTIER_PEAK], counter[COUNTER_MEMO_PEAK]);
+  printf(" krylov_workspace_bytes=%" PRIu64,
+         counter[COUNTER_KRYLOV_WORKSPACE_BYTES]);
+  printf(" model_workspace_bytes=%" PRIu64,
+         counter[COUNTER_MODEL_WORKSPACE_BYTES]);
+  printf(" amplitude_workspace_bytes=%" PRIu64,
+         counter[COUNTER_AMPLITUDE_WORKSPACE_BYTES]);
+  printf(" rss_bytes=%" PRIu64, counter[COUNTER_RSS_BYTES]);
+  printf(" depth_seconds=%.17g,%.17g,%.17g,%.17g",
+         time[TIME_DEPTH_0], time[TIME_DEPTH_1], time[TIME_DEPTH_2],
+         time[TIME_DEPTH_3]);
+  printf(" amplitude_seconds=%.17g connectivity_seconds=%.17g",
+         time[TIME_AMPLITUDE], time[TIME_CONNECTIVITY]);
+  printf(" total_seconds=%.17g\n", time[TIME_TOTAL]);
+}
+
+static int run_profile(int site_count, int qp_total, int requested_samples,
+                       int audit) {
+  ProfileModel fixture;
+  MVMCClassicKrylovModelWorkspace *model_workspace = NULL;
+  MVMCClassicKrylovRealAmplitudeWorkspace *amplitude_workspace = NULL;
+  MVMCKrylovWorkspace *krylov_workspace = NULL;
+  const MVMCKrylovFockModel *model = NULL;
+  MVMCKrylovLimits limits;
+  MVMCKrylovStatus status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  unsigned int *masks = NULL;
+  size_t mask_count = 0;
+  size_t sector_size = 0;
+  size_t sample_count = 0;
+  double *slater = NULL;
+  double complex *weights = NULL;
+  int *gutzwiller_indices = NULL;
+  const double complex projection_parameter[1] = {-0.27};
+  MVMCClassicKrylovAmplitudeLayout layout;
+  uint64_t local_counters[PROFILE_COUNTER_COUNT] = {0};
+  uint64_t sum_counters[PROFILE_COUNTER_COUNT] = {0};
+  uint64_t max_counters[PROFILE_COUNTER_COUNT] = {0};
+  double local_times[PROFILE_TIME_COUNT] = {0.0};
+  double sum_times[PROFILE_TIME_COUNT] = {0.0};
+  double max_times[PROFILE_TIME_COUNT] = {0.0};
+  const int rank = world_rank();
+  const int size = world_size();
+  size_t sample;
+  int local_ready = 1;
+  int return_code = 1;
+
+  memset(&fixture, 0, sizeof(fixture));
+  mask_count = fixed_masks(site_count, &masks);
+  if (mask_count == 0 || !checked_multiply_size(mask_count, mask_count,
+                                                &sector_size)) {
+    local_ready = 0;
+  }
+  if (local_ready) {
+    sample_count = requested_samples == 0 ? sector_size :
+                                               (size_t)requested_samples;
+    if (sample_count == 0 || sample_count > sector_size ||
+        !initialize_model(&fixture, site_count) ||
+        !initialize_slater(site_count, qp_total, &slater, &weights)) {
+      local_ready = 0;
+    }
+  }
+  if (local_ready) {
+    gutzwiller_indices =
+        (int *)calloc((size_t)site_count, sizeof(*gutzwiller_indices));
+    if (gutzwiller_indices == NULL) local_ready = 0;
+  }
+  if (!collective_all_ready(local_ready)) {
+    if (rank == 0) {
+      fprintf(stderr, "profile fixture allocation/preflight failed\n");
+    }
+    goto cleanup;
+  }
+  layout = amplitude_layout(site_count, qp_total, gutzwiller_indices,
+                            projection_parameter);
+  status = mvmc_classic_krylov_model_workspace_create_from_root(
+      rank == 0 ? &fixture.raw : NULL, world_communicator(),
+      &model_workspace);
+  if (!collective_all_ready(status == MVMC_KRYLOV_STATUS_OK)) {
+    if (rank == 0) {
+      fprintf(stderr, "model create failed collectively: %s\n",
+              mvmc_krylov_status_string(status));
+    }
+    goto cleanup;
+  }
+  status = mvmc_classic_krylov_real_amplitude_workspace_create(
+      &layout, slater, weights, &amplitude_workspace);
+  if (!collective_all_ready(status == MVMC_KRYLOV_STATUS_OK)) {
+    if (rank == 0) {
+      fprintf(stderr, "amplitude create failed collectively: %s\n",
+              mvmc_krylov_status_string(status));
+    }
+    goto cleanup;
+  }
+  model = mvmc_classic_krylov_model(model_workspace);
+  local_ready = model != NULL;
+  if (local_ready &&
+      !profile_limits(sector_size, model->term_count, &limits)) {
+    local_ready = 0;
+  }
+  if (local_ready) {
+    krylov_workspace =
+        mvmc_krylov_workspace_create((size_t)site_count, &limits, &status);
+    local_ready = krylov_workspace != NULL &&
+                  status == MVMC_KRYLOV_STATUS_OK;
+  }
+  if (!collective_all_ready(local_ready)) {
+    if (rank == 0) {
+      fprintf(stderr, "Krylov workspace create failed collectively: %s\n",
+              mvmc_krylov_status_string(status));
+    }
+    goto cleanup;
+  }
+  local_counters[COUNTER_KRYLOV_WORKSPACE_BYTES] =
+      (uint64_t)mvmc_krylov_workspace_bytes(krylov_workspace);
+  local_counters[COUNTER_MODEL_WORKSPACE_BYTES] =
+      (uint64_t)mvmc_classic_krylov_model_workspace_bytes(model_workspace);
+  local_counters[COUNTER_AMPLITUDE_WORKSPACE_BYTES] =
+      (uint64_t)mvmc_classic_krylov_real_amplitude_workspace_bytes(
+          amplitude_workspace);
+  if (rank == 0) {
+    printf("PROFILE schema=%d fixture=p3_scaling_electronic_real",
+           PROFILE_SCHEMA_VERSION);
+    printf(" site_count=%d qp_total=%d sample_count=%zu sector_size=%zu",
+           site_count, qp_total, sample_count, sector_size);
+    printf(" rank_count=%d audit=%d\n", size, audit);
+  }
+  for (sample = 0; sample < sample_count; ++sample) {
+    const size_t sector_index =
+        sample_count == 1
+            ? (sector_size - 1) / 2
+            : sample * (sector_size - 1) / (sample_count - 1);
+    const size_t up_index = sector_index / mask_count;
+    const size_t down_index = sector_index % mask_count;
+    const uint64_t configuration =
+        (uint64_t)masks[up_index] |
+        ((uint64_t)masks[down_index] << (unsigned int)site_count);
+    MVMCKrylovResult result;
+    const double evaluation_start = monotonic_seconds();
+    int order;
+    status = mvmc_krylov_evaluate(
+        krylov_workspace, model, &configuration, 1,
+        mvmc_classic_krylov_real_amplitude, amplitude_workspace, &result);
+    local_ready = status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+                  result.evaluated_order == MVMC_KRYLOV_MAX_ORDER;
+    if (!collective_all_ready(local_ready)) {
+      if (rank == 0) {
+        fprintf(stderr,
+                "profile state=%" PRIu64 " failed collectively: %s\n",
+                configuration, mvmc_krylov_status_string(status));
+      }
+      goto cleanup;
+    }
+    local_times[TIME_TOTAL] += elapsed_seconds(evaluation_start);
+    add_statistics(local_counters, local_times, &result.statistics);
+    if (rank == 0) {
+      printf("ROW %zu %zu %" PRIu64, sample, sector_index, configuration);
+      for (order = 0; order < PROFILE_DEPTH_COUNT; ++order) {
+        printf(" %.17g %.17g", creal(result.value[order]),
+               cimag(result.value[order]));
+      }
+      putchar('\n');
+      if (audit) {
+        printf("STAT %zu", sample);
+        printf(" depth_seconds=%.17g,%.17g,%.17g,%.17g",
+               result.statistics.depth_wall_seconds[0],
+               result.statistics.depth_wall_seconds[1],
+               result.statistics.depth_wall_seconds[2],
+               result.statistics.depth_wall_seconds[3]);
+        printf(" terminal_requests=%" PRIu64,
+               result.statistics.terminal_amplitude_requests);
+        printf(" raw_transitions=%" PRIu64,
+               result.statistics.raw_transitions);
+        printf(" memo_peak=%zu workspace_bytes=%zu\n",
+               result.statistics.memo_entries_peak,
+               result.statistics.workspace_bytes);
+      }
+    }
+  }
+  local_counters[COUNTER_RSS_BYTES] = resident_set_bytes();
+  reduce_profile(local_counters, local_times, sum_counters, max_counters,
+                 sum_times, max_times);
+  if (rank == 0 && audit) {
+    print_resource("rank_sum", sum_counters, sum_times);
+    print_resource("rank_max", max_counters, max_times);
+  }
+  return_code = 0;
+
+cleanup:
+  mvmc_krylov_workspace_destroy(krylov_workspace);
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(amplitude_workspace);
+  mvmc_classic_krylov_model_workspace_destroy(model_workspace);
+  free(gutzwiller_indices);
+  free(weights);
+  free(slater);
+  destroy_model(&fixture);
+  free(masks);
+  return return_code;
+}
+
+int main(int argc, char **argv) {
+  int site_count;
+  int qp_total;
+  int sample_count;
+  int audit;
+  int result;
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+#endif
+  if (argc != 5 ||
+      !parse_int(argv[1], 4, PROFILE_MAX_SITE_COUNT, &site_count) ||
+      (site_count & 1) != 0 || !parse_int(argv[2], 1, 4, &qp_total) ||
+      (qp_total != 1 && qp_total != 4) ||
+      !parse_int(argv[3], 0, 100000000, &sample_count) ||
+      !parse_int(argv[4], 0, 1, &audit)) {
+    if (world_rank() == 0) {
+      fprintf(stderr,
+              "usage: %s EVEN_SITE_COUNT(4..16) QP_TOTAL(1|4) "
+              "SAMPLES(0=all) AUDIT(0|1)\n",
+              argv[0]);
+    }
+    result = EXIT_FAILURE;
+  } else {
+    result = run_profile(site_count, qp_total, sample_count, audit) == 0
+                 ? EXIT_SUCCESS
+                 : EXIT_FAILURE;
+  }
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return result;
+}

--- a/test/absolute_krylov_reference_unit.c
+++ b/test/absolute_krylov_reference_unit.c
@@ -1,0 +1,797 @@
+#include <complex.h>
+#include <float.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "krylov_fock_reference.h"
+
+static int failures = 0;
+
+#define CHECK(condition, ...)                                                   \
+  do {                                                                          \
+    if (!(condition)) {                                                         \
+      fprintf(stderr, "AbsoluteKrylovReference_Unit FAIL: ");                  \
+      fprintf(stderr, __VA_ARGS__);                                             \
+      fprintf(stderr, "\n");                                                   \
+      ++failures;                                                               \
+    }                                                                           \
+  } while (0)
+
+typedef struct {
+  double complex values[64];
+  size_t calls;
+  size_t trace[64];
+  size_t trace_count;
+  MVMCKrylovStatus forced_status;
+  int return_nonfinite;
+  int mismatch_zero_classification;
+} TableAmplitude;
+
+static size_t SmallConfigurationIndex(const uint64_t *words,
+                                      size_t word_count) {
+  if (word_count != 1) return 63;
+  return (size_t)(words[0] & UINT64_C(63));
+}
+
+static MVMCKrylovStatus TableAmplitudeCallback(
+    const uint64_t *words, size_t word_count, void *context,
+    MVMCKrylovAmplitudeResult *result) {
+  TableAmplitude *table = (TableAmplitude *)context;
+  const size_t index = SmallConfigurationIndex(words, word_count);
+  ++table->calls;
+  if (table->trace_count < sizeof(table->trace) / sizeof(table->trace[0])) {
+    table->trace[table->trace_count++] = index;
+  }
+  if (table->forced_status != MVMC_KRYLOV_STATUS_OK) {
+    return table->forced_status;
+  }
+  memset(result, 0, sizeof(*result));
+  result->value = table->return_nonfinite ? NAN + 0.0 * I : table->values[index];
+  result->total_zero =
+      creal(result->value) == 0.0 && cimag(result->value) == 0.0;
+  if (table->mismatch_zero_classification) {
+    result->total_zero = !result->total_zero;
+  }
+  result->regular_component_count = 1;
+  result->local_factorization_count = 1;
+  result->global_factorization_count = 1;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovLimits DefaultLimits(int order) {
+  MVMCKrylovLimits limits;
+  limits.max_states = 512;
+  limits.max_transitions = 4096;
+  limits.max_amplitude_evaluations = 512;
+  limits.max_bytes = 16 * 1024 * 1024;
+  limits.max_order = order;
+  return limits;
+}
+
+static int ComplexClose(double complex actual, double complex expected,
+                        double tolerance) {
+  const double scale = 1.0 + cabs(expected);
+  return cabs(actual - expected) <= tolerance * scale;
+}
+
+static int DeterministicStatisticsEqual(const MVMCKrylovStatistics *lhs,
+                                        const MVMCKrylovStatistics *rhs) {
+  return lhs->root_evaluations == rhs->root_evaluations &&
+         lhs->requested_order == rhs->requested_order &&
+         lhs->completed_order == rhs->completed_order &&
+         memcmp(lhs->recursion_calls, rhs->recursion_calls,
+                sizeof(lhs->recursion_calls)) == 0 &&
+         memcmp(lhs->unique_states, rhs->unique_states,
+                sizeof(lhs->unique_states)) == 0 &&
+         memcmp(lhs->memo_hits, rhs->memo_hits, sizeof(lhs->memo_hits)) == 0 &&
+         memcmp(lhs->memo_misses, rhs->memo_misses,
+                sizeof(lhs->memo_misses)) == 0 &&
+         lhs->raw_transitions == rhs->raw_transitions &&
+         lhs->merged_duplicate_transitions ==
+             rhs->merged_duplicate_transitions &&
+         lhs->cancelled_zero_transitions ==
+             rhs->cancelled_zero_transitions &&
+         lhs->terminal_amplitude_requests ==
+             rhs->terminal_amplitude_requests &&
+         lhs->terminal_cache_hits == rhs->terminal_cache_hits &&
+         lhs->regular_component_count == rhs->regular_component_count &&
+         lhs->near_pivot_component_count ==
+             rhs->near_pivot_component_count &&
+         lhs->singular_component_count == rhs->singular_component_count &&
+         lhs->total_zero_count == rhs->total_zero_count &&
+         lhs->local_factorization_count == rhs->local_factorization_count &&
+         lhs->global_factorization_count == rhs->global_factorization_count &&
+         lhs->frontier_peak == rhs->frontier_peak &&
+         lhs->memo_entries_peak == rhs->memo_entries_peak &&
+         lhs->workspace_bytes == rhs->workspace_bytes;
+}
+
+static MVMCKrylovFockModel ElectronicModel(
+    size_t site_count, size_t up_count, size_t down_count,
+    const MVMCKrylovHamiltonianTerm *terms, size_t term_count,
+    const MVMCKrylovFermionOperator *operators, size_t operator_count) {
+  MVMCKrylovFockModel model;
+  memset(&model, 0, sizeof(model));
+  model.site_count = site_count;
+  model.up_electron_count = up_count;
+  model.down_electron_count = down_count;
+  model.hermitian = 1;
+  model.terms = terms;
+  model.term_count = term_count;
+  model.operators = operators;
+  model.operator_count = operator_count;
+  return model;
+}
+
+static MVMCKrylovStatus Evaluate(
+    const MVMCKrylovFockModel *model, uint64_t root,
+    const MVMCKrylovLimits *limits, TableAmplitude *amplitude,
+    MVMCKrylovResult *result) {
+  MVMCKrylovStatus status;
+  MVMCKrylovWorkspace *workspace =
+      mvmc_krylov_workspace_create(model->site_count, limits, &status);
+  if (workspace == NULL) return status;
+  status = mvmc_krylov_evaluate(workspace, model, &root, 1,
+                                TableAmplitudeCallback, amplitude, result);
+  mvmc_krylov_workspace_destroy(workspace);
+  return status;
+}
+
+static void TestConfigurationContract(void) {
+  MVMCKrylovFockModel model = ElectronicModel(33, 1, 1, NULL, 0, NULL, 0);
+  uint64_t words[2] = {UINT64_C(1), UINT64_C(2)};
+  CHECK(mvmc_krylov_fock_word_count(33) == 2,
+        "33-site configuration must use two words");
+  CHECK(mvmc_krylov_fock_validate(&model, words, 2) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "multiword electronic configuration rejected");
+  words[1] |= UINT64_C(4);
+  CHECK(mvmc_krylov_fock_validate(&model, words, 2) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "nonzero padding bit accepted");
+  words[1] &= ~UINT64_C(4);
+  CHECK(mvmc_krylov_fock_validate(&model, words, 1) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "wrong word count accepted");
+
+  model = ElectronicModel(2, 1, 1, NULL, 0, NULL, 0);
+  model.pure_spin = 1;
+  {
+    const uint64_t valid = UINT64_C(1) | (UINT64_C(1) << 3);
+    const uint64_t double_occupied = UINT64_C(1) | (UINT64_C(1) << 2);
+    CHECK(mvmc_krylov_fock_validate(&model, &valid, 1) ==
+              MVMC_KRYLOV_STATUS_OK,
+          "valid pure-spin configuration rejected");
+    CHECK(mvmc_krylov_fock_validate(&model, &double_occupied, 1) ==
+              MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "pure-spin double occupation/empty site accepted");
+  }
+}
+
+static void TestDenseThreeStateED(void) {
+  const double complex a = 0.7 + 0.2 * I;
+  const double complex b = -0.3 + 0.4 * I;
+  const double diagonal[3] = {0.25, -0.5, 0.75};
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 2},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+      {MVMC_KRYLOV_FERMION_CREATE, 2},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {diagonal[0], 0, 2, 0, 0}, {diagonal[1], 2, 2, 0, 1},
+      {diagonal[2], 4, 2, 0, 2}, {a, 6, 2, 1, 0},
+      {conj(a), 8, 2, 1, 1},     {b, 10, 2, 1, 2},
+      {conj(b), 12, 2, 1, 3},
+  };
+  const MVMCKrylovFockModel model = ElectronicModel(
+      3, 1, 0, terms, sizeof(terms) / sizeof(terms[0]), operators,
+      sizeof(operators) / sizeof(operators[0]));
+  const double complex matrix[3][3] = {
+      {diagonal[0], a, 0.0},
+      {conj(a), diagonal[1], b},
+      {0.0, conj(b), diagonal[2]},
+  };
+  double complex expected[4][3];
+  TableAmplitude amplitude;
+  MVMCKrylovLimits limits = DefaultLimits(3);
+  int order;
+  int row;
+  memset(&amplitude, 0, sizeof(amplitude));
+  expected[0][0] = 0.2 - 0.1 * I;
+  expected[0][1] = -0.3 + 0.8 * I;
+  expected[0][2] = 0.6 + 0.4 * I;
+  amplitude.values[1] = expected[0][0];
+  amplitude.values[2] = expected[0][1];
+  amplitude.values[4] = expected[0][2];
+  for (order = 1; order <= 3; ++order) {
+    for (row = 0; row < 3; ++row) {
+      int column;
+      expected[order][row] = 0.0;
+      for (column = 0; column < 3; ++column) {
+        expected[order][row] +=
+            matrix[row][column] * expected[order - 1][column];
+      }
+    }
+  }
+  for (row = 0; row < 3; ++row) {
+    MVMCKrylovResult result;
+    MVMCKrylovStatus status =
+        Evaluate(&model, UINT64_C(1) << row, &limits, &amplitude, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid,
+          "dense ED root %d failed: %s", row,
+          mvmc_krylov_status_string(status));
+    for (order = 0; order <= 3; ++order) {
+      CHECK(ComplexClose(result.value[order], expected[order][row], 2e-13),
+            "dense ED root=%d order=%d got=(%.17g,%.17g) expected=(%.17g,%.17g)",
+            row, order, creal(result.value[order]), cimag(result.value[order]),
+            creal(expected[order][row]), cimag(expected[order][row]));
+    }
+  }
+}
+
+static void TestZeroBridgesAndMemoization(void) {
+  const double complex a = 1.0 + 2.0 * I;
+  const MVMCKrylovFermionOperator two_site_operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm two_site_terms[] = {
+      {a, 0, 2, 1, 0}, {conj(a), 2, 2, 1, 1}};
+  const MVMCKrylovFockModel two_site_model = ElectronicModel(
+      2, 1, 0, two_site_terms, 2, two_site_operators, 4);
+  TableAmplitude amplitude;
+  MVMCKrylovLimits limits = DefaultLimits(3);
+  MVMCKrylovResult result;
+  const double complex terminal = 3.0 - I;
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.values[1] = 0.0;
+  amplitude.values[2] = terminal;
+  CHECK(Evaluate(&two_site_model, UINT64_C(1), &limits, &amplitude, &result) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "one-step zero bridge evaluation failed");
+  CHECK(result.value[0] == 0.0,
+        "zero bridge v0 must remain exact zero");
+  CHECK(ComplexClose(result.value[1], a * terminal, 1e-14),
+        "one-step zero bridge was truncated");
+  CHECK(result.value[2] == 0.0,
+        "two-site zero bridge v2 must return to zero amplitude");
+  CHECK(ComplexClose(result.value[3], a * terminal * (creal(a * conj(a))),
+                     1e-14),
+        "one-step zero bridge v3 mismatch");
+  CHECK(result.statistics.terminal_amplitude_requests == 2,
+        "terminal amplitude memoization count=%llu expected=2",
+        (unsigned long long)result.statistics.terminal_amplitude_requests);
+  CHECK(result.statistics.memo_hits[0] > 0,
+        "depth-0 memo was not reused");
+
+  {
+    const MVMCKrylovFermionOperator chain_operators[] = {
+        {MVMC_KRYLOV_FERMION_CREATE, 0},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+        {MVMC_KRYLOV_FERMION_CREATE, 1},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+        {MVMC_KRYLOV_FERMION_CREATE, 1},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+        {MVMC_KRYLOV_FERMION_CREATE, 2},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+    };
+    const MVMCKrylovHamiltonianTerm chain_terms[] = {
+        {2.0, 0, 2, 1, 0}, {2.0, 2, 2, 1, 1},
+        {-0.5, 4, 2, 1, 2}, {-0.5, 6, 2, 1, 3},
+    };
+    const MVMCKrylovFockModel chain_model = ElectronicModel(
+        3, 1, 0, chain_terms, 4, chain_operators, 8);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[4] = 5.0;
+    limits.max_order = 2;
+    CHECK(Evaluate(&chain_model, UINT64_C(1), &limits, &amplitude, &result) ==
+              MVMC_KRYLOV_STATUS_OK,
+          "two-step bridge evaluation failed");
+    CHECK(result.value[0] == 0.0 && result.value[1] == 0.0,
+          "two-step bridge lower orders must be zero");
+    CHECK(ComplexClose(result.value[2], -5.0, 1e-14),
+          "two-step bridge v2 mismatch: %.17g%+.17gi",
+          creal(result.value[2]), cimag(result.value[2]));
+  }
+}
+
+static void TestFermionSignAndExchange(void) {
+  const MVMCKrylovFermionOperator hop_operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 2},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+  };
+  const MVMCKrylovHamiltonianTerm hop_terms[] = {
+      {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+  const MVMCKrylovFockModel hop_model =
+      ElectronicModel(3, 2, 0, hop_terms, 2, hop_operators, 4);
+  TableAmplitude amplitude;
+  MVMCKrylovLimits limits = DefaultLimits(1);
+  MVMCKrylovResult result;
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.values[UINT64_C(6)] = 1.0;
+  CHECK(Evaluate(&hop_model, UINT64_C(3), &limits, &amplitude, &result) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "fermion sign evaluation failed");
+  CHECK(ComplexClose(result.value[1], -1.0, 1e-14),
+        "same-spin occupied-orbital parity sign mismatch");
+
+  {
+    const MVMCKrylovFermionOperator down_operators[] = {
+        {MVMC_KRYLOV_FERMION_CREATE, 5},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 3},
+        {MVMC_KRYLOV_FERMION_CREATE, 3},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 5},
+    };
+    const MVMCKrylovHamiltonianTerm down_terms[] = {
+        {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+    const MVMCKrylovFockModel down_model =
+        ElectronicModel(3, 1, 2, down_terms, 2, down_operators, 4);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[UINT64_C(49)] = 1.0;
+    CHECK(Evaluate(&down_model, UINT64_C(25), &limits, &amplitude,
+                   &result) == MVMC_KRYLOV_STATUS_OK,
+          "down-block boundary parity evaluation failed");
+    CHECK(ComplexClose(result.value[1], -1.0, 1e-14),
+          "up/down block boundary parity sign mismatch");
+  }
+
+  {
+    const MVMCKrylovFermionOperator exchange_operators[] = {
+        {MVMC_KRYLOV_FERMION_CREATE, 0},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+        {MVMC_KRYLOV_FERMION_CREATE, 3},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+        {MVMC_KRYLOV_FERMION_CREATE, 1},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+        {MVMC_KRYLOV_FERMION_CREATE, 2},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 3},
+    };
+    const MVMCKrylovHamiltonianTerm exchange_terms[] = {
+        {0.75, 0, 4, 2, 0}, {0.75, 4, 4, 2, 1}};
+    MVMCKrylovFockModel exchange_model = ElectronicModel(
+        2, 1, 1, exchange_terms, 2, exchange_operators, 8);
+    exchange_model.pure_spin = 1;
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[UINT64_C(9)] = 2.0;
+    CHECK(Evaluate(&exchange_model, UINT64_C(6), &limits, &amplitude,
+                   &result) == MVMC_KRYLOV_STATUS_OK,
+          "Exchange orientation evaluation failed");
+    CHECK(ComplexClose(result.value[1], 1.5, 1e-14),
+          "Exchange orientation/sign mismatch");
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[UINT64_C(6)] = 2.0;
+    CHECK(Evaluate(&exchange_model, UINT64_C(9), &limits, &amplitude,
+                   &result) == MVMC_KRYLOV_STATUS_OK,
+          "reverse Exchange orientation evaluation failed");
+    CHECK(ComplexClose(result.value[1], 1.5, 1e-14),
+          "reverse Exchange orientation/sign mismatch");
+  }
+}
+
+static void TestDuplicateMergeAndPermutation(void) {
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms_a[] = {
+      {1.0e16, 0, 2, 1, 10}, {1.0, 0, 2, 1, 12},
+      {-1.0e16, 0, 2, 1, 11}, {1.0e16, 2, 2, 1, 10},
+      {1.0, 2, 2, 1, 12}, {-1.0e16, 2, 2, 1, 11},
+  };
+  const MVMCKrylovHamiltonianTerm terms_b[] = {
+      {-1.0e16, 2, 2, 1, 11}, {1.0, 0, 2, 1, 12},
+      {1.0e16, 2, 2, 1, 10},  {-1.0e16, 0, 2, 1, 11},
+      {1.0, 2, 2, 1, 12},     {1.0e16, 0, 2, 1, 10},
+  };
+  const MVMCKrylovFockModel model_a =
+      ElectronicModel(2, 1, 0, terms_a, 6, operators, 4);
+  const MVMCKrylovFockModel model_b =
+      ElectronicModel(2, 1, 0, terms_b, 6, operators, 4);
+  TableAmplitude amplitude_a;
+  TableAmplitude amplitude_b;
+  MVMCKrylovLimits limits = DefaultLimits(3);
+  MVMCKrylovResult result_a;
+  MVMCKrylovResult result_b;
+  memset(&amplitude_a, 0, sizeof(amplitude_a));
+  memset(&amplitude_b, 0, sizeof(amplitude_b));
+  amplitude_a.values[1] = amplitude_b.values[1] = 3.0;
+  amplitude_a.values[2] = amplitude_b.values[2] = -2.0;
+  CHECK(Evaluate(&model_a, UINT64_C(1), &limits, &amplitude_a, &result_a) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "duplicate model A failed");
+  CHECK(Evaluate(&model_b, UINT64_C(1), &limits, &amplitude_b, &result_b) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "duplicate model B failed");
+  CHECK(memcmp(result_a.value, result_b.value, sizeof(result_a.value)) == 0,
+        "term permutation changed bitwise Krylov values");
+  CHECK(amplitude_a.trace_count == amplitude_b.trace_count &&
+            memcmp(amplitude_a.trace, amplitude_b.trace,
+                   amplitude_a.trace_count * sizeof(amplitude_a.trace[0])) ==
+                0,
+        "term permutation changed terminal callback order");
+  CHECK(DeterministicStatisticsEqual(&result_a.statistics,
+                                     &result_b.statistics),
+        "term permutation changed deterministic statistics");
+  CHECK(ComplexClose(result_a.value[1], -2.0, 1e-14),
+        "compensated duplicate merge lost residual coefficient");
+  CHECK(result_a.statistics.merged_duplicate_transitions > 0,
+        "duplicate transition counter was not incremented");
+
+  {
+    const double complex first = 0.75 + 1.25 * I;
+    const double complex second = -0.5 + 0.125 * I;
+    const MVMCKrylovHamiltonianTerm complex_terms[] = {
+        {first, 0, 2, 1, 0},       {second, 0, 2, 1, 1},
+        {conj(first), 2, 2, 1, 0}, {conj(second), 2, 2, 1, 1},
+    };
+    const MVMCKrylovFockModel complex_model =
+        ElectronicModel(2, 1, 0, complex_terms, 4, operators, 4);
+    TableAmplitude complex_amplitude;
+    MVMCKrylovResult complex_result;
+    memset(&complex_amplitude, 0, sizeof(complex_amplitude));
+    complex_amplitude.values[2] = 2.0 - I;
+    CHECK(Evaluate(&complex_model, UINT64_C(1), &limits,
+                   &complex_amplitude, &complex_result) ==
+              MVMC_KRYLOV_STATUS_OK,
+          "complex constructive duplicate model failed");
+    CHECK(ComplexClose(complex_result.value[1],
+                       (first + second) * (2.0 - I), 1e-14),
+          "complex constructive duplicate merge mismatch");
+  }
+
+  {
+    const double complex cancel = 1.0 + 2.0 * I;
+    const MVMCKrylovHamiltonianTerm cancel_terms[] = {
+        {cancel, 0, 2, 1, 0},       {-cancel, 0, 2, 1, 1},
+        {conj(cancel), 2, 2, 1, 0}, {-conj(cancel), 2, 2, 1, 1},
+    };
+    const MVMCKrylovFockModel cancel_model =
+        ElectronicModel(2, 1, 0, cancel_terms, 4, operators, 4);
+    TableAmplitude cancel_amplitude;
+    MVMCKrylovResult cancel_result;
+    memset(&cancel_amplitude, 0, sizeof(cancel_amplitude));
+    cancel_amplitude.values[1] = 1.0;
+    cancel_amplitude.values[2] = 9.0;
+    CHECK(Evaluate(&cancel_model, UINT64_C(1), &limits, &cancel_amplitude,
+                   &cancel_result) == MVMC_KRYLOV_STATUS_OK,
+          "destructive duplicate model failed");
+    CHECK(cancel_result.value[1] == 0.0 && cancel_result.value[2] == 0.0 &&
+              cancel_result.value[3] == 0.0,
+          "exactly cancelled connection was retained");
+    CHECK(cancel_result.statistics.cancelled_zero_transitions > 0,
+          "cancelled transition counter was not incremented");
+    CHECK(cancel_result.statistics.terminal_amplitude_requests == 1,
+          "cancelled neighbor still evaluated terminal amplitude");
+  }
+}
+
+static void CheckAtomicFailure(const MVMCKrylovResult *result,
+                               MVMCKrylovStatus expected,
+                               const char *label) {
+  int order;
+  CHECK(!result->valid && result->status == expected,
+        "%s did not return atomic invalid result", label);
+  CHECK(result->evaluated_order == -1,
+        "%s exposed a partial evaluated order", label);
+  for (order = 0; order <= MVMC_KRYLOV_MAX_ORDER; ++order) {
+    CHECK(result->value[order] == 0.0,
+          "%s exposed partial value[%d]", label, order);
+  }
+}
+
+static void TestFailuresAndLimits(void) {
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+  MVMCKrylovFockModel model =
+      ElectronicModel(2, 1, 0, terms, 2, operators, 4);
+  TableAmplitude amplitude;
+  MVMCKrylovLimits limits = DefaultLimits(2);
+  MVMCKrylovResult result;
+  MVMCKrylovStatus status;
+  MVMCKrylovWorkspace *workspace;
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.values[1] = 1.0;
+  amplitude.values[2] = 2.0;
+
+  model.hermitian = 0;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL,
+        "non-Hermitian model status=%d", (int)status);
+  model.hermitian = 1;
+
+  limits.max_states = 1;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+        "state limit did not fire");
+  CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                     "state limit");
+
+  limits = DefaultLimits(2);
+  limits.max_transitions = 1;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+        "transition limit did not fire");
+  CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                     "transition limit");
+
+  limits = DefaultLimits(1);
+  limits.max_amplitude_evaluations = 1;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+        "amplitude limit did not fire");
+  CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                     "amplitude limit");
+
+  limits = DefaultLimits(0);
+  limits.max_bytes = 1;
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+        "byte limit did not fail workspace creation");
+  mvmc_krylov_workspace_destroy(workspace);
+
+  limits = DefaultLimits(0);
+  limits.max_states = 0;
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "zero state limit was not rejected");
+
+  limits = DefaultLimits(0);
+  limits.max_transitions = 0;
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "zero transition limit was not rejected");
+
+  limits = DefaultLimits(0);
+  limits.max_amplitude_evaluations = 0;
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "zero amplitude-evaluation limit was not rejected");
+
+  limits = DefaultLimits(0);
+  limits.max_bytes = 0;
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "zero byte limit was not rejected");
+
+  limits = DefaultLimits(-1);
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "negative max order was not rejected");
+
+  limits = DefaultLimits(MVMC_KRYLOV_MAX_ORDER + 1);
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "max order above supported range was not rejected");
+
+  limits = DefaultLimits(0);
+  limits.max_states = SIZE_MAX;
+  workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "overflowing state limit was not rejected");
+
+  limits = DefaultLimits(0);
+  limits.max_transitions = SIZE_MAX;
+  workspace = mvmc_krylov_workspace_create(33, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "overflowing transition-word allocation was not rejected");
+
+  workspace = mvmc_krylov_workspace_create(SIZE_MAX, &limits, &status);
+  CHECK(workspace == NULL && status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "overflowing site count was not rejected");
+
+  limits = DefaultLimits(0);
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.return_nonfinite = 1;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+        "nonfinite callback value status=%d", (int)status);
+  CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_NONFINITE,
+                     "nonfinite amplitude");
+
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.forced_status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE,
+        "callback failure status=%d", (int)status);
+  CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE,
+                     "callback failure");
+
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.values[1] = 1.0;
+  amplitude.mismatch_zero_classification = 1;
+  status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+        "inconsistent zero classification accepted");
+
+  {
+    MVMCKrylovFermionOperator invalid_operators[4];
+    memcpy(invalid_operators, operators, sizeof(invalid_operators));
+    invalid_operators[0].orbital = 4;
+    model.operators = invalid_operators;
+    memset(&amplitude, 0, sizeof(amplitude));
+    status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "out-of-range orbital accepted");
+    model.operators = operators;
+  }
+
+  {
+    MVMCKrylovFermionOperator invalid_operators[4];
+    memcpy(invalid_operators, operators, sizeof(invalid_operators));
+    invalid_operators[0].kind = (MVMCKrylovFermionOperatorKind)99;
+    model.operators = invalid_operators;
+    status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "illegal operator kind accepted");
+    model.operators = operators;
+  }
+
+  {
+    MVMCKrylovHamiltonianTerm invalid_terms[2];
+    memcpy(invalid_terms, terms, sizeof(invalid_terms));
+    invalid_terms[0].coefficient = NAN + 0.0 * I;
+    model.terms = invalid_terms;
+    status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+          "nonfinite model coefficient status=%d", (int)status);
+    CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_NONFINITE,
+                       "nonfinite model coefficient");
+    model.terms = terms;
+  }
+
+  {
+    const MVMCKrylovHamiltonianTerm overflow_terms[] = {
+        {DBL_MAX, 0, 2, 1, 0}, {DBL_MAX, 2, 2, 1, 1}};
+    const MVMCKrylovFockModel overflow_model =
+        ElectronicModel(2, 1, 0, overflow_terms, 2, operators, 4);
+    limits = DefaultLimits(1);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[2] = 2.0;
+    status = Evaluate(&overflow_model, UINT64_C(1), &limits, &amplitude,
+                      &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+          "nonfinite coefficient-amplitude product status=%d", (int)status);
+    CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_NONFINITE,
+                       "nonfinite product");
+  }
+
+  {
+    const MVMCKrylovHamiltonianTerm sum_overflow_terms[] = {
+        {DBL_MAX, 0, 2, 1, 0}, {DBL_MAX, 0, 2, 1, 1},
+        {DBL_MAX, 2, 2, 1, 0}, {DBL_MAX, 2, 2, 1, 1},
+    };
+    const MVMCKrylovFockModel sum_overflow_model = ElectronicModel(
+        2, 1, 0, sum_overflow_terms, 4, operators, 4);
+    limits = DefaultLimits(1);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[2] = 1.0;
+    status = Evaluate(&sum_overflow_model, UINT64_C(1), &limits, &amplitude,
+                      &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+          "nonfinite duplicate sum status=%d", (int)status);
+    CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_NONFINITE,
+                       "nonfinite duplicate sum");
+  }
+
+  {
+    const MVMCKrylovFermionOperator spin_flip_operators[] = {
+        {MVMC_KRYLOV_FERMION_CREATE, 2},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+        {MVMC_KRYLOV_FERMION_CREATE, 0},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+    };
+    const MVMCKrylovHamiltonianTerm spin_flip_terms[] = {
+        {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+    const MVMCKrylovFockModel spin_flip_model = ElectronicModel(
+        2, 1, 0, spin_flip_terms, 2, spin_flip_operators, 4);
+    limits = DefaultLimits(1);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[1] = 1.0;
+    status = Evaluate(&spin_flip_model, UINT64_C(1), &limits, &amplitude,
+                      &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "sector-changing terminal status=%d", (int)status);
+    CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                       "sector-changing terminal");
+  }
+
+  {
+    const MVMCKrylovFockModel filled_model =
+        ElectronicModel(2, 2, 0, terms, 2, operators, 4);
+    limits = DefaultLimits(1);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[3] = 2.0;
+    status = Evaluate(&filled_model, UINT64_C(3), &limits, &amplitude,
+                      &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_OK && result.value[1] == 0.0,
+          "Pauli-blocked hopping was not a normal zero transition");
+    CHECK(result.statistics.raw_transitions == 0,
+          "Pauli-blocked term incremented transition counter");
+  }
+}
+
+static void TestRepeatedEvaluationAndOrderDomain(void) {
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+  const MVMCKrylovFockModel model =
+      ElectronicModel(2, 1, 0, terms, 2, operators, 4);
+  int order;
+  for (order = 0; order <= 3; ++order) {
+    MVMCKrylovLimits limits = DefaultLimits(order);
+    MVMCKrylovStatus status;
+    MVMCKrylovWorkspace *workspace =
+        mvmc_krylov_workspace_create(2, &limits, &status);
+    TableAmplitude amplitude;
+    MVMCKrylovResult first;
+    MVMCKrylovResult second;
+    const uint64_t root = UINT64_C(1);
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[1] = 2.0;
+    amplitude.values[2] = 5.0;
+    CHECK(workspace != NULL && status == MVMC_KRYLOV_STATUS_OK,
+          "workspace create failed for order %d", order);
+    if (workspace == NULL) continue;
+    CHECK(mvmc_krylov_evaluate(workspace, &model, &root, 1,
+                               TableAmplitudeCallback, &amplitude,
+                               &first) == MVMC_KRYLOV_STATUS_OK,
+          "first evaluation failed for order %d", order);
+    CHECK(mvmc_krylov_evaluate(workspace, &model, &root, 1,
+                               TableAmplitudeCallback, &amplitude,
+                               &second) == MVMC_KRYLOV_STATUS_OK,
+          "second evaluation failed for order %d", order);
+    CHECK(memcmp(first.value, second.value, sizeof(first.value)) == 0,
+          "repeated evaluation retained stale cache for order %d", order);
+    CHECK(first.evaluated_order == order && second.evaluated_order == order,
+          "evaluated order mismatch for %d", order);
+    mvmc_krylov_workspace_destroy(workspace);
+  }
+}
+
+int main(void) {
+  TestConfigurationContract();
+  TestDenseThreeStateED();
+  TestZeroBridgesAndMemoization();
+  TestFermionSignAndExchange();
+  TestDuplicateMergeAndPermutation();
+  TestFailuresAndLimits();
+  TestRepeatedEvaluationAndOrderDomain();
+
+  if (failures != 0) {
+    fprintf(stderr, "AbsoluteKrylovReference_Unit: %d failure(s)\n", failures);
+    return 1;
+  }
+  printf("AbsoluteKrylovReference_Unit: PASS\n");
+  return 0;
+}

--- a/test/absolute_krylov_reference_unit.c
+++ b/test/absolute_krylov_reference_unit.c
@@ -109,6 +109,25 @@ static int DeterministicStatisticsEqual(const MVMCKrylovStatistics *lhs,
          lhs->workspace_bytes == rhs->workspace_bytes;
 }
 
+static int FiniteNonnegativeTimings(
+    const MVMCKrylovStatistics *statistics) {
+  int depth;
+  if (statistics == NULL ||
+      !isfinite(statistics->amplitude_wall_seconds) ||
+      statistics->amplitude_wall_seconds < 0.0 ||
+      !isfinite(statistics->connectivity_wall_seconds) ||
+      statistics->connectivity_wall_seconds < 0.0) {
+    return 0;
+  }
+  for (depth = 0; depth <= MVMC_KRYLOV_MAX_ORDER; ++depth) {
+    if (!isfinite(statistics->depth_wall_seconds[depth]) ||
+        statistics->depth_wall_seconds[depth] < 0.0) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
 static MVMCKrylovFockModel ElectronicModel(
     size_t site_count, size_t up_count, size_t down_count,
     const MVMCKrylovHamiltonianTerm *terms, size_t term_count,
@@ -279,6 +298,8 @@ static void TestZeroBridgesAndMemoization(void) {
         (unsigned long long)result.statistics.terminal_amplitude_requests);
   CHECK(result.statistics.memo_hits[0] > 0,
         "depth-0 memo was not reused");
+  CHECK(FiniteNonnegativeTimings(&result.statistics),
+        "profile timings must be finite and nonnegative");
 
   {
     const MVMCKrylovFermionOperator chain_operators[] = {

--- a/test/absolute_pfaffian_unit.c
+++ b/test/absolute_pfaffian_unit.c
@@ -651,6 +651,204 @@ static void test_rank_local_projected_amplitude(void) {
         "rank-local state counters reduce to full counters");
 }
 
+static void test_value_only_api(void) {
+  const int n = 4;
+  double matrix[16] = {0.0};
+  double original[16];
+  double inverse[16];
+  double complex complex_matrix[16] = {0.0};
+  double complex complex_inverse[16];
+  MVMCAbsolutePfaffianRealValueWorkspace *real_workspace = NULL;
+  MVMCAbsolutePfaffianComplexValueWorkspace *complex_workspace = NULL;
+  MVMCAbsolutePfaffianResult full;
+  MVMCAbsolutePfaffianValueResult value;
+  MVMCAbsolutePfaffianValueResult components[4];
+  MVMCProjectedAmplitudeResult aggregate, empty;
+  double complex weights[4] = {1.0, 2.0, -I, 0.5 + 0.25 * I};
+
+  set_real_pair(matrix, n, 0, 1, 2.0);
+  set_real_pair(matrix, n, 0, 2, -1.0);
+  set_real_pair(matrix, n, 0, 3, 0.5);
+  set_real_pair(matrix, n, 1, 2, 3.0);
+  set_real_pair(matrix, n, 1, 3, 4.0);
+  set_real_pair(matrix, n, 2, 3, -2.0);
+  memcpy(original, matrix, sizeof(matrix));
+  CHECK(mvmc_absolute_pfaffian_real(matrix, n, n, inverse, n, 501, 0.0,
+                                     0.0, &full) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "value-only real full reference status");
+  CHECK(mvmc_absolute_pfaffian_real_value(matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "value-only real convenience status");
+  CHECK(value.state == MVMC_PFAFFIAN_VALUE_WELL_PIVOTED,
+        "value-only real well-pivoted classification");
+  CHECK(value.factor_info == full.factor_info &&
+            value.matrix_scale == full.matrix_scale &&
+            value.scaled_min_pivot == full.scaled_min_pivot &&
+            value.pfaffian == full.pfaffian,
+        "value-only real diagnostics and Pfaffian match full P1");
+  CHECK(memcmp(matrix, original, sizeof(matrix)) == 0,
+        "value-only real leaves source unchanged");
+
+  CHECK(mvmc_absolute_pfaffian_real_value_workspace_create(
+            n, &real_workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "value-only real workspace create");
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.pfaffian == full.pfaffian,
+        "value-only real workspace reuse first evaluation");
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.pfaffian == full.pfaffian,
+        "value-only real workspace reuse second evaluation");
+
+  memset(matrix, 0, sizeof(matrix));
+  set_real_pair(matrix, n, 0, 1, 1.0);
+  set_real_pair(matrix, n, 2, 3, 1.0e-15);
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_NEAR_PIVOT &&
+            close_complex(value.pfaffian, 1.0e-15, 1.0e-13),
+        "value-only near pivot retains finite Pfaffian");
+  memset(matrix, 0, sizeof(matrix));
+  set_real_pair(matrix, n, 0, 1, 1.0);
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_SINGULAR &&
+            value.factor_info > 0 && value.pfaffian == 0.0,
+        "value-only singular contract");
+  matrix[0] = NAN;
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_NONFINITE,
+        "value-only nonfinite classification");
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n, NAN, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only invalid input is atomic");
+
+  set_complex_pair(complex_matrix, n, 0, 1, 1.0 + 0.5 * I);
+  set_complex_pair(complex_matrix, n, 0, 2, -0.25 + 0.75 * I);
+  set_complex_pair(complex_matrix, n, 0, 3, 2.0 - 0.5 * I);
+  set_complex_pair(complex_matrix, n, 1, 2, 0.5 + 1.25 * I);
+  set_complex_pair(complex_matrix, n, 1, 3, -1.0 + 0.25 * I);
+  set_complex_pair(complex_matrix, n, 2, 3, 1.5 - 0.75 * I);
+  CHECK(mvmc_absolute_pfaffian_complex(
+            complex_matrix, n, n, complex_inverse, n, 502, 0.0, 0.0,
+            &full) == MVMC_PFAFFIAN_STATUS_OK,
+        "value-only complex full reference status");
+  CHECK(mvmc_absolute_pfaffian_complex_value_workspace_create(
+            n, &complex_workspace) == MVMC_PFAFFIAN_STATUS_OK,
+        "value-only complex workspace create");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_WELL_PIVOTED &&
+            close_complex(value.pfaffian, full.pfaffian, 1.0e-15),
+        "value-only complex phase matches full P1");
+  memset(complex_matrix, 0, sizeof(complex_matrix));
+  set_complex_pair(complex_matrix, n, 0, 1, 1.0 + I);
+  set_complex_pair(complex_matrix, n, 2, 3, 1.0e-15 - 0.5e-15 * I);
+  CHECK(mvmc_absolute_pfaffian_complex(
+            complex_matrix, n, n, complex_inverse, n, 503, 0.0, 0.0,
+            &full) == MVMC_PFAFFIAN_STATUS_OK &&
+            full.state == MVMC_PFAFFIAN_NEAR_SINGULAR,
+        "value-only complex near full reference");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_NEAR_PIVOT &&
+            value.pfaffian == full.pfaffian,
+        "value-only complex near state and phase match full P1");
+  memset(complex_matrix, 0, sizeof(complex_matrix));
+  set_complex_pair(complex_matrix, n, 0, 1, 1.0 + I);
+  CHECK(mvmc_absolute_pfaffian_complex(
+            complex_matrix, n, n, complex_inverse, n, 504, 0.0, 0.0,
+            &full) == MVMC_PFAFFIAN_STATUS_OK &&
+            full.state == MVMC_PFAFFIAN_SINGULAR,
+        "value-only complex singular full reference");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_SINGULAR &&
+            value.pfaffian == full.pfaffian && value.pfaffian == 0.0,
+        "value-only complex singular state matches full P1");
+  complex_matrix[0] = INFINITY + 0.0 * I;
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_PFAFFIAN_VALUE_NONFINITE,
+        "value-only complex nonfinite classification");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, n, n, INFINITY, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only complex invalid input is atomic");
+
+  components[0].state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  components[0].pfaffian = 2.0;
+  components[1].state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+  components[1].pfaffian = 0.0;
+  components[2].state = MVMC_PFAFFIAN_VALUE_NEAR_PIVOT;
+  components[2].pfaffian = -1.0 + I;
+  components[3].state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  components[3].pfaffian = 3.0 - 0.5 * I;
+  CHECK(mvmc_projected_amplitude_values(
+            components, weights, 4, &aggregate) == MVMC_PFAFFIAN_STATUS_OK &&
+            aggregate.valid && aggregate.regular_count == 2 &&
+            aggregate.near_singular_count == 1 &&
+            aggregate.singular_count == 1,
+        "value-only projected aggregation preserves classifications");
+  CHECK(close_complex(aggregate.total, 4.625 + 1.5 * I, 1.0e-15),
+        "value-only projected total matches direct oracle");
+  CHECK(fabs(aggregate.sum_abs -
+             (2.0 + sqrt(2.0) + cabs(1.625 + 0.5 * I))) < 1.0e-14,
+        "value-only projected absolute sum matches direct oracle");
+  CHECK(fabs(aggregate.cancellation_ratio -
+             cabs(aggregate.total) / aggregate.sum_abs) < 1.0e-15,
+        "value-only projected cancellation metric matches oracle");
+  CHECK(mvmc_projected_amplitude_value_slice(
+            NULL, 0, weights, 4, 2, 2, &empty) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            empty.valid && empty.total == 0.0 && empty.regular_count == 0,
+        "value-only empty QP slice is valid");
+  components[1].pfaffian = 1.0;
+  CHECK(mvmc_projected_amplitude_values(
+            components, weights, 4, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            aggregate.valid == 0,
+        "value-only invalid singular component fails atomically");
+
+  components[0].state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+  components[0].pfaffian = 0.0;
+  components[1] = components[0];
+  CHECK(mvmc_projected_amplitude_values(
+            components, weights, 2, &aggregate) == MVMC_PFAFFIAN_STATUS_OK &&
+            aggregate.valid && aggregate.total == 0.0 &&
+            aggregate.sum_abs == 0.0 && aggregate.singular_count == 2,
+        "all-zero value components remain a valid projected total");
+  components[0].state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  components[0].pfaffian = 1.0e16;
+  components[1].state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  components[1].pfaffian = -1.0e16;
+  components[2].state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+  components[2].pfaffian = 1.0;
+  weights[0] = weights[1] = weights[2] = 1.0;
+  CHECK(mvmc_projected_amplitude_values(
+            components, weights, 3, &aggregate) == MVMC_PFAFFIAN_STATUS_OK &&
+            aggregate.total == 1.0,
+        "value-only compensated sum retains a small cancellation remainder");
+
+  mvmc_absolute_pfaffian_complex_value_workspace_destroy(complex_workspace);
+  mvmc_absolute_pfaffian_real_value_workspace_destroy(real_workspace);
+}
+
 int main(int argc, char **argv) {
 #ifdef _mpi_use
   MPI_Init(&argc, &argv);
@@ -678,6 +876,7 @@ int main(int argc, char **argv) {
   test_invalid_arguments();
   test_projected_amplitude();
   test_rank_local_projected_amplitude();
+  test_value_only_api();
 
   if (failure_count != 0) {
     fprintf(stderr, "%d absolute Pfaffian checks failed\n", failure_count);

--- a/test/classic_krylov_amplitude_unit.c
+++ b/test/classic_krylov_amplitude_unit.c
@@ -1,0 +1,796 @@
+#include "classic_krylov_amplitude.h"
+#include "classic_pfaffian_matrix.h"
+
+#include <complex.h>
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failure_count = 0;
+
+#define CHECK(condition, message)                                    \
+  do {                                                               \
+    if (!(condition)) {                                              \
+      fprintf(stderr, "FAIL: %s (line %d)\n", (message), __LINE__); \
+      ++failure_count;                                               \
+    }                                                                \
+  } while (0)
+
+static int close_complex(double complex actual, double complex expected,
+                         double tolerance) {
+  return cabs(actual - expected) <= tolerance * fmax(1.0, cabs(expected));
+}
+
+static void rank_and_size(int *rank, int *size) {
+#ifdef _mpi_use
+  MPI_Comm_rank(MPI_COMM_WORLD, rank);
+  MPI_Comm_size(MPI_COMM_WORLD, size);
+#else
+  *rank = 0;
+  *size = 1;
+#endif
+}
+
+static MVMCClassicPfaffianCommunicator world_communicator(void) {
+#ifdef _mpi_use
+  return MPI_COMM_WORLD;
+#else
+  return 0;
+#endif
+}
+
+static MVMCClassicKrylovAmplitudeLayout base_layout(int qp_total,
+                                                     int rank, int size) {
+  MVMCClassicKrylovAmplitudeLayout layout;
+  memset(&layout, 0, sizeof(layout));
+  layout.site_count = 2;
+  layout.up_electron_count = 1;
+  layout.down_electron_count = 1;
+  layout.qp_total = qp_total;
+  layout.qp_start = qp_total * rank / size;
+  layout.qp_end = qp_total * (rank + 1) / size;
+  layout.communicator = world_communicator();
+  return layout;
+}
+
+static void set_real_pair(double *slater, int nsite, int up, int down,
+                          double pfaffian) {
+  const int nsite2 = 2 * nsite;
+  const int down_orbital = nsite + down;
+  slater[(size_t)down_orbital * (size_t)nsite2 + (size_t)up] = -pfaffian;
+  slater[(size_t)up * (size_t)nsite2 + (size_t)down_orbital] = pfaffian;
+}
+
+static void set_complex_pair(double complex *slater, int nsite, int up,
+                             int down, double complex pfaffian) {
+  const int nsite2 = 2 * nsite;
+  const int down_orbital = nsite + down;
+  slater[(size_t)down_orbital * (size_t)nsite2 + (size_t)up] = -pfaffian;
+  slater[(size_t)up * (size_t)nsite2 + (size_t)down_orbital] = pfaffian;
+}
+
+static void fill_real_slater(double *slater, int qp_total, int singular_qp,
+                             double *pfaffians) {
+  int qp, up, down;
+  memset(slater, 0, (size_t)qp_total * 16 * sizeof(*slater));
+  for (qp = 0; qp < qp_total; ++qp) {
+    double *component = slater + (size_t)qp * 16;
+    const double multiplier = qp == singular_qp ? 0.0 : (double)(qp + 1);
+    for (up = 0; up < 2; ++up) {
+      for (down = 0; down < 2; ++down) {
+        set_real_pair(component, 2, up, down,
+                      multiplier * (1.5 + (double)up + 0.25 * (double)down));
+      }
+    }
+    pfaffians[qp] = multiplier * 1.5;
+  }
+}
+
+static void fill_complex_slater(double complex *slater, int qp_total,
+                                int singular_qp,
+                                double complex *pfaffians) {
+  int qp, up, down;
+  memset(slater, 0, (size_t)qp_total * 16 * sizeof(*slater));
+  for (qp = 0; qp < qp_total; ++qp) {
+    double complex *component = slater + (size_t)qp * 16;
+    const double complex multiplier =
+        qp == singular_qp ? 0.0 : (double)(qp + 1) + 0.2 * (double)qp * I;
+    for (up = 0; up < 2; ++up) {
+      for (down = 0; down < 2; ++down) {
+        set_complex_pair(
+            component, 2, up, down,
+            multiplier * (1.5 + (double)up + 0.25 * (double)down));
+      }
+    }
+    pfaffians[qp] = multiplier * 1.5;
+  }
+}
+
+static void enable_gutzwiller(MVMCClassicKrylovAmplitudeLayout *layout,
+                              const int *indices,
+                              const double complex *parameter) {
+  layout->nproj = 1;
+  layout->ngutzwiller_idx = 1;
+  layout->gutzwiller_idx = indices;
+  layout->projection_parameters = parameter;
+}
+
+static void test_matrix_helper(void) {
+  double real_slater[16] = {0.0};
+  double real_original[16];
+  double real_matrix[4] = {0.0};
+  double complex complex_slater[16] = {0.0};
+  double complex complex_original[16];
+  double complex complex_matrix[4] = {0.0};
+  const int ele_idx[2] = {1, 0};
+  int invalid_idx[2] = {2, 0};
+
+  set_real_pair(real_slater, 2, 1, 0, 3.25);
+  set_complex_pair(complex_slater, 2, 1, 0, -0.5 + 2.0 * I);
+  memcpy(real_original, real_slater, sizeof(real_slater));
+  memcpy(complex_original, complex_slater, sizeof(complex_slater));
+  CHECK(mvmc_classic_pfaffian_build_real_matrix(
+            real_slater, 2, 2, ele_idx, real_matrix) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "real matrix helper status");
+  CHECK(real_matrix[0] == 0.0 && real_matrix[1] == -3.25 &&
+            real_matrix[2] == 3.25 && real_matrix[3] == 0.0,
+        "real matrix helper frozen column-major oracle");
+  CHECK(memcmp(real_slater, real_original, sizeof(real_slater)) == 0,
+        "real matrix helper leaves source unchanged");
+  CHECK(mvmc_classic_pfaffian_build_complex_matrix(
+            complex_slater, 2, 2, ele_idx, complex_matrix) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "complex matrix helper status");
+  CHECK(complex_matrix[0] == 0.0 &&
+            complex_matrix[1] == 0.5 - 2.0 * I &&
+            complex_matrix[2] == -0.5 + 2.0 * I &&
+            complex_matrix[3] == 0.0,
+        "complex matrix helper frozen column-major oracle");
+  CHECK(memcmp(complex_slater, complex_original,
+               sizeof(complex_slater)) == 0,
+        "complex matrix helper leaves source unchanged");
+  CHECK(mvmc_classic_pfaffian_build_real_matrix(
+            real_slater, 0, 2, ele_idx, real_matrix) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "matrix helper rejects zero site count");
+  CHECK(mvmc_classic_pfaffian_build_real_matrix(
+            real_slater, INT_MAX, 2, ele_idx, real_matrix) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            mvmc_classic_pfaffian_build_complex_matrix(
+                complex_slater, INT_MAX, 2, ele_idx, complex_matrix) ==
+                MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "matrix helpers reject overflow dimensions before arithmetic");
+  CHECK(mvmc_classic_pfaffian_build_real_matrix(
+            real_slater, 2, 3, ele_idx, real_matrix) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "matrix helper rejects odd particle count");
+  CHECK(mvmc_classic_pfaffian_build_real_matrix(
+            real_slater, 2, 2, invalid_idx, real_matrix) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "matrix helper rejects out-of-range electron index");
+}
+
+static void test_real_amplitude(int qp_total, int use_gutzwiller,
+                                int singular_qp, int mutate_source) {
+  double slater[64];
+  double pfaffians[4] = {0.0};
+  double complex weights[4] = {1.0, -1.0, 1.0, -1.0};
+  double complex parameter = -0.43;
+  int gutz_indices[2] = {0, 0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  const uint64_t configuration = UINT64_C(5);
+  double complex expected = 0.0;
+  int rank, size, qp;
+
+  rank_and_size(&rank, &size);
+  layout = base_layout(qp_total, rank, size);
+  if (use_gutzwiller) {
+    enable_gutzwiller(&layout, gutz_indices, &parameter);
+  }
+  fill_real_slater(slater, qp_total, singular_qp, pfaffians);
+  for (qp = 0; qp < qp_total; ++qp) expected += weights[qp] * pfaffians[qp];
+  if (use_gutzwiller) expected *= exp(creal(parameter));
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "real amplitude workspace create");
+  if (workspace == NULL) return;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_bytes(workspace) >
+            sizeof(*pfaffians),
+        "real amplitude workspace reports preallocated bytes");
+  if (mutate_source) {
+    memset(slater, 0x5a, sizeof(slater));
+    for (qp = 0; qp < qp_total; ++qp) weights[qp] = 99.0;
+    parameter = 99.0;
+    gutz_indices[0] = gutz_indices[1] = 1;
+  }
+  CHECK(mvmc_classic_krylov_real_amplitude(
+            &configuration, 1, workspace, &result) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "real amplitude evaluation status");
+  CHECK(close_complex(result.value, expected, 2.0e-14),
+        "real amplitude matches direct QP/projection oracle");
+  CHECK(result.total_zero == (expected == 0.0),
+        "real amplitude exact zero classification");
+  CHECK(result.global_factorization_count == (uint64_t)qp_total &&
+            result.local_factorization_count ==
+                (uint64_t)(layout.qp_end - layout.qp_start),
+        "real amplitude local/global factorization counts");
+  CHECK(result.singular_component_count ==
+            (uint64_t)(singular_qp >= 0 ? 1 : 0) &&
+            result.regular_component_count +
+                    result.near_pivot_component_count +
+                    result.singular_component_count ==
+                (uint64_t)qp_total,
+        "real amplitude component classifications");
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+}
+
+static void test_complex_amplitude(int qp_total, int use_gutzwiller,
+                                   int singular_qp) {
+  double complex slater[64];
+  double complex pfaffians[4] = {0.0};
+  double complex weights[4] = {1.0, -1.0 + 0.25 * I,
+                               0.5 - 0.75 * I, -I};
+  double complex parameter = -0.43;
+  int gutz_indices[2] = {0, 0};
+  MVMCClassicKrylovComplexAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  const uint64_t configuration = UINT64_C(5);
+  double complex expected = 0.0;
+  int rank, size, qp;
+
+  rank_and_size(&rank, &size);
+  layout = base_layout(qp_total, rank, size);
+  if (use_gutzwiller) {
+    enable_gutzwiller(&layout, gutz_indices, &parameter);
+  }
+  fill_complex_slater(slater, qp_total, singular_qp, pfaffians);
+  for (qp = 0; qp < qp_total; ++qp) expected += weights[qp] * pfaffians[qp];
+  if (use_gutzwiller) expected *= exp(creal(parameter));
+  CHECK(mvmc_classic_krylov_complex_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "complex amplitude workspace create");
+  if (workspace == NULL) return;
+  CHECK(mvmc_classic_krylov_complex_amplitude_workspace_bytes(workspace) >
+            sizeof(*pfaffians),
+        "complex amplitude workspace reports preallocated bytes");
+  CHECK(mvmc_classic_krylov_complex_amplitude(
+            &configuration, 1, workspace, &result) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "complex amplitude evaluation status");
+  CHECK(close_complex(result.value, expected, 3.0e-14),
+        "complex amplitude matches direct phase oracle");
+  CHECK(result.global_factorization_count == (uint64_t)qp_total &&
+            result.local_factorization_count ==
+                (uint64_t)(layout.qp_end - layout.qp_start),
+        "complex amplitude local/global factorization counts");
+  CHECK(result.singular_component_count ==
+            (uint64_t)(singular_qp >= 0 ? 1 : 0),
+        "complex amplitude singular component remains valid");
+  mvmc_classic_krylov_complex_amplitude_workspace_destroy(workspace);
+}
+
+static void test_all_zero_and_configuration_guards(void) {
+  double slater[16] = {0.0};
+  double complex weights[1] = {1.0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  uint64_t configuration = UINT64_C(5);
+  int rank, size;
+
+  rank_and_size(&rank, &size);
+  layout = base_layout(1, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "all-zero amplitude workspace create");
+  if (workspace == NULL) return;
+  CHECK(mvmc_classic_krylov_real_amplitude(
+            &configuration, 1, workspace, &result) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            result.value == 0.0 && result.total_zero == 1 &&
+            result.singular_component_count == 1,
+        "all singular components produce a valid exact-zero total");
+  configuration = UINT64_C(7);
+  CHECK(mvmc_classic_krylov_real_amplitude(
+            &configuration, 1, workspace, &result) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            result.value == 0.0,
+        "wrong particle sector is rejected atomically");
+  if (size > 1) {
+    configuration = rank == size - 1 ? UINT64_C(6) : UINT64_C(5);
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &configuration, 1, workspace, &result) ==
+              MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE,
+          "rank-mismatched configuration fails exact collective preflight");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+}
+
+static void test_projection_allowlist(void) {
+  double slater[16] = {0.0};
+  double complex weights[1] = {1.0};
+  double complex parameter[10] = {-0.43, 0.25};
+  int gutz_indices[2] = {0, 0};
+  int jastrow_row_0[2] = {-1, 0};
+  int jastrow_row_1[2] = {0, -1};
+  const int *jastrow_idx[2] = {jastrow_row_0, jastrow_row_1};
+  int dh2_row[4] = {0, 1, 1, 0};
+  const int *dh2_idx[1] = {dh2_row};
+  int dh4_row[8] = {0, 1, 0, 1, 1, 0, 1, 0};
+  const int *dh4_idx[1] = {dh4_row};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  int rank, size;
+
+  rank_and_size(&rank, &size);
+  layout = base_layout(1, rank, size);
+  layout.nproj = 1;
+  layout.njastrow_idx = 1;
+  layout.jastrow_idx = jastrow_idx;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL && workspace == NULL,
+        "well-formed Jastrow is outside the initial allowlist");
+
+  jastrow_row_0[1] = jastrow_row_1[0] = 1;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "out-of-range unsupported Jastrow index is malformed input");
+  jastrow_row_0[1] = jastrow_row_1[0] = 0;
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 2;
+  layout.ngutzwiller_idx = 1;
+  layout.njastrow_idx = 1;
+  gutz_indices[0] = gutz_indices[1] = 1;
+  layout.gutzwiller_idx = gutz_indices;
+  layout.jastrow_idx = jastrow_idx;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "Gutzwiller index cannot address a later projection class");
+  gutz_indices[0] = gutz_indices[1] = 0;
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 1;
+  layout.nspin_jastrow_idx = 1;
+  layout.spin_jastrow_idx = jastrow_idx;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL && workspace == NULL,
+        "well-formed Spin Jastrow is outside the initial allowlist");
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 6;
+  layout.ndoublon_holon_2site_idx = 1;
+  layout.doublon_holon_2site_idx = dh2_idx;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL && workspace == NULL,
+        "well-formed two-site doublon-holon is outside the allowlist");
+  dh2_row[0] = -1;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "out-of-range two-site doublon-holon site is malformed input");
+  dh2_row[0] = 0;
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 10;
+  layout.ndoublon_holon_4site_idx = 1;
+  layout.doublon_holon_4site_idx = dh4_idx;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL && workspace == NULL,
+        "well-formed four-site doublon-holon is outside the allowlist");
+  dh4_row[7] = 2;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "out-of-range four-site doublon-holon site is malformed input");
+  dh4_row[7] = 0;
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 1;
+  layout.ngutzwiller_idx = -1;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "negative projection count is malformed input");
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 2;
+  layout.ngutzwiller_idx = 1;
+  layout.gutzwiller_idx = gutz_indices;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "projection count formula mismatch is malformed input");
+
+  layout = base_layout(1, rank, size);
+  layout.nproj = 2;
+  layout.ngutzwiller_idx = 2;
+  layout.gutzwiller_idx = gutz_indices;
+  layout.projection_parameters = parameter;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+        "multiple Gutzwiller parameters are outside the initial allowlist");
+
+  {
+    const uint32_t unsupported_flags[] = {
+        MVMC_CLASSIC_KRYLOV_UNSUPPORTED_RBM,
+        MVMC_CLASSIC_KRYLOV_UNSUPPORTED_BACKFLOW,
+        MVMC_CLASSIC_KRYLOV_UNSUPPORTED_GENERAL_ORBITAL,
+        MVMC_CLASSIC_KRYLOV_UNSUPPORTED_BLOCK_UPDATE};
+    size_t flag;
+    for (flag = 0; flag < sizeof(unsupported_flags) /
+                              sizeof(unsupported_flags[0]); ++flag) {
+      layout = base_layout(1, rank, size);
+      layout.unsupported_features = unsupported_flags[flag];
+      CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+                &layout, slater, weights, &workspace) ==
+                MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL && workspace == NULL,
+            "unsupported feature is rejected without Pfaffian fallback");
+    }
+  }
+}
+
+static void test_weight_binding_guards(void) {
+  double real_slater[16] = {0.0};
+  double complex complex_slater[16] = {0.0};
+  double complex weights[1] = {1.0 + I};
+  MVMCClassicKrylovRealAmplitudeWorkspace *real_workspace = NULL;
+  MVMCClassicKrylovComplexAmplitudeWorkspace *complex_workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  int rank, size;
+
+  rank_and_size(&rank, &size);
+  layout = base_layout(1, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, real_slater, weights, &real_workspace) ==
+                MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            real_workspace == NULL,
+        "real adapter rejects a finite non-real QP weight");
+
+  weights[0] = NAN + 0.0 * I;
+  CHECK(mvmc_classic_krylov_complex_amplitude_workspace_create(
+            &layout, complex_slater, weights, &complex_workspace) ==
+                MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            complex_workspace == NULL,
+        "complex adapter rejects NaN QP weight real part");
+  weights[0] = 1.0 + INFINITY * I;
+  CHECK(mvmc_classic_krylov_complex_amplitude_workspace_create(
+            &layout, complex_slater, weights, &complex_workspace) ==
+                MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            complex_workspace == NULL,
+        "complex adapter rejects infinite QP weight imaginary part");
+}
+
+static void test_rank_invariant_cancellation(void) {
+  const double terms[4] = {1.0e16, 1.0, -1.0e16, 1.0};
+  double slater[64] = {0.0};
+  double complex weights[4] = {1.0, 1.0, 1.0, 1.0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  const uint64_t configuration = UINT64_C(5);
+  int rank, size, qp;
+
+  rank_and_size(&rank, &size);
+  for (qp = 0; qp < 4; ++qp) {
+    set_real_pair(slater + (size_t)qp * 16, 2, 0, 0, terms[qp]);
+  }
+  layout = base_layout(4, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "rank-invariant cancellation workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_OK &&
+              result.value == 2.0 &&
+              result.global_factorization_count == 4,
+          "global QP-order Neumaier sum is exactly rank-count invariant");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+}
+
+static void test_nonfinite_and_near_pivot_classification(void) {
+  double slater[64] = {0.0};
+  double complex weights[4] = {2.0, 1.0, 1.0, 1.0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  const uint64_t two_particle_configuration = UINT64_C(5);
+  const uint64_t four_particle_configuration = UINT64_C(15);
+  int rank, size, qp;
+
+  rank_and_size(&rank, &size);
+  set_real_pair(slater, 2, 0, 0, DBL_MAX);
+  layout = base_layout(1, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "finite product-overflow workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &two_particle_configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_NONFINITE &&
+              result.value == 0.0,
+          "finite weight times finite Pfaffian overflow is NONFINITE");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+
+  memset(slater, 0, sizeof(slater));
+  weights[0] = weights[1] = weights[2] = weights[3] = 1.0;
+  for (qp = 0; qp < 4; ++qp) {
+    set_real_pair(slater + (size_t)qp * 16, 2, 0, 0, DBL_MAX);
+  }
+  workspace = NULL;
+  layout = base_layout(4, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "finite sum-overflow workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &two_particle_configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_NONFINITE &&
+              result.value == 0.0,
+          "finite projected sum overflow is NONFINITE");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+
+  memset(slater, 0, sizeof(slater));
+  set_real_pair(slater, 2, 0, 0, NAN);
+  workspace = NULL;
+  layout = base_layout(1, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "nonfinite Slater workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &two_particle_configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_NONFINITE &&
+              result.value == 0.0,
+          "nonfinite Slater entry is classified NONFINITE atomically");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+
+  memset(slater, 0, sizeof(slater));
+  set_real_pair(slater, 2, 0, 0, 1.0);
+  set_real_pair(slater, 2, 1, 1, 1.0e-15);
+  workspace = NULL;
+  layout = base_layout(1, rank, size);
+  layout.up_electron_count = 2;
+  layout.down_electron_count = 2;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "near-pivot adapter workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &four_particle_configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_OK &&
+              result.near_pivot_component_count == 1 &&
+              result.regular_component_count == 0,
+          "adapter preserves value-only near-pivot classification");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+}
+
+static void test_projection_range_failure(void) {
+  double slater[16];
+  double pfaffians[1];
+  double complex weights[1] = {1.0};
+  double complex parameter = 1000.0;
+  int gutz_indices[2] = {0, 0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  const uint64_t configuration = UINT64_C(5);
+  int rank, size;
+
+  rank_and_size(&rank, &size);
+  fill_real_slater(slater, 1, -1, pfaffians);
+  layout = base_layout(1, rank, size);
+  enable_gutzwiller(&layout, gutz_indices, &parameter);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "overflow projection workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_NONFINITE &&
+              result.value == 0.0,
+          "projection exponential overflow is not a physical zero");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+
+  workspace = NULL;
+  parameter = -1000.0;
+  layout = base_layout(1, rank, size);
+  enable_gutzwiller(&layout, gutz_indices, &parameter);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "underflow projection workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_NONFINITE &&
+              result.value == 0.0,
+          "projection exponential underflow is not a physical zero");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+}
+
+static void test_split_communicator(void) {
+#ifdef _mpi_use
+  double slater[16];
+  double pfaffians[1];
+  double complex weights[1] = {1.0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovAmplitudeResult result;
+  uint64_t configuration = UINT64_C(5);
+  MPI_Comm split = MPI_COMM_NULL;
+  int world_rank, world_size, rank, size;
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  if (world_size < 2) return;
+  MPI_Comm_split(MPI_COMM_WORLD, world_rank % 2, world_rank, &split);
+  MPI_Comm_rank(split, &rank);
+  MPI_Comm_size(split, &size);
+  layout = base_layout(1, rank, size);
+  layout.communicator = split;
+  fill_real_slater(slater, 1, -1, pfaffians);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "split-communicator amplitude workspace create");
+  if (workspace != NULL) {
+    CHECK(mvmc_classic_krylov_real_amplitude(
+              &configuration, 1, workspace, &result) ==
+                  MVMC_KRYLOV_STATUS_OK &&
+              close_complex(result.value, pfaffians[0], 1.0e-14),
+          "split-communicator amplitude evaluation");
+  }
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(workspace);
+  MPI_Comm_free(&split);
+#endif
+}
+
+static void test_rank_mismatched_binding(void) {
+#ifdef _mpi_use
+  double slater[16];
+  double pfaffians[1];
+  double complex weights[1] = {1.0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  int rank, size;
+
+  rank_and_size(&rank, &size);
+  if (size < 2) return;
+  fill_real_slater(slater, 1, -1, pfaffians);
+  if (rank == size - 1) slater[2 * 4] += 0.125;
+  layout = base_layout(1, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+                MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE &&
+            workspace == NULL,
+        "rank-mismatched Slater binding fails bitwise collective audit");
+
+  fill_real_slater(slater, 1, -1, pfaffians);
+  layout = base_layout(1, rank, size);
+  layout.qp_start = 0;
+  layout.qp_end = 1;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+                MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE &&
+            workspace == NULL,
+        "overlapping QP ownership fails create-time partition audit");
+#endif
+}
+
+static void test_generic_engine_integration(void) {
+  double slater[16];
+  double pfaffians[1];
+  double complex weights[1] = {1.0};
+  MVMCClassicKrylovRealAmplitudeWorkspace *amplitude_workspace = NULL;
+  MVMCClassicKrylovAmplitudeLayout layout;
+  MVMCKrylovLimits limits;
+  MVMCKrylovFockModel model;
+  MVMCKrylovWorkspace *krylov_workspace = NULL;
+  MVMCKrylovResult result;
+  MVMCKrylovStatus status;
+  const uint64_t configuration = UINT64_C(5);
+  int rank, size;
+
+  rank_and_size(&rank, &size);
+  fill_real_slater(slater, 1, -1, pfaffians);
+  layout = base_layout(1, rank, size);
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &amplitude_workspace) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "generic integration amplitude workspace create");
+  if (amplitude_workspace == NULL) return;
+  memset(&limits, 0, sizeof(limits));
+  limits.max_states = 8;
+  limits.max_transitions = 8;
+  limits.max_amplitude_evaluations = 8;
+  limits.max_bytes = 65536;
+  limits.max_order = 0;
+  krylov_workspace = mvmc_krylov_workspace_create(2, &limits, &status);
+  CHECK(krylov_workspace != NULL && status == MVMC_KRYLOV_STATUS_OK,
+        "generic integration Krylov workspace create");
+  memset(&model, 0, sizeof(model));
+  model.site_count = 2;
+  model.up_electron_count = 1;
+  model.down_electron_count = 1;
+  model.hermitian = 1;
+  if (krylov_workspace != NULL) {
+    CHECK(mvmc_krylov_evaluate(
+              krylov_workspace, &model, &configuration, 1,
+              mvmc_classic_krylov_real_amplitude, amplitude_workspace,
+              &result) == MVMC_KRYLOV_STATUS_OK &&
+              result.valid && result.evaluated_order == 0 &&
+              close_complex(result.value[0], pfaffians[0], 1.0e-14) &&
+              result.statistics.global_factorization_count == 1,
+          "classic amplitude callback integrates with generic Krylov engine");
+  }
+  mvmc_krylov_workspace_destroy(krylov_workspace);
+  mvmc_classic_krylov_real_amplitude_workspace_destroy(amplitude_workspace);
+}
+
+int main(int argc, char **argv) {
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  test_matrix_helper();
+  test_real_amplitude(1, 0, -1, 1);
+  test_real_amplitude(4, 1, 1, 1);
+  test_complex_amplitude(1, 0, -1);
+  test_complex_amplitude(4, 1, 2);
+  test_all_zero_and_configuration_guards();
+  test_projection_allowlist();
+  test_weight_binding_guards();
+  test_rank_invariant_cancellation();
+  test_nonfinite_and_near_pivot_classification();
+  test_projection_range_failure();
+  test_rank_mismatched_binding();
+  test_split_communicator();
+  test_generic_engine_integration();
+
+  if (failure_count != 0) {
+    fprintf(stderr, "%d classic Krylov amplitude checks failed\n",
+            failure_count);
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+  puts("classic Krylov amplitude unit checks passed");
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return 0;
+}

--- a/test/classic_krylov_model_unit.c
+++ b/test/classic_krylov_model_unit.c
@@ -1,0 +1,367 @@
+#include "classic_krylov_model.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failure_count = 0;
+
+#define CHECK(condition, message)                                    \
+  do {                                                               \
+    if (!(condition)) {                                              \
+      fprintf(stderr, "FAIL: %s (line %d)\n", (message), __LINE__); \
+      ++failure_count;                                               \
+    }                                                                \
+  } while (0)
+
+static void rank_and_size(int *rank, int *size) {
+#ifdef _mpi_use
+  MPI_Comm_rank(MPI_COMM_WORLD, rank);
+  MPI_Comm_size(MPI_COMM_WORLD, size);
+#else
+  *rank = 0;
+  *size = 1;
+#endif
+}
+
+static MVMCClassicPfaffianCommunicator world_communicator(void) {
+#ifdef _mpi_use
+  return MPI_COMM_WORLD;
+#else
+  return 0;
+#endif
+}
+
+static MVMCClassicKrylovRawModel electronic_raw(
+    const MVMCClassicKrylovTransfer *transfers, int transfer_count,
+    const MVMCClassicKrylovSiteCoupling *intra, int intra_count,
+    const MVMCClassicKrylovPairCoupling *inter, int inter_count,
+    const MVMCClassicKrylovPairCoupling *hund, int hund_count) {
+  MVMCClassicKrylovRawModel raw;
+  memset(&raw, 0, sizeof(raw));
+  raw.site_count = 2;
+  raw.up_electron_count = 1;
+  raw.down_electron_count = 1;
+  raw.transfer_count = transfer_count;
+  raw.transfers = transfers;
+  raw.coulomb_intra_count = intra_count;
+  raw.coulomb_intra = intra;
+  raw.coulomb_inter_count = inter_count;
+  raw.coulomb_inter = inter;
+  raw.hund_count = hund_count;
+  raw.hund = hund;
+  return raw;
+}
+
+static MVMCKrylovStatus create_root_model(
+    const MVMCClassicKrylovRawModel *raw,
+    MVMCClassicKrylovModelWorkspace **workspace) {
+  int rank, size;
+  rank_and_size(&rank, &size);
+  (void)size;
+  return mvmc_classic_krylov_model_workspace_create_from_root(
+      rank == 0 ? raw : NULL, world_communicator(), workspace);
+}
+
+static void test_electronic_mapping_and_permutation(void) {
+  const MVMCClassicKrylovTransfer transfers_a[] = {
+      {0, 0, 1, 0, 0.5 + 0.25 * I},
+      {1, 0, 0, 0, 0.7 - 0.25 * I},
+      {0, 0, 1, 0, 0.2},
+      {0, 1, 0, 1, 0.3},
+  };
+  const MVMCClassicKrylovTransfer transfers_b[] = {
+      {0, 1, 0, 1, 0.3},
+      {0, 0, 1, 0, 0.2},
+      {0, 0, 1, 0, 0.5 + 0.25 * I},
+      {1, 0, 0, 0, 0.7 - 0.25 * I},
+  };
+  const MVMCClassicKrylovSiteCoupling intra_a[] = {
+      {1, 0.7}, {1, -0.2}};
+  const MVMCClassicKrylovSiteCoupling intra_b[] = {
+      {1, -0.2}, {1, 0.7}};
+  const MVMCClassicKrylovPairCoupling inter_a[] = {
+      {1, 0, 0.4}, {0, 1, 0.1}};
+  const MVMCClassicKrylovPairCoupling inter_b[] = {
+      {0, 1, 0.1}, {1, 0, 0.4}};
+  const MVMCClassicKrylovPairCoupling hund[] = {{0, 1, 0.6}};
+  MVMCClassicKrylovRawModel raw_a = electronic_raw(
+      transfers_a, 4, intra_a, 2, inter_a, 2, hund, 1);
+  MVMCClassicKrylovRawModel raw_b = electronic_raw(
+      transfers_b, 4, intra_b, 2, inter_b, 2, hund, 1);
+  MVMCClassicKrylovModelWorkspace *workspace_a = NULL;
+  MVMCClassicKrylovModelWorkspace *workspace_b = NULL;
+  const MVMCKrylovFockModel *model_a;
+  const MVMCKrylovFockModel *model_b;
+
+  CHECK(create_root_model(&raw_a, &workspace_a) == MVMC_KRYLOV_STATUS_OK,
+        "electronic model A create");
+  CHECK(create_root_model(&raw_b, &workspace_b) == MVMC_KRYLOV_STATUS_OK,
+        "electronic model B create");
+  if (workspace_a == NULL || workspace_b == NULL) goto cleanup;
+  model_a = mvmc_classic_krylov_model(workspace_a);
+  model_b = mvmc_classic_krylov_model(workspace_b);
+  CHECK(model_a != NULL && model_b != NULL,
+        "model accessor returned NULL");
+  if (model_a == NULL || model_b == NULL) goto cleanup;
+  CHECK(model_a->term_count == 10 && model_a->operator_count == 34,
+        "electronic family expansion count");
+  CHECK(model_a->term_count == model_b->term_count &&
+            model_a->operator_count == model_b->operator_count &&
+            memcmp(model_a->terms, model_b->terms,
+                   model_a->term_count * sizeof(*model_a->terms)) == 0 &&
+            memcmp(model_a->operators, model_b->operators,
+                   model_a->operator_count * sizeof(*model_a->operators)) ==
+                0,
+        "raw permutation changed canonical term list");
+  CHECK(model_a->terms[0].source_kind ==
+            MVMC_CLASSIC_KRYLOV_SOURCE_TRANSFER &&
+            model_a->terms[0].coefficient == -(0.7 + 0.25 * I),
+        "duplicate Transfer coefficient/sign mapping");
+  CHECK(model_a->terms[3].source_kind ==
+            MVMC_CLASSIC_KRYLOV_SOURCE_COULOMB_INTRA &&
+            cabs(model_a->terms[3].coefficient - 0.5) < 2.0e-15,
+        "CoulombIntra merge/mapping");
+  CHECK(model_a->terms[8].source_kind ==
+            MVMC_CLASSIC_KRYLOV_SOURCE_HUND &&
+            model_a->terms[8].coefficient == -0.6,
+        "Hund coefficient sign mapping");
+  CHECK(mvmc_classic_krylov_model_workspace_bytes(workspace_a) >
+            sizeof(*model_a),
+        "model workspace byte accounting");
+
+cleanup:
+  mvmc_classic_krylov_model_workspace_destroy(workspace_b);
+  mvmc_classic_krylov_model_workspace_destroy(workspace_a);
+}
+
+static void test_pure_spin_mapping(void) {
+  const MVMCClassicKrylovPairCoupling hund[] = {{0, 1, -0.25}};
+  const MVMCClassicKrylovPairCoupling exchange[] = {{1, 0, 0.75}};
+  MVMCClassicKrylovRawModel raw;
+  MVMCClassicKrylovModelWorkspace *workspace = NULL;
+  const MVMCKrylovFockModel *model;
+  memset(&raw, 0, sizeof(raw));
+  raw.site_count = 2;
+  raw.up_electron_count = 1;
+  raw.down_electron_count = 1;
+  raw.pure_spin = 1;
+  raw.hund_count = 1;
+  raw.hund = hund;
+  raw.exchange_count = 1;
+  raw.exchange = exchange;
+  CHECK(create_root_model(&raw, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "pure-spin model create");
+  if (workspace == NULL) return;
+  model = mvmc_classic_krylov_model(workspace);
+  CHECK(model != NULL && model->pure_spin == 1 && model->term_count == 4 &&
+            model->operator_count == 16,
+        "pure-spin family expansion count");
+  if (model != NULL) {
+    CHECK(model->terms[0].coefficient == 0.25 &&
+              model->terms[2].coefficient == 0.75 &&
+              model->terms[3].coefficient == 0.75,
+          "Hund/Exchange coefficient mapping");
+    CHECK(model->operators[8].orbital == 0 &&
+              model->operators[9].orbital == 1 &&
+              model->operators[10].orbital == 3 &&
+              model->operators[11].orbital == 2,
+          "Exchange forward orientation");
+  }
+  mvmc_classic_krylov_model_workspace_destroy(workspace);
+}
+
+static void expect_status(MVMCClassicKrylovRawModel *raw,
+                          MVMCKrylovStatus expected, const char *message) {
+  MVMCClassicKrylovModelWorkspace *workspace = NULL;
+  CHECK(create_root_model(raw, &workspace) == expected && workspace == NULL,
+        message);
+  mvmc_classic_krylov_model_workspace_destroy(workspace);
+}
+
+static void test_failure_contract(void) {
+  MVMCClassicKrylovTransfer transfers[2] = {
+      {0, 0, 1, 0, 1.0}, {1, 0, 0, 0, 1.0}};
+  MVMCClassicKrylovRawModel raw =
+      electronic_raw(transfers, 2, NULL, 0, NULL, 0, NULL, 0);
+
+  raw.transfer_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative raw count rejected");
+  raw.transfer_count = 2;
+  raw.coulomb_intra_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative CoulombIntra count rejected");
+  raw.coulomb_intra_count = 0;
+  raw.coulomb_inter_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative CoulombInter count rejected");
+  raw.coulomb_inter_count = 0;
+  raw.hund_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative Hund count rejected");
+  raw.hund_count = 0;
+  raw.exchange_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative Exchange count rejected");
+  raw.exchange_count = 0;
+  raw.pair_hopping_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative PairHopping count rejected");
+  raw.pair_hopping_count = 0;
+  raw.inter_all_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative InterAll count rejected");
+  raw.inter_all_count = 0;
+  raw.nbody_inter_all_count = -1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "negative NBodyInterAll count rejected");
+  raw.nbody_inter_all_count = 0;
+  raw.hund_count = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "positive count with NULL binding rejected");
+  raw.hund_count = 0;
+  transfers[0].output_site = 2;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "out-of-range Transfer site rejected");
+  transfers[0].output_site = 0;
+  transfers[0].input_spin = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+                "spin-changing Transfer rejected as unsupported");
+  transfers[0].input_spin = 0;
+  transfers[0].coefficient = NAN;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "nonfinite Transfer rejected");
+  transfers[0].coefficient = 1.0;
+  raw.transfer_count = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL,
+                "missing Transfer adjoint rejected");
+  raw.transfer_count = 2;
+  transfers[1].coefficient = 0.5;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL,
+                "mismatched Transfer adjoint rejected");
+  transfers[1].coefficient = nextafter(1.0, 2.0);
+  expect_status(&raw, MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL,
+                "one-ulp Transfer adjoint mismatch rejected");
+  transfers[1].coefficient = 1.0;
+  transfers[0].output_site = transfers[0].input_site = 0;
+  transfers[0].coefficient = 1.0 + I;
+  raw.transfer_count = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL,
+                "complex diagonal Transfer rejected");
+
+  transfers[0] = (MVMCClassicKrylovTransfer){0, 0, 1, 0, 1.0};
+  transfers[1] = (MVMCClassicKrylovTransfer){1, 0, 0, 0, 1.0};
+  raw.transfer_count = 2;
+  raw.pair_hopping_count = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+                "PairHopping rejected");
+  raw.pair_hopping_count = 0;
+  raw.inter_all_count = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+                "InterAll rejected");
+  raw.inter_all_count = 0;
+  raw.nbody_inter_all_count = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+                "NBodyInterAll rejected");
+  raw.nbody_inter_all_count = 0;
+
+  {
+    MVMCClassicKrylovPairCoupling exchange = {0, 1, 1.0};
+    raw.exchange_count = 1;
+    raw.exchange = &exchange;
+    expect_status(&raw, MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+                  "electronic Exchange rejected");
+    exchange.first_site = 2;
+    expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                  "malformed electronic Exchange is invalid before unsupported");
+    exchange.first_site = 0;
+    exchange.coefficient = NAN;
+    expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                  "nonfinite electronic Exchange is invalid before unsupported");
+    raw.exchange_count = 0;
+    raw.exchange = NULL;
+  }
+  transfers[1].input_site = 2;
+  transfers[0].input_spin = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                "malformed Transfer is invalid before spin-change unsupported");
+  transfers[0].input_spin = 0;
+  transfers[1].input_site = 0;
+  raw.pure_spin = 1;
+  expect_status(&raw, MVMC_KRYLOV_STATUS_UNSUPPORTED_MODEL,
+                "pure-spin Transfer rejected");
+}
+
+static void test_cancelled_duplicate(void) {
+  const MVMCClassicKrylovTransfer transfers[] = {
+      {0, 0, 1, 0, 1.0}, {0, 0, 1, 0, -1.0},
+      {1, 0, 0, 0, 1.0}, {1, 0, 0, 0, -1.0}};
+  MVMCClassicKrylovRawModel raw =
+      electronic_raw(transfers, 4, NULL, 0, NULL, 0, NULL, 0);
+  MVMCClassicKrylovModelWorkspace *workspace = NULL;
+  const MVMCKrylovFockModel *model;
+  CHECK(create_root_model(&raw, &workspace) == MVMC_KRYLOV_STATUS_OK,
+        "cancelled duplicate model create");
+  model = mvmc_classic_krylov_model(workspace);
+  CHECK(model != NULL && model->term_count == 0 &&
+            model->operator_count == 0,
+        "exactly cancelled raw terms were not removed");
+  mvmc_classic_krylov_model_workspace_destroy(workspace);
+}
+
+static void test_split_communicator(void) {
+#ifdef _mpi_use
+  const MVMCClassicKrylovTransfer transfers[] = {
+      {0, 0, 1, 0, 1.0}, {1, 0, 0, 0, 1.0}};
+  MVMCClassicKrylovRawModel raw =
+      electronic_raw(transfers, 2, NULL, 0, NULL, 0, NULL, 0);
+  MVMCClassicKrylovModelWorkspace *workspace = NULL;
+  MPI_Comm split = MPI_COMM_NULL;
+  int world_rank, world_size, split_rank;
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  if (world_size < 2) return;
+  MPI_Comm_split(MPI_COMM_WORLD, world_rank % 2, world_rank, &split);
+  MPI_Comm_rank(split, &split_rank);
+  CHECK(mvmc_classic_krylov_model_workspace_create_from_root(
+            split_rank == 0 ? &raw : NULL, split, &workspace) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "split communicator root-only model create");
+  mvmc_classic_krylov_model_workspace_destroy(workspace);
+  MPI_Comm_free(&split);
+#endif
+}
+
+int main(int argc, char **argv) {
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  test_electronic_mapping_and_permutation();
+  test_pure_spin_mapping();
+  test_failure_contract();
+  test_cancelled_duplicate();
+  test_split_communicator();
+
+  if (failure_count != 0) {
+    fprintf(stderr, "%d classic Krylov model checks failed\n", failure_count);
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+  puts("classic Krylov model unit checks passed");
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return 0;
+}

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -25,7 +25,12 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projected_ed.py DESTINATI
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projection_smoke.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_classic_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_production_anchor.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_profile.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/generate_absolute_krylov_p3_evidence.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_p3_evidence.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_p3_pipeline.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data/absolute_krylov_p3_manifest.json DESTINATION ${CMAKE_BINARY_DIR}/test/python/data)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data/absolute_krylov_p3_measurement_policy.json DESTINATION ${CMAKE_BINARY_DIR}/test/python/data)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nbodyg.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyg_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyinterall_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
@@ -430,6 +435,31 @@ if(MPI_FOUND)
     set_tests_properties(UpdateWeight_E2E_MPI PROPERTIES
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;MVMC_MPI_PROCS=2"
         RESOURCE_LOCK "update_weight_e2e_workdir")
+endif()
+
+add_test(NAME AbsoluteKrylovProfile_AuditParity
+    COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_profile.py
+            $<TARGET_FILE:absolute_krylov_profile_driver>)
+set_tests_properties(AbsoluteKrylovProfile_AuditParity PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1")
+add_test(NAME AbsoluteKrylovP3Evidence_Math
+    COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_p3_evidence.py
+            ${CMAKE_BINARY_DIR}/test/python/data/absolute_krylov_p3_measurement_policy.json)
+set_tests_properties(AbsoluteKrylovP3Evidence_Math PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+add_test(NAME AbsoluteKrylovP3Evidence_Pipeline
+    COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_p3_pipeline.py
+            ${CMAKE_BINARY_DIR}/test/python/data/absolute_krylov_p3_measurement_policy.json
+            ${CMAKE_SOURCE_DIR})
+set_tests_properties(AbsoluteKrylovP3Evidence_Pipeline PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python")
+if(MPI_FOUND)
+    add_test(NAME AbsoluteKrylovProfile_AuditParity_Rank2_mpi
+        COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_profile.py
+                $<TARGET_FILE:absolute_krylov_profile_driver>)
+    set_tests_properties(AbsoluteKrylovProfile_AuditParity_Rank2_mpi PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_MPIEXEC=${MPIEXEC_EXECUTABLE};MVMC_MPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}"
+        PROCESSORS 2)
 endif()
 
 add_test(NAME AbsoluteKrylovProductionAnchor

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -23,6 +23,9 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_complex_ed.py DESTINATION
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_heisenberg_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projected_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_lanczos2_projection_smoke.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_classic_ed.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_absolute_krylov_production_anchor.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data/absolute_krylov_p3_manifest.json DESTINATION ${CMAKE_BINARY_DIR}/test/python/data)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/runtest_nbodyg.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyg_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/nbodyinterall_exact_oracle.py DESTINATION ${CMAKE_BINARY_DIR}/test/python)
@@ -429,6 +432,24 @@ if(MPI_FOUND)
         RESOURCE_LOCK "update_weight_e2e_workdir")
 endif()
 
+add_test(NAME AbsoluteKrylovProductionAnchor
+    COMMAND ${PYTHON_EXECUTABLE}
+            runtest_absolute_krylov_production_anchor.py
+            $<TARGET_FILE:absolute_krylov_classic_ed_driver>)
+set_tests_properties(AbsoluteKrylovProductionAnchor PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1"
+    RESOURCE_LOCK "absolute_krylov_production_anchor")
+if(MPI_FOUND)
+    add_test(NAME AbsoluteKrylovProductionAnchor_Rank2_mpi
+        COMMAND ${PYTHON_EXECUTABLE}
+                runtest_absolute_krylov_production_anchor.py
+                $<TARGET_FILE:absolute_krylov_classic_ed_driver>)
+    set_tests_properties(AbsoluteKrylovProductionAnchor_Rank2_mpi PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_MPIEXEC=${MPIEXEC_EXECUTABLE};MVMC_MPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}"
+        PROCESSORS 2
+        RESOURCE_LOCK "absolute_krylov_production_anchor_mpi")
+endif()
+
 set(python_test_vmc_model
   HeisenbergChain
   HeisenbergChain_cmp
@@ -653,6 +674,31 @@ add_test(NAME Lanczos2_Real_ED
 set_tests_properties(Lanczos2_Real_ED PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_LANCZOS2_STATE_CHECK=1"
     RESOURCE_LOCK "lanczos2_real_ed_workdir")
+
+add_test(NAME AbsoluteKrylovClassic_ED
+    COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_classic_ed.py
+            $<TARGET_FILE:absolute_krylov_classic_ed_driver>)
+set_tests_properties(AbsoluteKrylovClassic_ED PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1")
+add_test(NAME AbsoluteKrylovClassic_ED_omp
+    COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_classic_ed.py
+            $<TARGET_FILE:absolute_krylov_classic_ed_driver>)
+set_tests_properties(AbsoluteKrylovClassic_ED_omp PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=4;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1")
+if(MPI_FOUND)
+    add_test(NAME AbsoluteKrylovClassic_ED_Rank2_mpi
+        COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_classic_ed.py
+                $<TARGET_FILE:absolute_krylov_classic_ed_driver>)
+    set_tests_properties(AbsoluteKrylovClassic_ED_Rank2_mpi PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=2;MVMC_MPIEXEC=${MPIEXEC_EXECUTABLE};MVMC_MPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}"
+        PROCESSORS 2)
+    add_test(NAME AbsoluteKrylovClassic_ED_Rank4_mpi
+        COMMAND ${PYTHON_EXECUTABLE} runtest_absolute_krylov_classic_ed.py
+                $<TARGET_FILE:absolute_krylov_classic_ed_driver>)
+    set_tests_properties(AbsoluteKrylovClassic_ED_Rank4_mpi PROPERTIES
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/test/python;OMP_NUM_THREADS=1;OPENBLAS_NUM_THREADS=1;MKL_NUM_THREADS=1;VECLIB_MAXIMUM_THREADS=1;MVMC_MPI_PROCS=4;MVMC_MPIEXEC=${MPIEXEC_EXECUTABLE};MVMC_MPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}"
+        PROCESSORS 4)
+endif()
 add_test(NAME Lanczos2_Real_ED_mpi
     COMMAND ${PYTHON_EXECUTABLE} runtest_lanczos2_real_ed.py)
 set_tests_properties(Lanczos2_Real_ED_mpi PROPERTIES

--- a/test/python/data/absolute_krylov_p3_manifest.json
+++ b/test/python/data/absolute_krylov_p3_manifest.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "fixture_id": "absolute-krylov-p3-l4-v1",
+  "site_count": 4,
+  "orders": [0, 1, 2, 3],
+  "comparison": {
+    "independent_ed": "absolute v_k on every fixed-sector configuration",
+    "production_anchor": "production F_k versus v_k/v_0 where v_0 is nonzero",
+    "complex_production_convention": "conjugate(v_k/v_0)"
+  },
+  "amplitude": {
+    "qp_total": 1,
+    "electronic_projection": "GUTZWILLER_ONLY",
+    "spin_projection": "NONE",
+    "gutzwiller_parameter": -0.27,
+    "zero_support_bridge_required": true
+  },
+  "model_parameters": {
+    "ring_bonds": [[0, 1], [1, 2], [2, 3], [3, 0]],
+    "electronic": {
+      "transfer_real": 0.75,
+      "transfer_imaginary_by_bond": [0.125, 0.1875, 0.25, 0.3125],
+      "diagonal_transfer": [1, 0, 0.4375],
+      "coulomb_intra": [0.25, -0.125, 0.375, -0.3125],
+      "coulomb_inter": [[0, 2, 0.1875], [1, 3, -0.15625]],
+      "hund": [[0, 1, 0.21875], [2, 3, -0.09375]]
+    },
+    "spin": {
+      "hund_by_bond": [0.375, -0.25, 0.1875, -0.125],
+      "exchange_by_bond": [0.625, -0.3125, 0.4375, -0.5625]
+    }
+  },
+  "pair_matrix": {
+    "real": [
+      [1.5, -0.5, 1.5, 1.0],
+      [-1.5, 0.5, -1.5, -1.0],
+      [-0.5, 1.5, 1.5, 2.0],
+      [-2.0, -2.0, -1.0, 0.5]
+    ],
+    "complex_real": [
+      [2.0, 1.0, 0.5, 0.5],
+      [-2.0, -1.0, -0.5, -0.5],
+      [0.5, 0.5, -0.5, -0.5],
+      [1.5, 0.5, 1.5, 1.5]
+    ],
+    "complex_imaginary": [
+      [1.0, 1.5, -0.5, -1.5],
+      [-1.0, -1.5, 0.5, 1.5],
+      [1.0, 2.0, -2.0, -1.5],
+      [1.5, 0.5, -1.5, 1.5]
+    ]
+  },
+  "cases": [
+    {
+      "name": "electronic_real",
+      "scalar": "real",
+      "term_families": [
+        "Transfer", "DiagonalTransfer", "CoulombIntra",
+        "CoulombInter", "Hund"
+      ]
+    },
+    {
+      "name": "electronic_complex",
+      "scalar": "complex",
+      "term_families": [
+        "Transfer", "DiagonalTransfer", "CoulombIntra",
+        "CoulombInter", "Hund"
+      ]
+    },
+    {
+      "name": "spin_real",
+      "scalar": "real",
+      "term_families": ["Hund", "Exchange"]
+    },
+    {
+      "name": "spin_complex",
+      "scalar": "complex",
+      "term_families": ["Hund", "Exchange"]
+    }
+  ],
+  "pilot_scan": {
+    "lambda": [1.0, 1.0, 1.0, 1.0],
+    "rho": [0.000001, 0.0001, 0.01]
+  }
+}

--- a/test/python/data/absolute_krylov_p3_measurement_policy.json
+++ b/test/python/data/absolute_krylov_p3_measurement_policy.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "policy_id": "absolute-krylov-p3-feasibility-v1",
+  "frozen_date": "2026-08-02",
+  "fixture_manifest": "absolute_krylov_p3_manifest.json",
+  "fixture_manifest_sha256": "8022b29800e98dc6be931dcbb88fef056cda4fed236024d5504e827350ad6285",
+  "p3_o1": {
+    "status": "fixed_before_official_p3d_measurement",
+    "representative_workload": {
+      "proposal_count": 4096,
+      "saved_sample_count": 4096,
+      "description": "one production-style 4096-sample second-Lanczos measurement block"
+    },
+    "l16_budgets": {
+      "proposal_seconds_per_configuration": 0.15,
+      "saved_increment_seconds_per_configuration": 0.25,
+      "combined_workload_seconds_per_rank": 1800.0,
+      "rank_rss_bytes": 4294967296
+    },
+    "rationale": "a 4096-sample measurement block must finish within a 30-minute interactive research window and fit a conservative 4-GiB per-rank memory allocation; the separate proposal/saved bounds prevent a passing aggregate from hiding an unusable stage",
+    "decision_rule": "a promoted guide must satisfy every runtime and RSS bound without assuming an unmeasured optimization"
+  },
+  "p3_o2": {
+    "status": "fixed",
+    "lambda": [1.0, 1.0, 1.0, 1.0],
+    "rho": [0.000001, 0.0001, 0.01]
+  },
+  "p3_o5": {
+    "status": "fixed_before_official_p3d_measurement",
+    "required_entries": {
+      "families": ["S", "K", "B"],
+      "i": [0, 1, 2],
+      "j": [0, 1, 2]
+    },
+    "scaled_basis": "u_k=s_k*v_k with s_0=1 and s_k=sqrt(N_0/N_k)",
+    "target_normalization": "sum_x T(x), where T=sum_k |u_k|^2",
+    "unsigned_scale": "sum_x |f_a(x)| / sum_x T(x)",
+    "absolute_standard_error_budget": "max(1e-12, 0.02 * unsigned_scale)",
+    "complex_variance": "E[|Y-E[Y]|^2]",
+    "sample_count": 4096,
+    "decision_rule": "every required entry in every frozen L=4 fixture must meet its entry-specific absolute one-sigma SE budget"
+  },
+  "official_scaling_grid": {
+    "site_counts": [4, 6, 8],
+    "qp_total": [1, 4],
+    "sample_count_by_site": {"4": 0, "6": 128, "8": 128},
+    "repeat_count": 7,
+    "mpi_rank_counts": [1, 2, 4],
+    "omp_threads": 1,
+    "blas_threads": 1,
+    "l16_extrapolation": "least-squares log-linear fit versus L for positive per-root timing and workspace series",
+    "l32_use": "sensitivity_only"
+  }
+}

--- a/test/python/generate_absolute_krylov_p3_evidence.py
+++ b/test/python/generate_absolute_krylov_p3_evidence.py
@@ -1,0 +1,1272 @@
+from __future__ import print_function
+
+import argparse
+import datetime
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+
+
+SCHEMA_VERSION = 1
+ORDERS = tuple(range(4))
+MATRIX_INDICES = tuple(range(3))
+EXPECTED_PROFILE_FIXTURE = "p3_scaling_electronic_real"
+EXPECTED_PROFILE_SITES = (4, 6, 8)
+EXPECTED_PROFILE_QP = (1, 4)
+EXPECTED_PROFILE_RANKS = (1, 2, 4)
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def sha256_text(text):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def read_json(path):
+    with open(path, "r") as handle:
+        return json.load(handle)
+
+
+def write_json(path, value):
+    parent = os.path.dirname(os.path.abspath(path))
+    if not os.path.isdir(parent):
+        os.makedirs(parent)
+    with open(path, "w") as handle:
+        json.dump(value, handle, indent=2, sort_keys=True, allow_nan=False)
+        handle.write("\n")
+
+
+def materialize_raw_files(paths, output, subdirectory):
+    destination_root = os.path.join(os.path.abspath(output), subdirectory)
+    if not os.path.isdir(destination_root):
+        os.makedirs(destination_root)
+    result = {}
+    names = [os.path.basename(path) for path in paths]
+    if len(names) != len(set(names)):
+        raise AssertionError("raw evidence basenames are not unique")
+    for source, name in zip(paths, names):
+        destination = os.path.join(destination_root, name)
+        if os.path.abspath(source) != os.path.abspath(destination):
+            shutil.copyfile(source, destination)
+        if sha256_file(destination) != sha256_file(source):
+            raise AssertionError("raw evidence copy checksum mismatch")
+        result[os.path.abspath(source)] = os.path.join(subdirectory, name)
+    return result
+
+
+def generated_at_jst():
+    zone = datetime.timezone(datetime.timedelta(hours=9))
+    return datetime.datetime.now(zone).isoformat(timespec="seconds")
+
+
+def complex_pair(value):
+    return [float(value.real), float(value.imag)]
+
+
+def finite_complex(value):
+    return math.isfinite(value.real) and math.isfinite(value.imag)
+
+
+def percentile(values, fraction):
+    ordered = sorted(float(value) for value in values)
+    if not ordered:
+        raise AssertionError("percentile of empty sequence")
+    position = fraction * (len(ordered) - 1)
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def common_metadata(args, fixture_hash):
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at_jst": generated_at_jst(),
+        "source_commit": args.source_commit,
+        "baseline_develop_commit": args.baseline_commit,
+        "compiler": args.compiler,
+        "mpi": args.mpi,
+        "blas": args.blas,
+        "strict_fp": args.strict_fp,
+        "omp_threads": args.omp_threads,
+        "blas_threads": args.blas_threads,
+        "fixture_sha256": fixture_hash,
+    }
+
+
+def validate_policy_contract(policy):
+    if policy.get("schema_version") != SCHEMA_VERSION:
+        raise AssertionError("measurement policy schema mismatch")
+    o2 = policy.get("p3_o2", {})
+    if o2.get("lambda") != [1.0] * len(ORDERS):
+        raise AssertionError("P3-O2 lambda grid mismatch")
+    if o2.get("rho") != [1.0e-6, 1.0e-4, 1.0e-2]:
+        raise AssertionError("P3-O2 rho grid mismatch")
+    o5 = policy.get("p3_o5", {})
+    required = o5.get("required_entries", {})
+    if (required.get("families") != ["S", "K", "B"] or
+            required.get("i") != list(MATRIX_INDICES) or
+            required.get("j") != list(MATRIX_INDICES) or
+            int(o5.get("sample_count", 0)) != 4096):
+        raise AssertionError("P3-O5 required-entry contract mismatch")
+    grid = policy.get("official_scaling_grid", {})
+    if (grid.get("site_counts") != list(EXPECTED_PROFILE_SITES) or
+            grid.get("qp_total") != list(EXPECTED_PROFILE_QP) or
+            grid.get("mpi_rank_counts") != list(EXPECTED_PROFILE_RANKS) or
+            int(grid.get("repeat_count", 0)) != 7 or
+            int(grid.get("omp_threads", 0)) != 1 or
+            int(grid.get("blas_threads", 0)) != 1):
+        raise AssertionError("official scaling grid contract mismatch")
+    counts = grid.get("sample_count_by_site", {})
+    if set(counts) != {str(site) for site in EXPECTED_PROFILE_SITES}:
+        raise AssertionError("sample-count grid keys mismatch")
+    if any(not isinstance(counts[str(site)], int) or
+           counts[str(site)] < 0 for site in EXPECTED_PROFILE_SITES):
+        raise AssertionError("invalid sample-count grid")
+    return policy
+
+
+def parse_ed_output(text):
+    cases = {}
+    current = None
+    rank_count = None
+    for line in text.splitlines():
+        fields = line.split()
+        if not fields:
+            continue
+        if fields[0] == "BEGIN":
+            if len(fields) != 6 or fields[2] != "rank_count":
+                raise AssertionError("malformed ED BEGIN: {}".format(line))
+            current = fields[1]
+            rank_count = int(fields[3])
+            cases[current] = []
+        elif fields[0] == "ROW":
+            if current is None or len(fields) != 10:
+                raise AssertionError("malformed ED ROW: {}".format(line))
+            values = []
+            for order in ORDERS:
+                value = complex(float(fields[2 + 2 * order]),
+                                float(fields[3 + 2 * order]))
+                if not finite_complex(value):
+                    raise AssertionError("nonfinite ED value")
+                values.append(value)
+            cases[current].append({
+                "configuration": int(fields[1]),
+                "values": values,
+            })
+        elif fields[0] == "END":
+            if current is None or fields[1] != current:
+                raise AssertionError("malformed ED END")
+            current = None
+    if current is not None or set(cases) != {
+            "electronic_real", "electronic_complex", "spin_real",
+            "spin_complex"}:
+        raise AssertionError("incomplete ED cases")
+    if rank_count != 1:
+        raise AssertionError("exact freeze must use the serial ED trace")
+    up_masks = [mask for mask in range(1 << 4)
+                if bin(mask).count("1") == 2]
+    electronic_sector = {
+        up | (down << 4) for up in up_masks for down in up_masks
+    }
+    spin_sector = {
+        up | (((~up) & 0x0f) << 4) for up in up_masks
+    }
+    for name, rows in cases.items():
+        observed = [row["configuration"] for row in rows]
+        expected = spin_sector if name.startswith("spin_") else electronic_sector
+        if len(observed) != len(set(observed)):
+            raise AssertionError("duplicate ED configuration in {}".format(name))
+        if set(observed) != expected:
+            raise AssertionError(
+                "ED sector coverage mismatch in {}: missing={} extra={}".format(
+                    name, sorted(expected - set(observed)),
+                    sorted(set(observed) - expected)))
+    return cases
+
+
+def run_ed_driver(path):
+    process = subprocess.run(
+        [path], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, check=False,
+    )
+    if process.returncode != 0:
+        raise AssertionError("ED driver failed:\n{}".format(process.stdout))
+    return process.stdout
+
+
+def run_correctness_gate(script, driver):
+    environment = os.environ.copy()
+    environment.pop("MVMC_MPI_PROCS", None)
+    environment.pop("MVMC_MPIEXEC", None)
+    environment.pop("MVMC_MPIEXEC_NUMPROC_FLAG", None)
+    process = subprocess.run(
+        [sys.executable, script, driver],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, check=False, env=environment,
+    )
+    expected = (
+        "absolute Krylov classic ED passed: 4 families, ranks=1, "
+        "orders=0..3, zero-support bridges verified"
+    )
+    if process.returncode != 0 or expected not in process.stdout:
+        raise AssertionError(
+            "independent deterministic correctness gate failed:\n{}".format(
+                process.stdout))
+    return {
+        "status": "PASS",
+        "script_file": os.path.basename(script),
+        "script_sha256": sha256_file(script),
+        "stdout_sha256": sha256_text(process.stdout),
+        "assertion": expected,
+    }
+
+
+def integrand_indices(family, i, j):
+    if family == "S":
+        return i, j
+    if family == "K":
+        return i, j + 1
+    if family == "B":
+        return i + 1, j + 1
+    raise AssertionError("unknown integrand family")
+
+
+def exact_case_statistics(rows, policy):
+    values = [row["values"] for row in rows]
+    norms = [sum(abs(row[order]) ** 2 for row in values)
+             for order in ORDERS]
+    if any(not math.isfinite(value) or value <= 0.0 for value in norms):
+        raise AssertionError("zero/nonfinite Krylov norm")
+    scales = [1.0] + [math.sqrt(norms[0] / norms[order])
+                      for order in ORDERS[1:]]
+    scaled = [[scales[order] * row[order] for order in ORDERS]
+              for row in values]
+    target = [sum(abs(value) ** 2 for value in row) for row in scaled]
+    target_sum = sum(target)
+    target_mean = target_sum / len(target)
+    entry_values = {}
+    entry_budget = {}
+    matrices = {family: [[None] * 3 for _ in MATRIX_INDICES]
+                for family in ("S", "K", "B")}
+    for family in ("S", "K", "B"):
+        for i in MATRIX_INDICES:
+            for j in MATRIX_INDICES:
+                left, right = integrand_indices(family, i, j)
+                samples = [row[left].conjugate() * row[right]
+                           for row in scaled]
+                name = "{}_{}{}".format(family, i, j)
+                unsigned_scale = sum(abs(value) for value in samples) / target_sum
+                budget = max(1.0e-12, 0.02 * unsigned_scale)
+                exact_target = sum(samples) / target_sum
+                cancellation_denominator = sum(abs(value) for value in samples)
+                cancellation = (abs(sum(samples)) / cancellation_denominator
+                                if cancellation_denominator != 0.0 else 1.0)
+                entry_values[name] = samples
+                entry_budget[name] = {
+                    "unsigned_scale": unsigned_scale,
+                    "absolute_standard_error_budget": budget,
+                    "exact_normalized_target": complex_pair(exact_target),
+                    "cancellation_ratio": cancellation,
+                }
+                matrices[family][i][j] = complex_pair(sum(samples))
+
+    guides = {}
+    sample_count = int(policy["p3_o5"]["sample_count"])
+    for rank in ORDERS:
+        for rho in policy["p3_o2"]["rho"]:
+            eta = float(rho) * target_mean
+            guide = [sum(abs(row[order]) ** 2
+                         for order in range(rank + 1)) + eta
+                     for row in scaled]
+            if any(not math.isfinite(value) or value <= 0.0
+                   for value in guide):
+                raise AssertionError("guide is not strictly positive")
+            guide_sum = sum(guide)
+            probabilities = [value / guide_sum for value in guide]
+            weights = [target[index] / guide[index]
+                       for index in range(len(guide))]
+            mean_weight = sum(probabilities[index] * weights[index]
+                              for index in range(len(guide)))
+            mean_square = sum(probabilities[index] * weights[index] ** 2
+                              for index in range(len(guide)))
+            ess = mean_weight ** 2 / mean_square
+            entry_statistics = {}
+            all_entries_pass = True
+            cross_term_max = 0.0
+            for left in ORDERS:
+                for right in ORDERS:
+                    cross_term_max = max(
+                        cross_term_max,
+                        max(abs(row[left].conjugate() * row[right]) /
+                            guide[index]
+                            for index, row in enumerate(scaled)))
+            for name, samples in entry_values.items():
+                raw = [samples[index] / guide[index]
+                       for index in range(len(guide))]
+                raw_mean = sum(probabilities[index] * raw[index]
+                               for index in range(len(guide)))
+                raw_second = sum(probabilities[index] * abs(raw[index]) ** 2
+                                 for index in range(len(guide)))
+                normalized = [value * guide_sum / target_sum for value in raw]
+                normalized_mean = sum(
+                    probabilities[index] * normalized[index]
+                    for index in range(len(guide)))
+                variance = sum(
+                    probabilities[index] *
+                    abs(normalized[index] - normalized_mean) ** 2
+                    for index in range(len(guide)))
+                second_moment = sum(
+                    probabilities[index] * abs(normalized[index]) ** 2
+                    for index in range(len(guide)))
+                standard_error = math.sqrt(max(variance, 0.0) / sample_count)
+                budget = entry_budget[name]["absolute_standard_error_budget"]
+                passed = standard_error <= budget
+                all_entries_pass = all_entries_pass and passed
+                tails = [abs(value) for value in raw]
+                entry_statistics[name] = {
+                    "expectation_f_over_g": complex_pair(raw_mean),
+                    "expectation_abs_f_over_g_squared": raw_second,
+                    "normalized_expectation": complex_pair(normalized_mean),
+                    "normalized_complex_variance": variance,
+                    "normalized_second_moment": second_moment,
+                    "absolute_standard_error_at_4096": standard_error,
+                    "absolute_standard_error_budget": budget,
+                    "budget_pass": passed,
+                    "cancellation_ratio": entry_budget[name]["cancellation_ratio"],
+                    "tail": {
+                        "max_abs_f_over_g": max(tails),
+                        "median_abs_f_over_g": percentile(tails, 0.5),
+                        "p99_abs_f_over_g": percentile(tails, 0.99),
+                    },
+                    "second_moment_efficiency_per_four_component_evaluations":
+                        (1.0 / (4.0 * second_moment)
+                         if second_moment > 0.0 else None),
+                }
+            key = "r{}_rho_{:.0e}".format(rank, float(rho))
+            guides[key] = {
+                "r": rank,
+                "rho": float(rho),
+                "eta": eta,
+                "guide_min": min(guide),
+                "guide_max": max(guide),
+                "guide_sum": guide_sum,
+                "strict_positive_support": True,
+                "t_ess_fraction": ess,
+                "t_weight_tail": {
+                    "max": max(weights),
+                    "median": percentile(weights, 0.5),
+                    "p99": percentile(weights, 0.99),
+                },
+                "cross_term_max_abs_over_g": cross_term_max,
+                "entries": entry_statistics,
+                "all_entry_budgets_pass": all_entries_pass,
+            }
+    return {
+        "sector_size": len(rows),
+        "norms": norms,
+        "krylov_scales": scales,
+        "sum_t": target_sum,
+        "mean_t": target_mean,
+        "matrices_unnormalized": matrices,
+        "entry_budgets": entry_budget,
+        "guides": guides,
+    }
+
+
+def exact_command(args):
+    fixture_hash = sha256_file(args.fixture_manifest)
+    policy_hash = sha256_file(args.policy)
+    fixture = read_json(args.fixture_manifest)
+    policy = validate_policy_contract(read_json(args.policy))
+    if fixture_hash != policy["fixture_manifest_sha256"]:
+        raise AssertionError("policy fixture hash does not match")
+    ed_text = run_ed_driver(args.ed_driver)
+    cases = parse_ed_output(ed_text)
+    correctness_gate = run_correctness_gate(
+        args.correctness_script, args.ed_driver)
+    metadata = common_metadata(args, fixture_hash)
+    metadata["measurement_policy_sha256"] = policy_hash
+
+    reference = dict(metadata)
+    reference.update({
+        "artifact": "p3_reference_results",
+        "fixture_id": fixture["fixture_id"],
+        "driver_stdout_sha256": sha256_text(ed_text),
+        "deterministic_correctness_gate": correctness_gate,
+        "deterministic_correctness_gate_pass": True,
+        "cases": {
+            name: [{
+                "configuration": row["configuration"],
+                "v": [complex_pair(value) for value in row["values"]],
+            } for row in rows]
+            for name, rows in sorted(cases.items())
+        },
+    })
+
+    analyzed = {name: exact_case_statistics(rows, policy)
+                for name, rows in sorted(cases.items())}
+    oracle = dict(metadata)
+    oracle.update({
+        "artifact": "p3_exact_oracle",
+        "basis": "u_k=s_k*v_k",
+        "matrix_definition": {
+            "S_ij": "sum conj(u_i)*u_j",
+            "K_ij": "sum conj(u_i)*u_(j+1)",
+            "B_ij": "sum conj(u_(i+1))*u_(j+1)",
+        },
+        "cases": {
+            name: {
+                key: value for key, value in case.items()
+                if key not in ("entry_budgets", "guides")
+            } for name, case in analyzed.items()
+        },
+    })
+
+    model_manifest = dict(metadata)
+    model_manifest.update({
+        "artifact": "p3_model_manifest",
+        "fixture": fixture,
+        "measurement_policy": policy,
+        "p3_o5_materialized_before_profile_timing": True,
+        "entry_budgets": {
+            name: case["entry_budgets"] for name, case in analyzed.items()
+        },
+    })
+
+    candidates = {}
+    integrand_cases = {}
+    for name, case in analyzed.items():
+        integrand_cases[name] = {"guides": case["guides"]}
+        for key, guide in case["guides"].items():
+            aggregate = candidates.setdefault(key, {
+                "r": guide["r"], "rho": guide["rho"],
+                "all_cases_entry_budgets_pass": True,
+                "all_cases_strict_positive_support": True,
+                "all_cases_t_proxy_finite": True,
+                "minimum_t_ess_fraction": 1.0,
+                "maximum_t_weight_tail": 0.0,
+            })
+            aggregate["all_cases_entry_budgets_pass"] = (
+                aggregate["all_cases_entry_budgets_pass"] and
+                guide["all_entry_budgets_pass"])
+            aggregate["minimum_t_ess_fraction"] = min(
+                aggregate["minimum_t_ess_fraction"],
+                guide["t_ess_fraction"])
+            aggregate["all_cases_strict_positive_support"] = (
+                aggregate["all_cases_strict_positive_support"] and
+                guide["strict_positive_support"])
+            proxy_values = [
+                guide["t_ess_fraction"],
+                guide["t_weight_tail"]["max"],
+                guide["t_weight_tail"]["median"],
+                guide["t_weight_tail"]["p99"],
+                guide["cross_term_max_abs_over_g"],
+            ]
+            aggregate["all_cases_t_proxy_finite"] = (
+                aggregate["all_cases_t_proxy_finite"] and
+                all(math.isfinite(value) for value in proxy_values))
+            aggregate["maximum_t_weight_tail"] = max(
+                aggregate["maximum_t_weight_tail"],
+                guide["t_weight_tail"]["max"])
+    for rank in ORDERS:
+        family = [candidate for candidate in candidates.values()
+                  if candidate["r"] == rank]
+        ess_values = [candidate["minimum_t_ess_fraction"]
+                      for candidate in family]
+        tail_values = [candidate["maximum_t_weight_tail"]
+                       for candidate in family]
+        floor_improvement = (
+            max(ess_values) > min(ess_values) or
+            min(tail_values) < max(tail_values)
+        )
+        for candidate in family:
+            candidate_improves = floor_improvement and (
+                candidate["minimum_t_ess_fraction"] > min(ess_values) or
+                candidate["maximum_t_weight_tail"] < max(tail_values)
+            )
+            candidate["floor_scan_improvement_observed"] = \
+                candidate_improves
+            candidate["p3_exact_feasibility_gate_pass"] = (
+                candidate["all_cases_entry_budgets_pass"] and
+                candidate["all_cases_strict_positive_support"] and
+                candidate["all_cases_t_proxy_finite"] and
+                candidate["minimum_t_ess_fraction"] > 0.0 and
+                candidate_improves
+            )
+    integrands = dict(metadata)
+    integrands.update({
+        "artifact": "p3_integrand_statistics",
+        "sample_count_for_budget": policy["p3_o5"]["sample_count"],
+        "cases": integrand_cases,
+        "candidate_summary": candidates,
+        "t_ess_limitation": (
+            "aggregate positive-target proxy only; every signed/complex "
+            "S/K/B entry is gated separately"
+        ),
+    })
+
+    write_json(os.path.join(args.output, "p3_reference_results.json"),
+               reference)
+    write_json(os.path.join(args.output, "p3_exact_oracle.json"), oracle)
+    write_json(os.path.join(args.output, "p3_model_manifest.json"),
+               model_manifest)
+    write_json(os.path.join(args.output, "p3_integrand_statistics.json"),
+               integrands)
+    print("frozen exact evidence and entry-specific P3-O5 budgets")
+
+
+def parse_key_values(line):
+    result = {}
+    for token in line.split()[1:]:
+        if "=" in token:
+            key, value = token.split("=", 1)
+            result[key] = value
+    return result
+
+
+def parse_number(value):
+    if "," in value:
+        return [parse_number(part) for part in value.split(",")]
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def parse_profile_log(path):
+    with open(path, "r") as handle:
+        text = handle.read()
+    header = None
+    rows = []
+    resources = {}
+    for line in text.splitlines():
+        if line.startswith("PROFILE "):
+            if header is not None:
+                raise AssertionError("duplicate PROFILE header")
+            header = {key: parse_number(value)
+                      for key, value in parse_key_values(line).items()}
+        elif line.startswith("ROW "):
+            rows.append(line)
+        elif line.startswith("RESOURCE "):
+            fields = parse_key_values(line)
+            scope = fields.pop("scope")
+            resources[scope] = {key: parse_number(value)
+                                for key, value in fields.items()}
+    if header is None or not rows or set(resources) != {"rank_sum", "rank_max"}:
+        raise AssertionError("incomplete profile log {}".format(path))
+    if int(header["audit"]) != 1 or len(rows) != int(header["sample_count"]):
+        raise AssertionError("invalid profile audit trace")
+    return {
+        "path": os.path.abspath(path),
+        "sha256": sha256_file(path),
+        "header": header,
+        "rows": rows,
+        "trace_sha256": sha256_text("\n".join(rows) + "\n"),
+        "resources": resources,
+    }
+
+
+def fixed_sector_size(site_count):
+    half = site_count // 2
+    one_spin = math.factorial(site_count) // (
+        math.factorial(half) * math.factorial(site_count - half))
+    return one_spin * one_spin
+
+
+def fixed_masks(site_count):
+    half = site_count // 2
+    return [mask for mask in range(1 << site_count)
+            if bin(mask).count("1") == half]
+
+
+def expected_profile_rows(site_count, sample_count):
+    masks = fixed_masks(site_count)
+    sector_size = len(masks) * len(masks)
+    rows = []
+    for sample in range(sample_count):
+        sector_index = ((sector_size - 1) // 2 if sample_count == 1 else
+                        sample * (sector_size - 1) // (sample_count - 1))
+        up_index = sector_index // len(masks)
+        down_index = sector_index % len(masks)
+        configuration = (masks[up_index] |
+                         (masks[down_index] << site_count))
+        rows.append((sample, sector_index, configuration))
+    return rows
+
+
+def validate_profile_run(run, policy):
+    header = run["header"]
+    required = {
+        "schema", "fixture", "site_count", "qp_total", "sample_count",
+        "sector_size", "rank_count", "audit",
+    }
+    missing = required - set(header)
+    if missing:
+        raise AssertionError("profile header fields missing: {}".format(
+            sorted(missing)))
+    if (int(header["schema"]) != SCHEMA_VERSION or
+            header["fixture"] != EXPECTED_PROFILE_FIXTURE or
+            int(header["audit"]) != 1):
+        raise AssertionError("profile schema/fixture/audit mismatch")
+    site = int(header["site_count"])
+    qp = int(header["qp_total"])
+    ranks = int(header["rank_count"])
+    if (site not in policy["official_scaling_grid"]["site_counts"] or
+            qp not in policy["official_scaling_grid"]["qp_total"] or
+            ranks not in
+            policy["official_scaling_grid"]["mpi_rank_counts"]):
+        raise AssertionError("profile header is outside the frozen grid")
+    expected_sector = fixed_sector_size(site)
+    requested = int(
+        policy["official_scaling_grid"]["sample_count_by_site"][str(site)])
+    expected_samples = expected_sector if requested == 0 else requested
+    if (int(header["sector_size"]) != expected_sector or
+            int(header["sample_count"]) != expected_samples):
+        raise AssertionError(
+            "profile sector/sample contract mismatch for L{}".format(site))
+    observed_rows = []
+    for line in run["rows"]:
+        fields = line.split()
+        if len(fields) != 12 or fields[0] != "ROW":
+            raise AssertionError("malformed profile ROW")
+        try:
+            identifiers = tuple(int(value) for value in fields[1:4])
+            values = [float(value) for value in fields[4:]]
+        except ValueError:
+            raise AssertionError("non-numeric profile ROW")
+        if any(not math.isfinite(value) for value in values):
+            raise AssertionError("nonfinite profile ROW value")
+        observed_rows.append(identifiers)
+    if observed_rows != expected_profile_rows(site, expected_samples):
+        raise AssertionError("profile sample/configuration schedule mismatch")
+    rank_sum = run["resources"]["rank_sum"]
+    rank_max = run["resources"]["rank_max"]
+    if (int(rank_max.get("roots", -1)) != expected_samples or
+            int(rank_sum.get("roots", -1)) != expected_samples * ranks):
+        raise AssertionError("profile root-count invariant mismatch")
+    logical = (
+        "regular_logical", "near_pivot_logical", "singular_logical",
+        "total_zero_logical", "global_factorizations_logical",
+    )
+    for field in logical:
+        if (field not in run["resources"]["rank_sum"] or
+                field not in run["resources"]["rank_max"] or
+                run["resources"]["rank_sum"][field] !=
+                run["resources"]["rank_max"][field]):
+            raise AssertionError(
+                "communicator-global logical counter mismatch: {}".format(
+                    field))
+    if ("local_factorizations" not in rank_sum or
+            int(rank_sum["local_factorizations"]) !=
+            int(rank_sum["global_factorizations_logical"])):
+        raise AssertionError("invalid local/global factorization counters")
+
+
+def log_linear_fit(points, target_l):
+    usable = [(float(site), float(value)) for site, value in points
+              if value > 0.0 and math.isfinite(value)]
+    if len(usable) != 3:
+        raise AssertionError("L=4/6/8 positive values required for fit")
+    mean_x = sum(point[0] for point in usable) / len(usable)
+    logs = [math.log(point[1]) for point in usable]
+    mean_y = sum(logs) / len(logs)
+    denominator = sum((point[0] - mean_x) ** 2 for point in usable)
+    slope = sum((point[0] - mean_x) * (logs[index] - mean_y)
+                for index, point in enumerate(usable)) / denominator
+    intercept = mean_y - slope * mean_x
+    prediction = math.exp(intercept + slope * float(target_l))
+    return {
+        "model": "log(value)=intercept+slope*L",
+        "intercept": intercept,
+        "slope": slope,
+        "prediction": prediction,
+        "points": [[int(site), value] for site, value in usable],
+    }
+
+
+def extrapolate_nonnegative(points, target_l):
+    if all(float(value) == 0.0 for _, value in points):
+        return {
+            "model": "structural_zero",
+            "intercept": None,
+            "slope": 0.0,
+            "prediction": 0.0,
+            "points": [[int(site), float(value)] for site, value in points],
+        }
+    return log_linear_fit(points, target_l)
+
+
+def profile_command(args):
+    policy = validate_policy_contract(read_json(args.policy))
+    model_manifest = read_json(args.model_manifest)
+    integrands = read_json(args.integrand_statistics)
+    reference = read_json(args.reference_results)
+    production_anchor = read_json(args.production_anchor)
+    policy_hash = sha256_file(args.policy)
+    if model_manifest["measurement_policy_sha256"] != policy_hash:
+        raise AssertionError("profile policy differs from frozen manifest")
+    runs = [parse_profile_log(path) for path in args.profile_log]
+    for run in runs:
+        validate_profile_run(run, policy)
+    artifacts = (model_manifest, integrands, reference, production_anchor)
+    expected_fixture_hash = model_manifest["fixture_sha256"]
+    for artifact in artifacts:
+        if (artifact.get("source_commit") != args.source_commit or
+                artifact.get("baseline_develop_commit") !=
+                args.baseline_commit or
+                artifact.get("fixture_sha256") != expected_fixture_hash or
+                artifact.get("measurement_policy_sha256") != policy_hash):
+            raise AssertionError("cross-artifact provenance mismatch")
+    if not reference.get("deterministic_correctness_gate_pass", False):
+        raise AssertionError("deterministic correctness gate is not PASS")
+    anchor_runs = production_anchor.get("runs", [])
+    if (not production_anchor.get("all_runs_pass", False) or
+            len(anchor_runs) != len(EXPECTED_PROFILE_RANKS[:2]) or
+            sorted(run.get("rank_count") for run in anchor_runs) != [1, 2] or
+            any(run.get("status") != "PASS" for run in anchor_runs)):
+        raise AssertionError("serial/MPI production anchor gate is not PASS")
+    groups = {}
+    for run in runs:
+        header = run["header"]
+        key = (int(header["site_count"]), int(header["qp_total"]),
+               int(header["rank_count"]))
+        groups.setdefault(key, []).append(run)
+    expected_repeats = int(policy["official_scaling_grid"]["repeat_count"])
+    expected_keys = {(site, qp, rank)
+                     for site in policy["official_scaling_grid"]["site_counts"]
+                     for qp in policy["official_scaling_grid"]["qp_total"]
+                     for rank in policy["official_scaling_grid"]["mpi_rank_counts"]}
+    if set(groups) != expected_keys:
+        raise AssertionError("profile grid mismatch: missing={} extra={}".format(
+            sorted(expected_keys - set(groups)),
+            sorted(set(groups) - expected_keys)))
+
+    cross_rank_trace_invariance = {}
+    for site in policy["official_scaling_grid"]["site_counts"]:
+        for qp in policy["official_scaling_grid"]["qp_total"]:
+            traces = {
+                member["trace_sha256"]
+                for rank in policy["official_scaling_grid"]["mpi_rank_counts"]
+                for member in groups[(site, qp, rank)]
+            }
+            if len(traces) != 1:
+                raise AssertionError(
+                    "MPI rank-count trace mismatch for L{} qp{}".format(
+                        site, qp))
+            cross_rank_trace_invariance["L{}_qp{}".format(site, qp)] = {
+                "rank_counts":
+                    policy["official_scaling_grid"]["mpi_rank_counts"],
+                "trace_sha256": next(iter(traces)),
+                "status": "PASS",
+            }
+
+    summaries = {}
+    for key, members in sorted(groups.items()):
+        if len(members) != expected_repeats:
+            raise AssertionError("repeat count mismatch for {}".format(key))
+        traces = {member["trace_sha256"] for member in members}
+        if len(traces) != 1:
+            raise AssertionError("repeat trace mismatch for {}".format(key))
+        roots = [member["resources"]["rank_max"]["roots"]
+                 for member in members]
+        depth_per_root = []
+        for member in members:
+            resource = member["resources"]["rank_max"]
+            depth_per_root.append([
+                float(value) / float(resource["roots"])
+                for value in resource["depth_seconds"]
+            ])
+        median_depth = [statistics.median(row[order]
+                                          for row in depth_per_root)
+                        for order in ORDERS]
+        summaries["L{}_qp{}_rank{}".format(*key)] = {
+            "site_count": key[0],
+            "qp_total": key[1],
+            "rank_count": key[2],
+            "repeat_count": len(members),
+            "sample_count": members[0]["header"]["sample_count"],
+            "sector_size": members[0]["header"]["sector_size"],
+            "trace_sha256": members[0]["trace_sha256"],
+            "roots_per_rank": statistics.median(roots),
+            "median_depth_seconds_per_root": median_depth,
+            "median_total_seconds_per_root": statistics.median(
+                float(member["resources"]["rank_max"]["total_seconds"]) /
+                float(member["resources"]["rank_max"]["roots"])
+                for member in members),
+            "median_workspace_bytes_per_rank": statistics.median(
+                member["resources"]["rank_max"]["krylov_workspace_bytes"] +
+                member["resources"]["rank_max"]["model_workspace_bytes"] +
+                member["resources"]["rank_max"]["amplitude_workspace_bytes"]
+                for member in members),
+            "median_rss_bytes_per_rank": statistics.median(
+                member["resources"]["rank_max"]["rss_bytes"]
+                for member in members),
+            "rank_sum_median": {
+                key_name: statistics.median(
+                    member["resources"]["rank_sum"][key_name]
+                    for member in members)
+                for key_name in (
+                    "roots", "raw_transitions", "merged_duplicates",
+                    "cancelled_zero", "terminal_requests",
+                    "terminal_cache_hits", "local_factorizations",
+                    "global_factorizations_logical")
+            },
+            "rank_max_peaks": {
+                key_name: max(member["resources"]["rank_max"][key_name]
+                              for member in members)
+                for key_name in ("frontier_peak", "memo_peak")
+            },
+        }
+
+    fixture_hash = model_manifest["fixture_sha256"]
+    metadata = common_metadata(args, fixture_hash)
+    metadata["measurement_policy_sha256"] = policy_hash
+    raw_profile_files = materialize_raw_files(
+        [run["path"] for run in runs], args.output, "raw_profiles")
+    resources = dict(metadata)
+    resources.update({
+        "artifact": "p3_resource_statistics",
+        "official_hpc_measurement": True,
+        "counter_semantics": {
+            "rank_sum": "sum of per-rank work counters",
+            "rank_max": "maximum per-rank work/resource counter",
+            "logical_component_and_global_factorization_counters": (
+                "communicator-global logical counts, recorded once rather "
+                "than summing replicated callback results"
+            ),
+        },
+        "raw_logs": [{
+            "file": raw_profile_files[run["path"]],
+            "sha256": run["sha256"],
+            "header": run["header"],
+            "trace_sha256": run["trace_sha256"],
+            "rank_sum": run["resources"]["rank_sum"],
+            "rank_max": run["resources"]["rank_max"],
+        } for run in runs],
+        "cross_rank_trace_invariance": cross_rank_trace_invariance,
+        "group_summary": summaries,
+    })
+
+    extrapolations = {}
+    o1 = policy["p3_o1"]
+    budgets = o1["l16_budgets"]
+    workload = o1["representative_workload"]
+    guide_passes_all_grid_points = {guide_rank: True for guide_rank in ORDERS}
+    for qp in policy["official_scaling_grid"]["qp_total"]:
+        for rank_count in policy["official_scaling_grid"]["mpi_rank_counts"]:
+            combo = "qp{}_rank{}".format(qp, rank_count)
+            combo_result = {
+                "qp_total": qp,
+                "rank_count": rank_count,
+                "guides": {},
+            }
+            workspace_points = []
+            rss_points = []
+            for site in (4, 6, 8):
+                summary = summaries["L{}_qp{}_rank{}".format(
+                    site, qp, rank_count)]
+                workspace_points.append(
+                    (site, summary["median_workspace_bytes_per_rank"]))
+                rss_points.append((site, summary["median_rss_bytes_per_rank"]))
+            workspace_l16 = log_linear_fit(workspace_points, 16)
+            rss_l16 = log_linear_fit(rss_points, 16)
+            workspace_l32 = log_linear_fit(workspace_points, 32)
+            rss_l32 = log_linear_fit(rss_points, 32)
+            combo_result["rank_memory"] = {
+                "l16_workspace": workspace_l16,
+                "l16_rss": rss_l16,
+                "l16_conservative_bytes": max(
+                    workspace_l16["prediction"], rss_l16["prediction"]),
+                "l32_workspace_sensitivity": workspace_l32,
+                "l32_rss_sensitivity": rss_l32,
+            }
+            for guide_rank in ORDERS:
+                proposal_points = []
+                saved_points = []
+                full_points = []
+                for site in (4, 6, 8):
+                    depth = summaries[
+                        "L{}_qp{}_rank{}".format(site, qp, rank_count)
+                    ]["median_depth_seconds_per_root"]
+                    proposal_points.append((site, sum(depth[:guide_rank + 1])))
+                    saved_points.append((site, sum(depth[guide_rank + 1:])))
+                    full_points.append((site, sum(depth)))
+                proposal_l16 = log_linear_fit(proposal_points, 16)
+                saved_l16 = extrapolate_nonnegative(saved_points, 16)
+                full_l16 = log_linear_fit(full_points, 16)
+                full_l32 = log_linear_fit(full_points, 32)
+                combined = (
+                    float(workload["proposal_count"]) *
+                    proposal_l16["prediction"] +
+                    float(workload["saved_sample_count"]) *
+                    saved_l16["prediction"])
+                memory = combo_result["rank_memory"]["l16_conservative_bytes"]
+                passed = (
+                    proposal_l16["prediction"] <=
+                    float(budgets["proposal_seconds_per_configuration"]) and
+                    saved_l16["prediction"] <=
+                    float(budgets["saved_increment_seconds_per_configuration"]) and
+                    combined <=
+                    float(budgets["combined_workload_seconds_per_rank"]) and
+                    memory <= float(budgets["rank_rss_bytes"])
+                )
+                guide_passes_all_grid_points[guide_rank] = (
+                    guide_passes_all_grid_points[guide_rank] and passed)
+                combo_result["guides"]["r{}".format(guide_rank)] = {
+                    "proposal_component_evaluation_count": guide_rank + 1,
+                    "saved_increment_component_evaluation_count":
+                        ORDERS[-1] - guide_rank,
+                    "accepted_current_guide_re_evaluation_count": 0,
+                    "proposal_l16": proposal_l16,
+                    "saved_increment_l16": saved_l16,
+                    "full_l16": full_l16,
+                    "combined_workload_seconds_l16": combined,
+                    "full_l32_sensitivity": full_l32,
+                    "o1_budget_pass": passed,
+                }
+            extrapolations[combo] = combo_result
+
+    viable_r = {guide_rank for guide_rank, passed
+                in guide_passes_all_grid_points.items() if passed}
+    exact_candidates = integrands["candidate_summary"]
+    correctness_gate = {
+        "independent_deterministic_ed": {
+            "status": "PASS",
+            "script_sha256": reference["deterministic_correctness_gate"]
+            ["script_sha256"],
+            "stdout_sha256": reference["deterministic_correctness_gate"]
+            ["stdout_sha256"],
+        },
+        "production_action_anchor": {
+            "status": "PASS",
+            "rank_counts": sorted(run["rank_count"] for run in anchor_runs),
+            "log_sha256": sorted(run["sha256"] for run in anchor_runs),
+        },
+        "profile_cross_rank_trace_invariance": {
+            "status": "PASS",
+            "groups": len(cross_rank_trace_invariance),
+        },
+        "all_pass": True,
+    }
+    promoted = []
+    for name, candidate in sorted(exact_candidates.items()):
+        if (correctness_gate["all_pass"] and
+                candidate["p3_exact_feasibility_gate_pass"] and
+                int(candidate["r"]) in viable_r):
+            promoted.append(name)
+    decision = "GO" if promoted else "STOP"
+    cost = dict(metadata)
+    cost.update({
+        "artifact": "p3_cost_feasibility",
+        "p3_o1": o1,
+        "extrapolation": extrapolations,
+        "o1_viable_guide_r_across_all_grid_points": sorted(viable_r),
+        "o5_candidate_summary": exact_candidates,
+        "correctness_gate": correctness_gate,
+        "promoted_candidates": promoted,
+        "p4_decision": decision,
+        "decision_reason": (
+            "at least one candidate passes exact integrand and measured "
+            "L=16 cost/RSS gates" if promoted else
+            "no candidate passes both exact integrand and conservative "
+            "L=16 cost/RSS gates; redesign cache/workspace/API before P4"
+        ),
+        "p3_o3_api": (
+            "promote_testing_value_cache_contract" if promoted else
+            "not_fixed_reference_workspace_requires_redesign"
+        ),
+    })
+
+    l4_cost = summaries["L4_qp1_rank1"]["median_depth_seconds_per_root"]
+    for case in integrands["cases"].values():
+        for guide in case["guides"].values():
+            full_cost = sum(l4_cost)
+            for entry in guide["entries"].values():
+                moment = entry["normalized_second_moment"]
+                entry["hpc_second_moment_efficiency_per_second"] = (
+                    1.0 / (moment * full_cost)
+                    if moment > 0.0 and full_cost > 0.0 else None)
+    integrands["hpc_cost_basis"] = {
+        "group": "L4_qp1_rank1",
+        "median_full_seconds_per_root": sum(l4_cost),
+    }
+    integrands["compiler"] = args.compiler
+    integrands["mpi"] = args.mpi
+    integrands["blas"] = args.blas
+    integrands["generated_at_jst"] = generated_at_jst()
+
+    write_json(os.path.join(args.output, "p3_resource_statistics.json"),
+               resources)
+    write_json(os.path.join(args.output, "p3_cost_feasibility.json"), cost)
+    write_json(args.integrand_statistics, integrands)
+    print("profile evidence complete: P4 {}".format(decision))
+
+
+def anchor_command(args):
+    fixture_hash = sha256_file(args.fixture_manifest)
+    policy_hash = sha256_file(args.policy)
+    policy = validate_policy_contract(read_json(args.policy))
+    if fixture_hash != policy["fixture_manifest_sha256"]:
+        raise AssertionError("anchor policy fixture hash does not match")
+    pattern = re.compile(
+        r"P3 production action anchor passed: 4 cases, "
+        r"([0-9]+) sampled rows, ([0-9]+) case-local distinct states"
+    )
+    if len(args.anchor_log) != len(args.anchor_rank_count):
+        raise AssertionError("anchor log/rank-count cardinality mismatch")
+    if sorted(args.anchor_rank_count) != [1, 2]:
+        raise AssertionError("production anchor requires rank counts 1 and 2")
+    runs = []
+    for path, rank_count in zip(args.anchor_log, args.anchor_rank_count):
+        with open(path, "r") as handle:
+            text = handle.read()
+        match = pattern.search(text)
+        if match is None:
+            raise AssertionError("anchor PASS summary missing: {}".format(path))
+        rows = int(match.group(1))
+        states = int(match.group(2))
+        if rows != 16384 * rank_count or states != 70:
+            raise AssertionError("anchor coverage count mismatch")
+        runs.append({
+            "file": None,
+            "source_path": os.path.abspath(path),
+            "sha256": sha256_file(path),
+            "case_count": 4,
+            "rank_count": rank_count,
+            "sampled_rows": rows,
+            "sampled_rows_per_rank": rows // rank_count,
+            "case_local_distinct_states": states,
+            "status": "PASS",
+        })
+    raw_anchor_files = materialize_raw_files(
+        [run["source_path"] for run in runs], args.output, "raw_anchor")
+    for run in runs:
+        run["file"] = raw_anchor_files[run.pop("source_path")]
+    metadata = common_metadata(args, fixture_hash)
+    metadata["measurement_policy_sha256"] = policy_hash
+    artifact = dict(metadata)
+    artifact.update({
+        "artifact": "p3_production_anchor",
+        "comparison": (
+            "production F_k versus absolute-reference v_k/v_0 on exact "
+            "nonzero support"
+        ),
+        "runs": runs,
+        "all_runs_pass": True,
+    })
+    write_json(os.path.join(args.output, "p3_production_anchor.json"),
+               artifact)
+    print("production action anchor evidence complete")
+
+
+def copy_if_distinct(source, destination):
+    if os.path.abspath(source) != os.path.abspath(destination):
+        shutil.copyfile(source, destination)
+
+
+def validate_commit_object(repository, commit):
+    if re.match(r"^[0-9a-f]{40}$", commit or "") is None:
+        raise AssertionError("commit provenance must be a full lowercase SHA")
+    process = subprocess.run(
+        ["git", "-C", repository, "rev-parse", "--verify",
+         commit + "^{commit}"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, check=False,
+    )
+    if process.returncode != 0 or process.stdout.strip() != commit:
+        raise AssertionError("commit provenance is not a repository commit")
+
+
+def validate_referenced_raw(output, records, expected_count, label):
+    if len(records) != expected_count:
+        raise AssertionError("{} raw evidence count mismatch".format(label))
+    names = [record.get("file") for record in records]
+    if len(names) != len(set(names)) or any(not name for name in names):
+        raise AssertionError("{} raw evidence names are invalid".format(label))
+    output_real = os.path.realpath(output)
+    for record, relative in zip(records, names):
+        if os.path.isabs(relative):
+            raise AssertionError("raw evidence path must be relative")
+        path = os.path.realpath(os.path.join(output_real, relative))
+        if (os.path.commonpath([output_real, path]) != output_real or
+                not os.path.isfile(path) or os.path.islink(path) or
+                sha256_file(path) != record.get("sha256")):
+            raise AssertionError(
+                "{} raw evidence is missing or changed: {}".format(
+                    label, relative))
+
+
+def finalize_command(args):
+    required_artifacts = {
+        "p3_reference_results.json": "p3_reference_results",
+        "p3_model_manifest.json": "p3_model_manifest",
+        "p3_resource_statistics.json": "p3_resource_statistics",
+        "p3_cost_feasibility.json": "p3_cost_feasibility",
+        "p3_exact_oracle.json": "p3_exact_oracle",
+        "p3_production_anchor.json": "p3_production_anchor",
+        "p3_integrand_statistics.json": "p3_integrand_statistics",
+    }
+    output = os.path.abspath(args.output)
+    if not os.path.isdir(output):
+        raise AssertionError("evidence output directory is missing")
+    validate_commit_object(args.repository, args.source_commit)
+    validate_commit_object(args.repository, args.baseline_commit)
+    if (not os.path.isfile(args.build_config) or
+            os.path.getsize(args.build_config) == 0 or
+            not os.path.isfile(args.review) or
+            os.path.getsize(args.review) == 0):
+        raise AssertionError("build config and review must be nonempty files")
+    fixture_hashes = set()
+    policy_hashes = set()
+    for filename, artifact_name in sorted(required_artifacts.items()):
+        path = os.path.join(output, filename)
+        artifact = read_json(path)
+        if (artifact.get("schema_version") != SCHEMA_VERSION or
+                artifact.get("artifact") != artifact_name or
+                artifact.get("source_commit") != args.source_commit or
+                artifact.get("baseline_develop_commit") !=
+                args.baseline_commit or
+                not artifact.get("compiler") or
+                not artifact.get("mpi") or
+                not artifact.get("blas") or
+                int(artifact.get("omp_threads", 0)) != 1 or
+                int(artifact.get("blas_threads", 0)) != 1 or
+                not artifact.get("strict_fp")):
+            raise AssertionError(
+                "final evidence metadata mismatch: {}".format(filename))
+        fixture_hashes.add(artifact.get("fixture_sha256"))
+        policy_hashes.add(artifact.get("measurement_policy_sha256"))
+    if len(fixture_hashes) != 1 or None in fixture_hashes or \
+            len(policy_hashes) != 1 or None in policy_hashes:
+        raise AssertionError("final evidence provenance hashes disagree")
+    reference = read_json(os.path.join(output, "p3_reference_results.json"))
+    anchor = read_json(os.path.join(output, "p3_production_anchor.json"))
+    cost = read_json(os.path.join(output, "p3_cost_feasibility.json"))
+    resources = read_json(
+        os.path.join(output, "p3_resource_statistics.json"))
+    policy = read_json(os.path.join(output, "p3_model_manifest.json"))[
+        "measurement_policy"]
+    grid = policy["official_scaling_grid"]
+    expected_profile_logs = (
+        len(grid["site_counts"]) * len(grid["qp_total"]) *
+        len(grid["mpi_rank_counts"]) * int(grid["repeat_count"]))
+    validate_referenced_raw(
+        output, resources.get("raw_logs", []), expected_profile_logs,
+        "profile")
+    validate_referenced_raw(output, anchor.get("runs", []), 2, "anchor")
+    if (not reference.get("deterministic_correctness_gate_pass", False) or
+            not anchor.get("all_runs_pass", False) or
+            not cost.get("correctness_gate", {}).get("all_pass", False) or
+            cost.get("p4_decision") not in ("GO", "STOP")):
+        raise AssertionError("final correctness/decision gate is incomplete")
+    copy_if_distinct(args.build_config,
+                     os.path.join(output, "build_config.txt"))
+    copy_if_distinct(args.review, os.path.join(output, "review.md"))
+    if (os.path.getsize(os.path.join(output, "build_config.txt")) == 0 or
+            os.path.getsize(os.path.join(output, "review.md")) == 0):
+        raise AssertionError("materialized build config/review is empty")
+    with open(os.path.join(output, "source_commit.txt"), "w") as handle:
+        handle.write(args.source_commit + "\n")
+    with open(os.path.join(output, "baseline_develop_commit.txt"), "w") as handle:
+        handle.write(args.baseline_commit + "\n")
+    checksum_path = os.path.join(output, "checksums.sha256")
+    entries = []
+    for root, directories, files in os.walk(output):
+        directories.sort()
+        for filename in sorted(files):
+            path = os.path.join(root, filename)
+            if os.path.abspath(path) == checksum_path:
+                continue
+            if os.path.islink(path):
+                raise AssertionError("symlink is not allowed in evidence ledger")
+            relative = os.path.relpath(path, output)
+            entries.append((relative, sha256_file(path)))
+    with open(checksum_path, "w") as handle:
+        for relative, digest in sorted(entries):
+            handle.write("{}  {}\n".format(digest, relative))
+    print("finalized P3 evidence ledger: {} files".format(len(entries)))
+
+
+def add_common_arguments(parser):
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--baseline-commit", required=True)
+    parser.add_argument("--compiler", required=True)
+    parser.add_argument("--mpi", required=True)
+    parser.add_argument("--blas", required=True)
+    parser.add_argument("--strict-fp", required=True)
+    parser.add_argument("--omp-threads", type=int, default=1)
+    parser.add_argument("--blas-threads", type=int, default=1)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    exact = subparsers.add_parser("exact")
+    add_common_arguments(exact)
+    exact.add_argument("--ed-driver", required=True)
+    exact.add_argument("--correctness-script", required=True)
+    exact.add_argument("--fixture-manifest", required=True)
+    exact.add_argument("--policy", required=True)
+    exact.add_argument("--output", required=True)
+    exact.set_defaults(function=exact_command)
+
+    profile = subparsers.add_parser("profiles")
+    add_common_arguments(profile)
+    profile.add_argument("--policy", required=True)
+    profile.add_argument("--model-manifest", required=True)
+    profile.add_argument("--integrand-statistics", required=True)
+    profile.add_argument("--reference-results", required=True)
+    profile.add_argument("--production-anchor", required=True)
+    profile.add_argument("--profile-log", action="append", required=True)
+    profile.add_argument("--output", required=True)
+    profile.set_defaults(function=profile_command)
+
+    anchor = subparsers.add_parser("anchor")
+    add_common_arguments(anchor)
+    anchor.add_argument("--fixture-manifest", required=True)
+    anchor.add_argument("--policy", required=True)
+    anchor.add_argument("--anchor-log", action="append", required=True)
+    anchor.add_argument("--anchor-rank-count", action="append", type=int,
+                        required=True)
+    anchor.add_argument("--output", required=True)
+    anchor.set_defaults(function=anchor_command)
+
+    finalize = subparsers.add_parser("finalize")
+    finalize.add_argument("--source-commit", required=True)
+    finalize.add_argument("--baseline-commit", required=True)
+    finalize.add_argument("--repository", required=True)
+    finalize.add_argument("--build-config", required=True)
+    finalize.add_argument("--review", required=True)
+    finalize.add_argument("--output", required=True)
+    finalize.set_defaults(function=finalize_command)
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    if not hasattr(args, "function"):
+        parser.error("a subcommand is required")
+    args.function(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/runtest_absolute_krylov_classic_ed.py
+++ b/test/python/runtest_absolute_krylov_classic_ed.py
@@ -1,0 +1,394 @@
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+import sys
+
+import numpy as np
+
+
+SITE_COUNT = 4
+ORBITAL_COUNT = 2 * SITE_COUNT
+GUTZWILLER_PARAMETER = -0.27
+BONDS = ((0, 1), (1, 2), (2, 3), (3, 0))
+INTRA = (0.25, -0.125, 0.375, -0.3125)
+INTER = ((0, 2, 0.1875), (1, 3, -0.15625))
+ELECTRONIC_HUND = ((0, 1, 0.21875), (2, 3, -0.09375))
+SPIN_HUND = (0.375, -0.25, 0.1875, -0.125)
+SPIN_EXCHANGE = (0.625, -0.3125, 0.4375, -0.5625)
+
+
+def popcount(value):
+    return bin(value).count("1")
+
+
+def fixed_basis(pure_spin):
+    basis = []
+    for up_mask in range(1 << SITE_COUNT):
+        if popcount(up_mask) != 2:
+            continue
+        for down_mask in range(1 << SITE_COUNT):
+            if popcount(down_mask) != 2:
+                continue
+            if pure_spin and down_mask != ((~up_mask) & 0x0f):
+                continue
+            basis.append(up_mask | (down_mask << SITE_COUNT))
+    return basis
+
+
+def apply_operators(state, operators):
+    sign = 1
+    updated = state
+    for kind, orbital in reversed(operators):
+        occupied = (updated >> orbital) & 1
+        parity = popcount(updated & ((1 << orbital) - 1))
+        if kind == "annihilate":
+            if not occupied:
+                return None
+            if parity & 1:
+                sign = -sign
+            updated &= ~(1 << orbital)
+        else:
+            if occupied:
+                return None
+            if parity & 1:
+                sign = -sign
+            updated |= 1 << orbital
+    return updated, sign
+
+
+def density_term(first, second, coefficient):
+    return coefficient, (
+        ("create", first), ("annihilate", first),
+        ("create", second), ("annihilate", second),
+    )
+
+
+def electronic_terms(complex_case):
+    terms = []
+    for bond_index, (left, right) in enumerate(BONDS):
+        hopping = 0.75
+        if complex_case:
+            hopping += 1.0j * (0.125 + 0.0625 * bond_index)
+        for spin in (0, 1):
+            left_orbital = left + spin * SITE_COUNT
+            right_orbital = right + spin * SITE_COUNT
+            terms.append((
+                -hopping,
+                (("create", left_orbital),
+                 ("annihilate", right_orbital)),
+            ))
+            terms.append((
+                -np.conj(hopping),
+                (("create", right_orbital),
+                 ("annihilate", left_orbital)),
+            ))
+    terms.append((
+        -0.4375,
+        (("create", 1), ("annihilate", 1)),
+    ))
+    for site, coefficient in enumerate(INTRA):
+        terms.append(density_term(
+            site, site + SITE_COUNT, coefficient
+        ))
+    for first, second, coefficient in INTER:
+        for first_spin in (0, 1):
+            for second_spin in (0, 1):
+                terms.append(density_term(
+                    first + first_spin * SITE_COUNT,
+                    second + second_spin * SITE_COUNT,
+                    coefficient,
+                ))
+    for first, second, coefficient in ELECTRONIC_HUND:
+        for spin in (0, 1):
+            terms.append(density_term(
+                first + spin * SITE_COUNT,
+                second + spin * SITE_COUNT,
+                -coefficient,
+            ))
+    return terms
+
+
+def spin_terms():
+    terms = []
+    for bond_index, (first, second) in enumerate(BONDS):
+        for spin in (0, 1):
+            terms.append(density_term(
+                first + spin * SITE_COUNT,
+                second + spin * SITE_COUNT,
+                -SPIN_HUND[bond_index],
+            ))
+        up_first = first
+        up_second = second
+        down_first = first + SITE_COUNT
+        down_second = second + SITE_COUNT
+        terms.append((
+            SPIN_EXCHANGE[bond_index],
+            (("create", up_first), ("annihilate", up_second),
+             ("create", down_second), ("annihilate", down_first)),
+        ))
+        terms.append((
+            SPIN_EXCHANGE[bond_index],
+            (("create", up_second), ("annihilate", up_first),
+             ("create", down_first), ("annihilate", down_second)),
+        ))
+    return terms
+
+
+def dense_hamiltonian(basis, terms):
+    state_index = {state: index for index, state in enumerate(basis)}
+    matrix = np.zeros((len(basis), len(basis)), dtype=complex)
+    for column, state in enumerate(basis):
+        for coefficient, operators in terms:
+            applied = apply_operators(state, operators)
+            if applied is None:
+                continue
+            destination, sign = applied
+            if destination not in state_index:
+                raise AssertionError(
+                    "term escaped the fixed sector: {} -> {}".format(
+                        state, destination
+                    )
+                )
+            matrix[state_index[destination], column] += sign * coefficient
+    residual = np.max(np.abs(matrix - np.conj(matrix.T)))
+    if residual > 2.0e-13:
+        raise AssertionError(
+            "independent Hamiltonian is not Hermitian: {:.3e}".format(
+                residual
+            )
+        )
+    return matrix
+
+
+def pair_matrix(complex_case):
+    if complex_case:
+        pairs = np.array([
+            [2.0 + 1.0j, 1.0 + 1.5j, 0.5 - 0.5j, 0.5 - 1.5j],
+            [-2.0 - 1.0j, -1.0 - 1.5j, -0.5 + 0.5j, -0.5 + 1.5j],
+            [0.5 + 1.0j, 0.5 + 2.0j, -0.5 - 2.0j, -0.5 - 1.5j],
+            [1.5 + 1.5j, 0.5 + 0.5j, 1.5 - 1.5j, 1.5 + 1.5j],
+        ], dtype=complex)
+        return pairs
+    return np.array([
+        [1.5, -0.5, 1.5, 1.0],
+        [-1.5, 0.5, -1.5, -1.0],
+        [-0.5, 1.5, 1.5, 2.0],
+        [-2.0, -2.0, -1.0, 0.5],
+    ], dtype=complex)
+
+
+def pfaffian(matrix):
+    size = matrix.shape[0]
+    if size == 0:
+        return 1.0 + 0.0j
+    value = 0.0 + 0.0j
+    for column in range(1, size):
+        keep = [index for index in range(1, size) if index != column]
+        minor = matrix[np.ix_(keep, keep)]
+        sign = 1.0 if column % 2 == 1 else -1.0
+        value += sign * matrix[0, column] * pfaffian(minor)
+    return value
+
+
+def amplitude(state, complex_case, pure_spin):
+    up_sites = [
+        site for site in range(SITE_COUNT) if (state >> site) & 1
+    ]
+    down_sites = [
+        site for site in range(SITE_COUNT)
+        if (state >> (site + SITE_COUNT)) & 1
+    ]
+    pairs = pair_matrix(complex_case)
+    matrix = np.zeros((4, 4), dtype=complex)
+    for up_index, up_site in enumerate(up_sites):
+        for down_index, down_site in enumerate(down_sites):
+            value = pairs[up_site, down_site]
+            matrix[up_index, 2 + down_index] = value
+            matrix[2 + down_index, up_index] = -value
+    value = pfaffian(matrix)
+    if not pure_spin:
+        doublons = sum(
+            ((state >> site) & 1)
+            and ((state >> (site + SITE_COUNT)) & 1)
+            for site in range(SITE_COUNT)
+        )
+        value *= np.exp(GUTZWILLER_PARAMETER * doublons)
+    return value
+
+
+def independent_reference(name):
+    pure_spin = name.startswith("spin_")
+    complex_case = name.endswith("_complex")
+    basis = fixed_basis(pure_spin)
+    terms = spin_terms() if pure_spin else electronic_terms(complex_case)
+    hamiltonian = dense_hamiltonian(basis, terms)
+    powers = [np.array([
+        amplitude(state, complex_case, pure_spin) for state in basis
+    ], dtype=complex)]
+    for _ in range(3):
+        powers.append(np.dot(hamiltonian, powers[-1]))
+    zero_indices = [
+        index for index, value in enumerate(powers[0])
+        if abs(value) <= 2.0e-14
+    ]
+    if not zero_indices:
+        raise AssertionError("{} has no exact zero-support state".format(name))
+    if not any(
+            max(abs(powers[order][index]) for order in range(1, 4))
+            > 1.0e-8 for index in zero_indices):
+        raise AssertionError(
+            "{} has no zero-support bridge into H^k psi".format(name)
+        )
+    return {
+        state: np.array([powers[order][index] for order in range(4)])
+        for index, state in enumerate(basis)
+    }
+
+
+def parse_driver_output(output):
+    cases = {}
+    metadata = {}
+    active = None
+    for line in output.splitlines():
+        columns = line.split()
+        if not columns:
+            continue
+        if columns[0] == "BEGIN":
+            active = columns[1]
+            cases[active] = {}
+            metadata[active] = {
+                "rank_count": int(columns[3]),
+                "empty_qp_ranks": int(columns[5]),
+            }
+        elif columns[0] == "ROW":
+            if active is None or len(columns) != 10:
+                raise AssertionError("malformed ROW: {}".format(line))
+            values = np.array([
+                float(columns[2 + 2 * order])
+                + 1.0j * float(columns[3 + 2 * order])
+                for order in range(4)
+            ])
+            assert_finite_power("driver ROW", values)
+            cases[active][int(columns[1])] = values
+        elif columns[0] == "END":
+            if active != columns[1]:
+                raise AssertionError("mismatched END: {}".format(line))
+            active = None
+    if active is not None:
+        raise AssertionError("driver output ended inside {}".format(active))
+    return cases, metadata
+
+
+def assert_finite_power(label, values):
+    if not np.all(np.isfinite(np.asarray(values, dtype=complex))):
+        raise AssertionError("{} contains NaN or Inf: {}".format(label, values))
+
+
+def check_nonfinite_guard():
+    for value in (np.nan + 0.0j, np.inf + 0.0j, 0.0 + np.inf * 1.0j):
+        try:
+            assert_finite_power("negative-control", np.array([value]))
+        except AssertionError:
+            continue
+        raise AssertionError("nonfinite comparison guard accepted {}".format(value))
+
+
+def driver_command(driver):
+    mpi_procs = int(os.environ.get("MVMC_MPI_PROCS", "1"))
+    if mpi_procs == 1:
+        return [driver], mpi_procs
+    mpiexec = os.environ.get("MVMC_MPIEXEC") or shutil.which("mpiexec")
+    if not mpiexec:
+        raise AssertionError("MVMC_MPIEXEC/mpiexec is unavailable")
+    numproc_flag = os.environ.get("MVMC_MPIEXEC_NUMPROC_FLAG", "-np")
+    return [mpiexec, numproc_flag, str(mpi_procs), driver], mpi_procs
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise AssertionError("usage: runtest_absolute_krylov_classic_ed.py DRIVER")
+    check_nonfinite_guard()
+    command, expected_ranks = driver_command(sys.argv[1])
+    process = subprocess.run(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, check=False,
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "absolute Krylov classic driver failed:\n{}".format(
+                process.stdout
+            )
+        )
+    cases, metadata = parse_driver_output(process.stdout)
+    expected_cases = (
+        "electronic_real", "electronic_complex", "spin_real", "spin_complex"
+    )
+    if set(cases) != set(expected_cases):
+        raise AssertionError("driver cases mismatch: {}".format(sorted(cases)))
+    if expected_ranks > 1:
+        serial = subprocess.run(
+            [sys.argv[1]], stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            universal_newlines=True, check=False,
+        )
+        if serial.returncode != 0:
+            raise AssertionError(
+                "serial rank-invariance reference failed:\n{}".format(
+                    serial.stdout
+                )
+            )
+        serial_cases, _ = parse_driver_output(serial.stdout)
+        for name in expected_cases:
+            if set(serial_cases[name]) != set(cases[name]):
+                raise AssertionError("{} MPI/serial basis drift".format(name))
+            for state in cases[name]:
+                if not np.array_equal(
+                        cases[name][state], serial_cases[name][state]):
+                    raise AssertionError(
+                        "{} state={} is not bitwise rank invariant".format(
+                            name, state
+                        )
+                    )
+    for name in expected_cases:
+        reference = independent_reference(name)
+        if set(cases[name]) != set(reference):
+            raise AssertionError("{} basis mismatch".format(name))
+        if metadata[name]["rank_count"] != expected_ranks:
+            raise AssertionError("{} rank-count mismatch".format(name))
+        expected_empty = max(0, expected_ranks - 1)
+        if metadata[name]["empty_qp_ranks"] != expected_empty:
+            raise AssertionError("{} empty-QP audit mismatch".format(name))
+        for state, expected in reference.items():
+            actual = cases[name][state]
+            assert_finite_power("{} state={} expected".format(name, state),
+                                expected)
+            error = np.max(np.abs(actual - expected))
+            scale = max(1.0, float(np.max(np.abs(expected))))
+            absolute_tolerance = 2.0e-13 if name.endswith("_real") else 2.0e-12
+            relative_tolerance = 2.0e-12 if name.endswith("_real") else 2.0e-11
+            allowed = absolute_tolerance + relative_tolerance * scale
+            if error > allowed:
+                raise AssertionError(
+                    "{} state={} mismatch: error={:.3e} allowed={:.3e}\n"
+                    "actual={}\nexpected={}".format(
+                        name, state, error, allowed, actual, expected
+                    )
+                )
+        if name.endswith("_real"):
+            imaginary = max(
+                float(np.max(np.abs(values.imag)))
+                for values in cases[name].values()
+            )
+            if imaginary > 2.0e-12:
+                raise AssertionError(
+                    "{} unexpectedly complex: {:.3e}".format(name, imaginary)
+                )
+    print(
+        "absolute Krylov classic ED passed: 4 families, ranks={}, "
+        "orders=0..3, zero-support bridges verified".format(expected_ranks)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/runtest_absolute_krylov_p3_evidence.py
+++ b/test/python/runtest_absolute_krylov_p3_evidence.py
@@ -1,0 +1,89 @@
+from __future__ import print_function
+
+import math
+import copy
+import sys
+
+import generate_absolute_krylov_p3_evidence as evidence
+
+
+def close(actual, expected, tolerance=1.0e-13):
+    return abs(actual - expected) <= tolerance * (1.0 + abs(expected))
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise AssertionError(
+            "usage: runtest_absolute_krylov_p3_evidence.py POLICY"
+        )
+    policy = evidence.read_json(sys.argv[1])
+    evidence.validate_policy_contract(policy)
+    bad_policy = copy.deepcopy(policy)
+    bad_policy["official_scaling_grid"]["sample_count_by_site"].pop("8")
+    try:
+        evidence.validate_policy_contract(bad_policy)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("incomplete policy contract was accepted")
+    rows = [
+        {"configuration": 1,
+         "values": [1.0 + 0.0j, 1.0 + 0.0j,
+                    1.0 + 1.0j, 2.0 - 1.0j]},
+        {"configuration": 2,
+         "values": [1.0 + 0.0j, -1.0 + 0.0j,
+                    2.0 - 1.0j, -2.0 + 1.0j]},
+    ]
+    result = evidence.exact_case_statistics(rows, policy)
+    if result["sector_size"] != 2 or len(result["guides"]) != 12:
+        raise AssertionError("unexpected exact evidence dimensions")
+    scales = result["krylov_scales"]
+    scaled = [[scales[index] * row["values"][index]
+               for index in evidence.ORDERS] for row in rows]
+    independent_k00 = sum(row[0].conjugate() * row[1] for row in scaled)
+    encoded_k00 = result["matrices_unnormalized"]["K"][0][0]
+    if not close(complex(*encoded_k00), independent_k00):
+        raise AssertionError("K_00 index convention mismatch")
+    independent_b22 = sum(row[3].conjugate() * row[3] for row in scaled)
+    encoded_b22 = result["matrices_unnormalized"]["B"][2][2]
+    if not close(complex(*encoded_b22), independent_b22):
+        raise AssertionError("B_22 index convention mismatch")
+    for guide in result["guides"].values():
+        if not guide["strict_positive_support"]:
+            raise AssertionError("positive floor did not close support")
+        if not (0.0 < guide["t_ess_fraction"] <= 1.0 + 1.0e-13):
+            raise AssertionError("invalid T-ESS fraction")
+        for entry in guide["entries"].values():
+            if (entry["normalized_complex_variance"] < 0.0 or
+                    entry["absolute_standard_error_at_4096"] < 0.0):
+                raise AssertionError("invalid integrand variance/SE")
+    fit = evidence.log_linear_fit(
+        [(4, math.exp(0.4)), (6, math.exp(0.6)),
+         (8, math.exp(0.8))], 16)
+    if not close(fit["prediction"], math.exp(1.6), 1.0e-12):
+        raise AssertionError("log-linear extrapolation mismatch")
+    zero = evidence.extrapolate_nonnegative([(4, 0), (6, 0), (8, 0)], 16)
+    if zero["prediction"] != 0.0 or zero["model"] != "structural_zero":
+        raise AssertionError("structural zero extrapolation mismatch")
+    if evidence.parse_number("fixture-id") != "fixture-id":
+        raise AssertionError("profile string parser mismatch")
+    malformed = []
+    for case in (
+            "electronic_real", "electronic_complex", "spin_real",
+            "spin_complex"):
+        malformed.extend([
+            "BEGIN {} rank_count 1 empty_qp_ranks 0".format(case),
+            "ROW 0 1 0 2 0 3 0 4 0",
+            "END {}".format(case),
+        ])
+    try:
+        evidence.parse_ed_output("\n".join(malformed) + "\n")
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("incomplete exact sector was accepted")
+    print("absolute Krylov P3 evidence math: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/runtest_absolute_krylov_p3_pipeline.py
+++ b/test/python/runtest_absolute_krylov_p3_pipeline.py
@@ -1,0 +1,292 @@
+from __future__ import print_function
+
+import argparse
+import copy
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import generate_absolute_krylov_p3_evidence as evidence
+
+
+def expect_failure(function, label):
+    try:
+        function()
+    except AssertionError:
+        return
+    raise AssertionError("negative gate was accepted: {}".format(label))
+
+
+def git_head(repository):
+    process = subprocess.run(
+        ["git", "-C", repository, "rev-parse", "HEAD"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, check=False,
+    )
+    if process.returncode != 0:
+        raise AssertionError("cannot resolve test repository HEAD")
+    return process.stdout.strip()
+
+
+def metadata(commit, fixture_hash, policy_hash):
+    return {
+        "schema_version": evidence.SCHEMA_VERSION,
+        "generated_at_jst": evidence.generated_at_jst(),
+        "source_commit": commit,
+        "baseline_develop_commit": commit,
+        "compiler": "synthetic-compiler",
+        "mpi": "synthetic-mpi",
+        "blas": "synthetic-blas",
+        "strict_fp": "enabled",
+        "omp_threads": 1,
+        "blas_threads": 1,
+        "fixture_sha256": fixture_hash,
+        "measurement_policy_sha256": policy_hash,
+    }
+
+
+def write_profile(path, site, qp, ranks, sample_count):
+    sector_size = evidence.fixed_sector_size(site)
+    scale = 1.0e-6 * (2.0 ** (site / 2.0))
+    global_factorizations = sample_count * qp
+    with open(path, "w") as handle:
+        handle.write(
+            "PROFILE schema=1 fixture={} site_count={} qp_total={} "
+            "sample_count={} sector_size={} rank_count={} audit=1\n".format(
+                evidence.EXPECTED_PROFILE_FIXTURE, site, qp, sample_count,
+                sector_size, ranks))
+        for sample, sector_index, configuration in \
+                evidence.expected_profile_rows(site, sample_count):
+            handle.write(
+                "ROW {} {} {} 1 0 2 0 3 0 4 0\n".format(
+                    sample, sector_index, configuration))
+        for scope in ("rank_sum", "rank_max"):
+            multiplier = ranks if scope == "rank_sum" else 1
+            roots = sample_count * multiplier
+            elapsed = sample_count * scale * multiplier
+            handle.write(
+                "RESOURCE scope={} roots={} recursion=1,1,1,1 "
+                "unique=1,1,1,1 memo_hits=1,1,1,1 "
+                "memo_misses=1,1,1,1 raw_transitions={} "
+                "merged_duplicates=0 cancelled_zero=0 "
+                "terminal_requests={} terminal_cache_hits=1 "
+                "regular_logical={} near_pivot_logical=0 "
+                "singular_logical=0 total_zero_logical=0 "
+                "local_factorizations={} "
+                "global_factorizations_logical={} frontier_peak=1 "
+                "memo_peak=1 krylov_workspace_bytes={} "
+                "model_workspace_bytes=1024 amplitude_workspace_bytes=1024 "
+                "rss_bytes={} depth_seconds={},{},{},{} "
+                "amplitude_seconds={} connectivity_seconds={} "
+                "total_seconds={}\n".format(
+                    scope, roots, roots, roots, global_factorizations,
+                    global_factorizations, global_factorizations,
+                    1024 * (2 ** site), 2048 * (2 ** site), elapsed,
+                    elapsed, elapsed, elapsed, elapsed, elapsed, elapsed))
+
+
+def profile_args(output, policy_path, logs, commit):
+    return argparse.Namespace(
+        source_commit=commit, baseline_commit=commit,
+        compiler="synthetic-compiler", mpi="synthetic-mpi",
+        blas="synthetic-blas", strict_fp="enabled", omp_threads=1,
+        blas_threads=1, policy=policy_path,
+        model_manifest=os.path.join(output, "p3_model_manifest.json"),
+        integrand_statistics=os.path.join(
+            output, "p3_integrand_statistics.json"),
+        reference_results=os.path.join(output, "p3_reference_results.json"),
+        production_anchor=os.path.join(
+            output, "p3_production_anchor.json"),
+        profile_log=logs, output=output,
+    )
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise AssertionError(
+            "usage: runtest_absolute_krylov_p3_pipeline.py POLICY REPOSITORY")
+    policy_path = os.path.abspath(sys.argv[1])
+    repository = os.path.abspath(sys.argv[2])
+    policy = evidence.validate_policy_contract(evidence.read_json(policy_path))
+    policy_hash = evidence.sha256_file(policy_path)
+    fixture_hash = "f" * 64
+    commit = git_head(repository)
+    root = tempfile.mkdtemp(prefix="absolute-krylov-p3-pipeline-")
+    try:
+        output = os.path.join(root, "evidence")
+        inputs = os.path.join(root, "inputs")
+        os.makedirs(output)
+        os.makedirs(inputs)
+        base = metadata(commit, fixture_hash, policy_hash)
+        model = dict(base)
+        model.update({
+            "artifact": "p3_model_manifest",
+            "measurement_policy": policy,
+        })
+        reference = dict(base)
+        reference.update({
+            "artifact": "p3_reference_results",
+            "deterministic_correctness_gate_pass": True,
+            "deterministic_correctness_gate": {
+                "status": "PASS", "script_sha256": "1" * 64,
+                "stdout_sha256": "2" * 64,
+            },
+        })
+        oracle = dict(base)
+        oracle.update({"artifact": "p3_exact_oracle"})
+        integrands = dict(base)
+        integrands.update({
+            "artifact": "p3_integrand_statistics",
+            "candidate_summary": {
+                "r0_rho_1e-06": {
+                    "r": 0, "rho": 1.0e-6,
+                    "p3_exact_feasibility_gate_pass": True,
+                },
+            },
+            "cases": {
+                "electronic_real": {
+                    "guides": {
+                        "r0_rho_1e-06": {
+                            "entries": {
+                                "S_00": {"normalized_second_moment": 1.0},
+                            },
+                        },
+                    },
+                },
+            },
+        })
+        anchor_directory = os.path.join(output, "raw_anchor")
+        os.makedirs(anchor_directory)
+        anchor_runs = []
+        for ranks in (1, 2):
+            relative = os.path.join(
+                "raw_anchor", "anchor_rank{}.log".format(ranks))
+            path = os.path.join(output, relative)
+            with open(path, "w") as handle:
+                handle.write("synthetic production anchor rank {} PASS\n".format(
+                    ranks))
+            anchor_runs.append({
+                "file": relative, "sha256": evidence.sha256_file(path),
+                "rank_count": ranks, "status": "PASS",
+            })
+        anchor = dict(base)
+        anchor.update({
+            "artifact": "p3_production_anchor", "all_runs_pass": True,
+            "runs": anchor_runs,
+        })
+        for filename, value in (
+                ("p3_model_manifest.json", model),
+                ("p3_reference_results.json", reference),
+                ("p3_exact_oracle.json", oracle),
+                ("p3_integrand_statistics.json", integrands),
+                ("p3_production_anchor.json", anchor)):
+            evidence.write_json(os.path.join(output, filename), value)
+
+        logs = []
+        grid = policy["official_scaling_grid"]
+        for site in grid["site_counts"]:
+            requested = grid["sample_count_by_site"][str(site)]
+            sample_count = (evidence.fixed_sector_size(site)
+                            if requested == 0 else requested)
+            for qp in grid["qp_total"]:
+                for ranks in grid["mpi_rank_counts"]:
+                    for repeat in range(grid["repeat_count"]):
+                        path = os.path.join(
+                            inputs,
+                            "profile_L{}_qp{}_rank{}_rep{}.log".format(
+                                site, qp, ranks, repeat))
+                        write_profile(path, site, qp, ranks, sample_count)
+                        logs.append(path)
+
+        parsed = evidence.parse_profile_log(logs[0])
+        invalid_roots = copy.deepcopy(parsed)
+        invalid_roots["resources"]["rank_max"]["roots"] += 1
+        expect_failure(
+            lambda: evidence.validate_profile_run(invalid_roots, policy),
+            "root-count invariant")
+        invalid_schedule = copy.deepcopy(parsed)
+        invalid_schedule["rows"][0] = invalid_schedule["rows"][1]
+        expect_failure(
+            lambda: evidence.validate_profile_run(invalid_schedule, policy),
+            "sample schedule")
+
+        arguments = profile_args(output, policy_path, logs, commit)
+        evidence.profile_command(arguments)
+        cost = evidence.read_json(
+            os.path.join(output, "p3_cost_feasibility.json"))
+        if (cost["p4_decision"] != "GO" or
+                not cost["correctness_gate"]["all_pass"]):
+            raise AssertionError("synthetic command-level AND gate did not GO")
+
+        bad_reference = copy.deepcopy(reference)
+        bad_reference["deterministic_correctness_gate_pass"] = False
+        bad_reference_path = os.path.join(root, "bad_reference.json")
+        evidence.write_json(bad_reference_path, bad_reference)
+        bad_arguments = copy.copy(arguments)
+        bad_arguments.reference_results = bad_reference_path
+        expect_failure(lambda: evidence.profile_command(bad_arguments),
+                       "deterministic correctness AND gate")
+
+        bad_anchor = copy.deepcopy(anchor)
+        bad_anchor["all_runs_pass"] = False
+        bad_anchor_path = os.path.join(root, "bad_anchor.json")
+        evidence.write_json(bad_anchor_path, bad_anchor)
+        bad_arguments = copy.copy(arguments)
+        bad_arguments.production_anchor = bad_anchor_path
+        expect_failure(lambda: evidence.profile_command(bad_arguments),
+                       "production anchor AND gate")
+
+        changed_log = os.path.join(root, "changed_rank_trace.log")
+        shutil.copyfile(logs[7], changed_log)
+        with open(changed_log, "r") as handle:
+            changed = handle.read()
+        changed = changed.replace(" 1 0 2 0 3 0 4 0\n",
+                                  " 1 0 2 0 3 0 5 0\n", 1)
+        with open(changed_log, "w") as handle:
+            handle.write(changed)
+        bad_arguments = copy.copy(arguments)
+        bad_arguments.profile_log = list(logs)
+        bad_arguments.profile_log[7] = changed_log
+        expect_failure(lambda: evidence.profile_command(bad_arguments),
+                       "cross-rank trace invariance")
+
+        build_config = os.path.join(root, "build_config.txt")
+        review = os.path.join(root, "review.md")
+        with open(build_config, "w") as handle:
+            handle.write("synthetic build configuration\n")
+        with open(review, "w") as handle:
+            handle.write("synthetic review\n")
+        finalize = argparse.Namespace(
+            source_commit=commit, baseline_commit=commit,
+            repository=repository, build_config=build_config,
+            review=review, output=output,
+        )
+        invalid_commit = copy.copy(finalize)
+        invalid_commit.source_commit = "WORKTREE"
+        expect_failure(lambda: evidence.finalize_command(invalid_commit),
+                       "noncommit provenance")
+        missing = os.path.join(output, anchor_runs[0]["file"])
+        held = missing + ".held"
+        os.rename(missing, held)
+        expect_failure(lambda: evidence.finalize_command(finalize),
+                       "missing raw anchor")
+        os.rename(held, missing)
+        evidence.finalize_command(finalize)
+        checksum_path = os.path.join(output, "checksums.sha256")
+        with open(checksum_path, "r") as handle:
+            checksum_lines = [line.rstrip("\n") for line in handle]
+        if len(checksum_lines) < len(logs) + len(anchor_runs):
+            raise AssertionError("raw evidence is absent from checksum ledger")
+        for line in checksum_lines:
+            digest, relative = line.split("  ", 1)
+            if evidence.sha256_file(os.path.join(output, relative)) != digest:
+                raise AssertionError("final checksum ledger mismatch")
+        print("absolute Krylov P3 command pipeline: PASS")
+    finally:
+        shutil.rmtree(root)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/runtest_absolute_krylov_production_anchor.py
+++ b/test/python/runtest_absolute_krylov_production_anchor.py
@@ -1,0 +1,433 @@
+from __future__ import print_function
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import numpy as np
+
+from runtest_absolute_krylov_classic_ed import (
+    BONDS,
+    ELECTRONIC_HUND,
+    GUTZWILLER_PARAMETER,
+    INTER,
+    INTRA,
+    SITE_COUNT,
+    SPIN_EXCHANGE,
+    SPIN_HUND,
+    assert_finite_power,
+    driver_command,
+    pair_matrix,
+    parse_driver_output,
+)
+from runtest_bf_fsz import run_vmc, update_modpara
+from runtest_lanczos2_real_ed import (
+    assert_scaled_close,
+    occupation_state,
+    read_ls2_oracle,
+)
+
+
+def write_site_definition(workdir, filename, count_name, values):
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("{}          {}\n".format(count_name, len(values)))
+        destination.write("=============================================\n")
+        destination.write("============ i coupling =====================\n")
+        destination.write("=============================================\n")
+        for site, coefficient in enumerate(values):
+            destination.write(
+                "{:5d} {:25.15f}\n".format(site, coefficient)
+            )
+
+
+def write_bond_definition(workdir, filename, count_name, rows):
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("{}          {}\n".format(count_name, len(rows)))
+        destination.write("=============================================\n")
+        destination.write("============ i j coupling ===================\n")
+        destination.write("=============================================\n")
+        for first, second, coefficient in rows:
+            destination.write(
+                "{:5d} {:5d} {:25.15f}\n".format(
+                    first, second, coefficient
+                )
+            )
+
+
+def write_transfer(workdir, complex_case):
+    rows = []
+    for bond_index, (left, right) in enumerate(BONDS):
+        hopping = 0.75
+        if complex_case:
+            hopping += 1.0j * (0.125 + 0.0625 * bond_index)
+        for spin in (0, 1):
+            rows.append((left, spin, right, spin, hopping.real, hopping.imag))
+            reverse = np.conj(hopping)
+            rows.append((right, spin, left, spin,
+                         reverse.real, reverse.imag))
+    rows.append((1, 0, 1, 0, 0.4375, 0.0))
+    with open(os.path.join(workdir, "trans.def"), "w") as destination:
+        destination.write("========================\n")
+        destination.write("NTransfer      {}\n".format(len(rows)))
+        destination.write("========================\n")
+        destination.write("========i_j_s_tijs======\n")
+        destination.write("========================\n")
+        for row in rows:
+            destination.write(
+                "{:5d} {:5d} {:5d} {:5d} {:25.15f} {:25.15f}\n".format(
+                    *row
+                )
+            )
+
+
+def write_zero_transfer(workdir):
+    with open(os.path.join(workdir, "trans.def"), "w") as destination:
+        destination.write("========================\n")
+        destination.write("NTransfer       0\n")
+        destination.write("========================\n")
+        destination.write("========i_j_s_tijs======\n")
+        destination.write("========================\n")
+
+
+def write_locspin(workdir, pure_spin):
+    with open(os.path.join(workdir, "locspn.def"), "w") as destination:
+        destination.write("================================\n")
+        destination.write("NlocalSpin     {}\n".format(
+            SITE_COUNT if pure_spin else 0
+        ))
+        destination.write("================================\n")
+        destination.write("========i_1LocSpn_0IteElc ======\n")
+        destination.write("================================\n")
+        for site in range(SITE_COUNT):
+            destination.write(
+                "{:5d} {:5d}\n".format(site, 1 if pure_spin else 0)
+            )
+
+
+def write_gutzwiller(workdir):
+    with open(os.path.join(workdir, "gutzwilleridx.def"), "w") as destination:
+        destination.write("=============================================\n")
+        destination.write("NGutzwillerIdx          1\n")
+        destination.write("ComplexType             0\n")
+        destination.write("=============================================\n")
+        destination.write("=============================================\n")
+        for site in range(SITE_COUNT):
+            destination.write("{:5d} {:5d}\n".format(site, 0))
+        destination.write("{:5d} {:5d}\n".format(0, 0))
+
+
+def write_namelist(workdir, pure_spin):
+    entries = [
+        ("ModPara", "modpara.def"),
+        ("LocSpin", "locspn.def"),
+        ("Trans", "trans.def"),
+    ]
+    if pure_spin:
+        entries.extend([
+            ("Hund", "hund.def"),
+            ("Exchange", "exchange.def"),
+        ])
+    else:
+        entries.extend([
+            ("CoulombIntra", "coulombintra.def"),
+            ("CoulombInter", "coulombinter.def"),
+            ("Hund", "hund.def"),
+            ("Gutzwiller", "gutzwilleridx.def"),
+        ])
+    entries.extend([
+        ("Orbital", "orbitalidx.def"),
+        ("TransSym", "qptransidx.def"),
+    ])
+    with open(os.path.join(workdir, "namelist.def"), "w") as destination:
+        for keyword, filename in entries:
+            destination.write("{:>16}  {}\n".format(keyword, filename))
+
+
+def write_initial(workdir, complex_case, pure_spin):
+    values = [0.0] * 6
+    if not pure_spin:
+        values.extend([GUTZWILLER_PARAMETER, 0.0, 0.0])
+    for value in pair_matrix(complex_case).reshape(SITE_COUNT * SITE_COUNT):
+        values.extend([value.real, value.imag, 0.0])
+    filename = "p3_anchor_{}_{}.dat".format(
+        "spin" if pure_spin else "electronic",
+        "complex" if complex_case else "real",
+    )
+    with open(os.path.join(workdir, filename), "w") as destination:
+        destination.write(
+            " ".join("{:.18e}".format(value) for value in values)
+        )
+        destination.write("\n")
+    return filename
+
+
+def prepare_case(rootdir, name):
+    pure_spin = name.startswith("spin_")
+    complex_case = name.endswith("_complex")
+    reference_name = (
+        "BackFlow_Identity_Complex"
+        if complex_case else "BackFlow_Identity_Real"
+    )
+    reference_dir = os.path.join(rootdir, "data", reference_name)
+    suffix = "_mpi" if os.environ.get("MVMC_MPI_PROCS") else ""
+    workdir = os.path.join(rootdir, "work", "P3ProductionAnchor_" + name + suffix)
+    if os.path.exists(workdir):
+        shutil.rmtree(workdir)
+    os.makedirs(workdir)
+    for filename in ("modpara.def", "orbitalidx.def", "qptransidx.def"):
+        shutil.copy2(
+            os.path.join(reference_dir, filename),
+            os.path.join(workdir, filename),
+        )
+    write_locspin(workdir, pure_spin)
+    if pure_spin:
+        write_zero_transfer(workdir)
+        write_bond_definition(
+            workdir, "hund.def", "NHund",
+            tuple((left, right, SPIN_HUND[index])
+                  for index, (left, right) in enumerate(BONDS)),
+        )
+        write_bond_definition(
+            workdir, "exchange.def", "NExchange",
+            tuple((left, right, SPIN_EXCHANGE[index])
+                  for index, (left, right) in enumerate(BONDS)),
+        )
+    else:
+        write_transfer(workdir, complex_case)
+        write_site_definition(
+            workdir, "coulombintra.def", "NCoulombIntra", INTRA
+        )
+        write_bond_definition(
+            workdir, "coulombinter.def", "NCoulombInter", INTER
+        )
+        write_bond_definition(
+            workdir, "hund.def", "NHund", ELECTRONIC_HUND
+        )
+        write_gutzwiller(workdir)
+    write_namelist(workdir, pure_spin)
+    update_modpara(
+        workdir,
+        {
+            "NLanczosMode": "1",
+            "NLanczosStep": "2",
+            "NLanczosSupportMode": "1",
+            "NVMCCalMode": "1",
+            "NVMCSample": "4096",
+            "NVMCWarmUp": "64",
+            "NVMCInterval": "1",
+            "Ncond": "0" if pure_spin else "4",
+            "2Sz": "0",
+            "NMPTrans": "1",
+            "NExUpdatePath": "2" if pure_spin else "0",
+            "NSplitSize": "1",
+        },
+    )
+    return workdir, write_initial(workdir, complex_case, pure_spin)
+
+
+def collect_rows(workdir, dump_name):
+    mpi_procs = os.environ.get("MVMC_MPI_PROCS")
+    if not mpi_procs:
+        return read_ls2_oracle(os.path.join(workdir, dump_name))
+    rows = []
+    for rank in range(int(mpi_procs)):
+        rows.extend(read_ls2_oracle(os.path.join(
+            workdir, dump_name + ".rank{:04d}".format(rank)
+        )))
+    return rows
+
+
+def run_reference_driver(driver):
+    command, _ = driver_command(driver)
+    process = subprocess.run(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        universal_newlines=True, check=False,
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "P3 reference driver failed:\n{}".format(process.stdout)
+        )
+    return parse_driver_output(process.stdout)[0]
+
+
+def validate_manifest(rootdir):
+    path = os.path.join(rootdir, "data", "absolute_krylov_p3_manifest.json")
+    with open(path) as source:
+        manifest = json.load(source)
+    if manifest.get("schema_version") != 1:
+        raise AssertionError("P3 fixture manifest schema mismatch")
+    if manifest.get("fixture_id") != "absolute-krylov-p3-l4-v1" or \
+            manifest.get("site_count") != SITE_COUNT or \
+            manifest.get("orders") != [0, 1, 2, 3]:
+        raise AssertionError("P3 fixture manifest core metadata mismatch")
+    expected_amplitude = {
+        "qp_total": 1,
+        "electronic_projection": "GUTZWILLER_ONLY",
+        "spin_projection": "NONE",
+        "gutzwiller_parameter": GUTZWILLER_PARAMETER,
+        "zero_support_bridge_required": True,
+    }
+    if manifest.get("amplitude") != expected_amplitude:
+        raise AssertionError("P3 fixture amplitude metadata mismatch")
+    expected_cases = [
+        {
+            "name": "electronic_real", "scalar": "real",
+            "term_families": [
+                "Transfer", "DiagonalTransfer", "CoulombIntra",
+                "CoulombInter", "Hund",
+            ],
+        },
+        {
+            "name": "electronic_complex", "scalar": "complex",
+            "term_families": [
+                "Transfer", "DiagonalTransfer", "CoulombIntra",
+                "CoulombInter", "Hund",
+            ],
+        },
+        {
+            "name": "spin_real", "scalar": "real",
+            "term_families": ["Hund", "Exchange"],
+        },
+        {
+            "name": "spin_complex", "scalar": "complex",
+            "term_families": ["Hund", "Exchange"],
+        },
+    ]
+    if manifest.get("cases") != expected_cases:
+        raise AssertionError("P3 fixture per-case coverage metadata mismatch")
+    required = {
+        "Transfer", "DiagonalTransfer", "CoulombIntra", "CoulombInter",
+        "Hund", "Exchange",
+    }
+    observed = set()
+    for case in manifest.get("cases", []):
+        observed.update(case.get("term_families", []))
+    if observed != required:
+        raise AssertionError(
+            "P3 manifest term coverage mismatch: {}".format(sorted(observed))
+        )
+    if manifest.get("pilot_scan") != {
+            "lambda": [1.0, 1.0, 1.0, 1.0],
+            "rho": [1e-06, 0.0001, 0.01]}:
+        raise AssertionError("P3-O2 pilot scan is not frozen in manifest")
+    parameters = manifest.get("model_parameters", {})
+    electronic = parameters.get("electronic", {})
+    spin = parameters.get("spin", {})
+    expected_parameters = {
+        "ring_bonds": [list(bond) for bond in BONDS],
+        "electronic": {
+            "transfer_real": 0.75,
+            "transfer_imaginary_by_bond": [
+                0.125 + 0.0625 * index for index in range(len(BONDS))
+            ],
+            "diagonal_transfer": [1, 0, 0.4375],
+            "coulomb_intra": list(INTRA),
+            "coulomb_inter": [list(row) for row in INTER],
+            "hund": [list(row) for row in ELECTRONIC_HUND],
+        },
+        "spin": {
+            "hund_by_bond": list(SPIN_HUND),
+            "exchange_by_bond": list(SPIN_EXCHANGE),
+        },
+    }
+    if parameters != expected_parameters or not electronic or not spin:
+        raise AssertionError("P3 fixture model parameters drifted from manifest")
+    pair_data = manifest.get("pair_matrix", {})
+    manifest_real = np.array(pair_data.get("real", []), dtype=complex)
+    manifest_complex = np.array(
+        pair_data.get("complex_real", []), dtype=float
+    ) + 1.0j * np.array(
+        pair_data.get("complex_imaginary", []), dtype=float
+    )
+    if not np.array_equal(manifest_real, pair_matrix(False)) or \
+            not np.array_equal(manifest_complex, pair_matrix(True)):
+        raise AssertionError("P3 fixture pair matrix drifted from manifest")
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise AssertionError(
+            "usage: runtest_absolute_krylov_production_anchor.py DRIVER"
+        )
+    rootdir = os.getcwd()
+    validate_manifest(rootdir)
+    p3_results = run_reference_driver(sys.argv[1])
+    cases = (
+        "electronic_real", "electronic_complex", "spin_real", "spin_complex"
+    )
+    total_rows = 0
+    total_states = 0
+    for name in cases:
+        complex_case = name.endswith("_complex")
+        support = {
+            state for state, absolute in p3_results[name].items()
+            if abs(absolute[0]) > 2.0e-13
+        }
+        workdir, initial = prepare_case(rootdir, name)
+        dump_name = "p3_production_anchor_{}.dat".format(name)
+        process = run_vmc(
+            rootdir, workdir,
+            mpi_procs=os.environ.get("MVMC_MPI_PROCS"),
+            init_path=initial,
+            extra_env={"MVMC_LANCZOS_ORACLE_DUMP": dump_name},
+        )
+        if process.returncode != 0:
+            raise AssertionError(
+                "{} production run failed:\n{}".format(name, process.stdout)
+            )
+        rows = collect_rows(workdir, dump_name)
+        seen = set()
+        for sample, occupation, production_power in rows:
+            state = occupation_state(occupation)
+            if state not in p3_results[name]:
+                raise AssertionError(
+                    "{} sample {} state {} is outside P3 basis".format(
+                        name, sample, state
+                    )
+                )
+            absolute = p3_results[name][state]
+            if abs(absolute[0]) <= 2.0e-13:
+                raise AssertionError(
+                    "{} production sampled zero-support state {}".format(
+                        name, state
+                    )
+                )
+            expected = absolute / absolute[0]
+            if complex_case:
+                expected = np.conj(expected)
+            assert_finite_power(
+                "{} sample {} production".format(name, sample),
+                production_power,
+            )
+            assert_finite_power(
+                "{} sample {} expected".format(name, sample), expected
+            )
+            for order in range(4):
+                assert_scaled_close(
+                    "{} sample {} F{}".format(name, sample, order),
+                    production_power[order], expected[order],
+                    3.0e-10, 3.0e-9,
+                )
+            seen.add(state)
+        if seen != support:
+            raise AssertionError(
+                "{} production anchor did not enumerate nonzero support: "
+                "seen={}/{} missing={} extra={}".format(
+                    name, len(seen), len(support),
+                    sorted(support - seen), sorted(seen - support)
+                )
+            )
+        total_rows += len(rows)
+        total_states += len(seen)
+    print(
+        "P3 production action anchor passed: 4 cases, {} sampled rows, "
+        "{} case-local distinct states".format(total_rows, total_states)
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/python/runtest_absolute_krylov_profile.py
+++ b/test/python/runtest_absolute_krylov_profile.py
@@ -1,0 +1,126 @@
+from __future__ import print_function
+
+import math
+import os
+import shutil
+import subprocess
+import sys
+
+
+def command(driver, audit):
+    mpi_procs = int(os.environ.get("MVMC_MPI_PROCS", "1"))
+    arguments = [driver, "4", "1", "6", str(audit)]
+    if mpi_procs == 1:
+        return arguments
+    mpiexec = os.environ.get("MVMC_MPIEXEC") or shutil.which("mpiexec")
+    if not mpiexec:
+        raise AssertionError("MVMC_MPIEXEC/mpiexec is unavailable")
+    flag = os.environ.get("MVMC_MPIEXEC_NUMPROC_FLAG", "-np")
+    return [mpiexec, flag, str(mpi_procs)] + arguments
+
+
+def run(driver, audit):
+    process = subprocess.run(
+        command(driver, audit),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        check=False,
+    )
+    if process.returncode != 0:
+        raise AssertionError(
+            "profile driver audit={} failed:\n{}".format(
+                audit, process.stdout
+            )
+        )
+    return process.stdout.splitlines()
+
+
+def parse_key_values(line):
+    fields = {}
+    for token in line.split()[1:]:
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        fields[key] = value
+    return fields
+
+
+def validate_resource(line):
+    fields = parse_key_values(line)
+    required = (
+        "scope", "roots", "recursion", "unique", "memo_hits",
+        "memo_misses", "raw_transitions", "terminal_requests",
+        "regular_logical", "near_pivot_logical", "singular_logical",
+        "total_zero_logical", "local_factorizations",
+        "global_factorizations_logical", "frontier_peak", "memo_peak",
+        "krylov_workspace_bytes", "model_workspace_bytes",
+        "amplitude_workspace_bytes", "rss_bytes", "depth_seconds",
+        "amplitude_seconds", "connectivity_seconds", "total_seconds",
+    )
+    missing = [key for key in required if key not in fields]
+    if missing:
+        raise AssertionError("resource fields missing: {}".format(missing))
+    if fields["scope"] not in ("rank_sum", "rank_max"):
+        raise AssertionError("unexpected resource scope")
+    for key in (
+        "roots", "raw_transitions", "terminal_requests",
+        "global_factorizations_logical", "frontier_peak", "memo_peak",
+        "krylov_workspace_bytes", "model_workspace_bytes",
+        "amplitude_workspace_bytes", "rss_bytes",
+    ):
+        if int(fields[key]) <= 0:
+            raise AssertionError("nonpositive resource {}".format(key))
+    for key in (
+        "amplitude_seconds", "connectivity_seconds", "total_seconds",
+    ):
+        value = float(fields[key])
+        if not math.isfinite(value) or value < 0.0:
+            raise AssertionError("invalid timing {}".format(key))
+    depth = [float(value) for value in fields["depth_seconds"].split(",")]
+    if len(depth) != 4 or any(
+            not math.isfinite(value) or value < 0.0 for value in depth):
+        raise AssertionError("invalid depth timings")
+    if (float(fields["total_seconds"]) <= 0.0 or sum(depth) <= 0.0 or
+            float(fields["amplitude_seconds"]) +
+            float(fields["connectivity_seconds"]) <= 0.0):
+        raise AssertionError("profile hook recorded no measurable work")
+    return fields
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise AssertionError("usage: runtest_absolute_krylov_profile.py DRIVER")
+    without_audit = run(sys.argv[1], 0)
+    with_audit = run(sys.argv[1], 1)
+    rows_without = [line for line in without_audit if line.startswith("ROW ")]
+    rows_with = [line for line in with_audit if line.startswith("ROW ")]
+    if rows_without != rows_with or len(rows_with) != 6:
+        raise AssertionError("audit changed deterministic configuration/value trace")
+    if any(line.startswith(("STAT ", "RESOURCE ")) for line in without_audit):
+        raise AssertionError("audit-off run leaked profile records")
+    stats = [line for line in with_audit if line.startswith("STAT ")]
+    resources = [line for line in with_audit if line.startswith("RESOURCE ")]
+    if len(stats) != 6 or len(resources) != 2:
+        raise AssertionError("incomplete audit records")
+    parsed = {
+        fields["scope"]: fields
+        for fields in (validate_resource(line) for line in resources)
+    }
+    logical = (
+        "regular_logical", "near_pivot_logical", "singular_logical",
+        "total_zero_logical", "global_factorizations_logical",
+    )
+    for key in logical:
+        if int(parsed["rank_sum"][key]) != int(parsed["rank_max"][key]):
+            raise AssertionError(
+                "communicator-global counter was rank-multiplied: {}".format(
+                    key))
+    if (int(parsed["rank_sum"]["local_factorizations"]) !=
+            int(parsed["rank_sum"]["global_factorizations_logical"])):
+        raise AssertionError("local factorization work count is inconsistent")
+    print("absolute Krylov profile audit parity: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a Testing-only canonical-Fock reference evaluator for absolute Krylov amplitudes `v_0` through `v_3`, including configurations where the base amplitude is zero
- add value-only Pfaffian, classic amplitude/model adapters, independent ED checks, and production-action anchors
- add MPI/OMP profiling and a machine-readable feasibility pipeline with a frozen policy for the one-dimensional periodic `Nsite=4/6/8` fixtures
- close the two independent-review build-portability findings by initializing `merged_count` and restricting the MPI-only `index` declaration

## Motivation

The ratio-based Lanczos path cannot recover contributions from configurations outside the support of the base state. This change provides a correctness reference that crosses zero support and a measured gate for deciding whether that reference architecture can be promoted to the next implementation phase.

## Feasibility result

P3 is complete, but promotion of the current workspace/API to P4 is stopped. The full `r=3` guide is the only candidate that satisfies the exact integrand-error gate, while the current allocated-capacity model extrapolates to approximately 803–813 GiB per rank at `Nsite=16`, above the 4 GiB per-rank limit for every tested configuration.

The 803–813 GiB value is an allocated-capacity extrapolation, not measured RSS or a physical lower bound. P4 should resume only after a bounded streaming/cache workspace is designed and measured under the same policy.

## Validation

- full CTest: 449/449 PASS
- independent focused suite: 32/32 PASS, including MPI rank 2/4 variants
- ASan/UBSan focused suite: 28/28 PASS
- Testing=OFF symbol-isolation check: PASS
- Linux/HPC focused suite: 8/8 PASS with 126 profile runs collected
- M-1/M-2 follow-up: non-MPI strict-warning targets PASS, non-MPI focused 14/14 PASS, normal MPI focused 27/27 PASS
- independent all-diff review: High 0, must-fix 0; M-1/M-2 closed, M-3 through M-7 retained as P4 redesign gates