### PR TITLE
Add bounded power-Lanczos evaluation engine

### DIFF
--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -35,7 +35,8 @@ if(Testing)
   target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION
       MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
       MVMC_ENABLE_PFAFFIAN_STATE_AUDIT
-      MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE)
+      MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE
+      MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
 endif(Testing)
 target_link_libraries(vmc.out StdFace_mvmc m)
 target_link_libraries(vmc.out pfapack)

--- a/src/mVMC/CMakeLists.txt
+++ b/src/mVMC/CMakeLists.txt
@@ -31,7 +31,8 @@ if(Testing)
   # Keep fault injection, reference samplers, and audits out of production.
   target_sources(vmc.out PRIVATE classic_pfaffian_sampler.c
       classic_pfaffian_audit.c krylov_fock_reference.c
-      classic_krylov_amplitude.c classic_krylov_model.c)
+      classic_krylov_amplitude.c classic_krylov_model.c
+      bounded_krylov_engine.c bounded_krylov_collective.c)
   target_compile_definitions(vmc.out PRIVATE MVMC_ENABLE_FAULT_INJECTION
       MVMC_ENABLE_PFAFFIAN_SAMPLER_REFERENCE
       MVMC_ENABLE_PFAFFIAN_STATE_AUDIT

--- a/src/mVMC/absolute_pfaffian.c
+++ b/src/mVMC/absolute_pfaffian.c
@@ -1350,7 +1350,7 @@ static int decompose_finite_complex(
   return valid_unit_phase(*phase) && isfinite(*log_abs);
 }
 
-static int valid_scaled_complex(const MVMCScaledComplex *value) {
+int mvmc_scaled_complex_is_valid(const MVMCScaledComplex *value) {
   if (value == NULL) return 0;
   switch (value->state) {
     case MVMC_SCALED_COMPLEX_FINITE_NONZERO:
@@ -1486,8 +1486,8 @@ MVMCPfaffianStatus mvmc_scaled_complex_multiply(
   double error_bound = -INFINITY;
   double output_log_abs;
   double max_input;
-  if (result == NULL || !valid_scaled_complex(left) ||
-      !valid_scaled_complex(right)) {
+  if (result == NULL || !mvmc_scaled_complex_is_valid(left) ||
+      !mvmc_scaled_complex_is_valid(right)) {
     return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   }
   if (left->state == MVMC_SCALED_COMPLEX_NONFINITE ||
@@ -1605,7 +1605,7 @@ MVMCPfaffianStatus mvmc_scaled_complex_sum_ordered(
     return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
   }
   for (index = 0; index < value_count; ++index) {
-    if (!valid_scaled_complex(values + index)) {
+    if (!mvmc_scaled_complex_is_valid(values + index)) {
       return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
     }
     if (values[index].state == MVMC_SCALED_COMPLEX_NONFINITE) {
@@ -1695,7 +1695,7 @@ MVMCScaledComplexExportStatus mvmc_scaled_complex_export_common_scale(
     double complex *result) {
   double delta;
   double magnitude;
-  if (result == NULL || !valid_scaled_complex(value) ||
+  if (result == NULL || !mvmc_scaled_complex_is_valid(value) ||
       !isfinite(common_log_scale)) {
     return MVMC_SCALED_EXPORT_INVALID;
   }
@@ -2045,7 +2045,7 @@ MVMCPfaffianStatus mvmc_projected_scaled_amplitude_values(
   for (index = 0; index < component_count; ++index) {
     MVMCScaledComplex scaled_weight;
     if (!finite_complex(weights[index]) ||
-        !valid_scaled_complex(&components[index].value)) {
+        !mvmc_scaled_complex_is_valid(&components[index].value)) {
       free(terms);
       return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
     }

--- a/src/mVMC/absolute_pfaffian.c
+++ b/src/mVMC/absolute_pfaffian.c
@@ -1263,6 +1263,897 @@ MVMCPfaffianStatus mvmc_projected_amplitude_value_slice(
       local_component_count, result);
 }
 
+#if defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+static int finite_complex(double complex value) {
+  return isfinite(creal(value)) && isfinite(cimag(value));
+}
+
+static int negative_infinity(double value) {
+  return isinf(value) && value < 0.0;
+}
+
+static double log_add_bounds(double left, double right) {
+  double maximum;
+  if (negative_infinity(left)) return right;
+  if (negative_infinity(right)) return left;
+  if (!isfinite(left) || !isfinite(right)) return INFINITY;
+  maximum = fmax(left, right);
+  return maximum + log1p(exp(fmin(left, right) - maximum));
+}
+
+static MVMCScaledComplex scaled_nonfinite(void) {
+  MVMCScaledComplex value;
+  value.state = MVMC_SCALED_COMPLEX_NONFINITE;
+  value.phase = NAN + I * NAN;
+  value.log_abs = NAN;
+  value.log_abs_error_bound = NAN;
+  value.max_input_log_abs = NAN;
+  value.cancellation_log_abs = NAN;
+  value.cancellation_ratio = NAN;
+  return value;
+}
+
+static MVMCScaledComplex scaled_exact_zero(void) {
+  MVMCScaledComplex value;
+  value.state = MVMC_SCALED_COMPLEX_EXACT_ZERO;
+  value.phase = 1.0;
+  value.log_abs = -INFINITY;
+  value.log_abs_error_bound = -INFINITY;
+  value.max_input_log_abs = -INFINITY;
+  value.cancellation_log_abs = -INFINITY;
+  value.cancellation_ratio = 0.0;
+  return value;
+}
+
+static MVMCScaledComplex scaled_numeric_zero(
+    double log_abs_error_bound, double max_input_log_abs,
+    double cancellation_log_abs, double cancellation_ratio) {
+  MVMCScaledComplex value;
+  value.state = MVMC_SCALED_COMPLEX_NUMERIC_ZERO;
+  value.phase = 1.0;
+  value.log_abs = -INFINITY;
+  value.log_abs_error_bound = log_abs_error_bound;
+  value.max_input_log_abs = max_input_log_abs;
+  value.cancellation_log_abs = cancellation_log_abs;
+  value.cancellation_ratio = cancellation_ratio;
+  return value;
+}
+
+static int valid_error_log(double value) {
+  return isfinite(value) || negative_infinity(value);
+}
+
+static int valid_unit_phase(double complex phase) {
+  double magnitude;
+  if (!finite_complex(phase)) return 0;
+  magnitude = cabs(phase);
+  return isfinite(magnitude) && magnitude > 0.0 &&
+         fabs(magnitude - 1.0) <= 32.0 * DBL_EPSILON;
+}
+
+static int decompose_finite_complex(
+    double complex value, double complex *phase, double *log_abs) {
+  const double real_abs = fabs(creal(value));
+  const double imag_abs = fabs(cimag(value));
+  const double scale = fmax(real_abs, imag_abs);
+  double complex scaled;
+  double scaled_abs;
+  if (phase == NULL || log_abs == NULL || !finite_complex(value) ||
+      scale == 0.0 || !isfinite(scale)) {
+    return 0;
+  }
+  scaled = (creal(value) / scale) + I * (cimag(value) / scale);
+  scaled_abs = hypot(creal(scaled), cimag(scaled));
+  if (!isfinite(scaled_abs) || scaled_abs == 0.0) return 0;
+  *phase = scaled / scaled_abs;
+  *log_abs = log(scale) + log(scaled_abs);
+  return valid_unit_phase(*phase) && isfinite(*log_abs);
+}
+
+static int valid_scaled_complex(const MVMCScaledComplex *value) {
+  if (value == NULL) return 0;
+  switch (value->state) {
+    case MVMC_SCALED_COMPLEX_FINITE_NONZERO:
+      return valid_unit_phase(value->phase) &&
+             isfinite(value->log_abs) &&
+             valid_error_log(value->log_abs_error_bound) &&
+             (negative_infinity(value->log_abs_error_bound) ||
+              value->log_abs_error_bound < value->log_abs) &&
+             isfinite(value->max_input_log_abs) &&
+             isfinite(value->cancellation_log_abs) &&
+             isfinite(value->cancellation_ratio) &&
+             value->cancellation_ratio >= 0.0 &&
+             value->cancellation_ratio <= 1.0;
+    case MVMC_SCALED_COMPLEX_EXACT_ZERO:
+      return valid_unit_phase(value->phase) &&
+             negative_infinity(value->log_abs) &&
+             negative_infinity(value->log_abs_error_bound) &&
+             negative_infinity(value->max_input_log_abs) &&
+             negative_infinity(value->cancellation_log_abs) &&
+             value->cancellation_ratio == 0.0;
+    case MVMC_SCALED_COMPLEX_NUMERIC_ZERO:
+      return valid_unit_phase(value->phase) &&
+             negative_infinity(value->log_abs) &&
+             isfinite(value->log_abs_error_bound) &&
+             valid_error_log(value->max_input_log_abs) &&
+             valid_error_log(value->cancellation_log_abs) &&
+             isfinite(value->cancellation_ratio) &&
+             value->cancellation_ratio >= 0.0 &&
+             value->cancellation_ratio <= 1.0;
+    case MVMC_SCALED_COMPLEX_NONFINITE:
+      return 1;
+  }
+  return 0;
+}
+
+static double phase_rounding_error_log(double log_abs) {
+  const double relative_bound = 32.0 * DBL_EPSILON;
+  return log_abs + log(relative_bound);
+}
+
+static int normalize_phase(double complex phase, double complex *normalized) {
+  double ignored_log_abs;
+  return decompose_finite_complex(phase, normalized, &ignored_log_abs);
+}
+
+MVMCPfaffianStatus mvmc_scaled_complex_make_finite(
+    double complex phase, double log_abs, double log_abs_error_bound,
+    MVMCScaledComplex *result) {
+  MVMCScaledComplex candidate;
+  double complex normalized;
+  if (result == NULL || !isfinite(log_abs) ||
+      !valid_error_log(log_abs_error_bound)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (!normalize_phase(phase, &normalized)) {
+    candidate = scaled_nonfinite();
+    *result = candidate;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (isfinite(log_abs_error_bound) &&
+      log_abs <= log_abs_error_bound) {
+    candidate = scaled_numeric_zero(log_abs_error_bound, log_abs, log_abs,
+                                    1.0);
+  } else {
+    candidate.state = MVMC_SCALED_COMPLEX_FINITE_NONZERO;
+    candidate.phase = normalized;
+    candidate.log_abs = log_abs;
+    candidate.log_abs_error_bound = log_abs_error_bound;
+    candidate.max_input_log_abs = log_abs;
+    candidate.cancellation_log_abs = log_abs;
+    candidate.cancellation_ratio = 1.0;
+  }
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_scaled_complex_make_exact_zero(
+    MVMCScaledComplex *result) {
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  *result = scaled_exact_zero();
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_scaled_complex_make_numeric_zero(
+    double log_abs_error_bound, double max_input_log_abs,
+    double cancellation_log_abs, double cancellation_ratio,
+    MVMCScaledComplex *result) {
+  if (result == NULL || !isfinite(log_abs_error_bound) ||
+      !valid_error_log(max_input_log_abs) ||
+      !valid_error_log(cancellation_log_abs) ||
+      !isfinite(cancellation_ratio) || cancellation_ratio < 0.0 ||
+      cancellation_ratio > 1.0) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  *result = scaled_numeric_zero(log_abs_error_bound, max_input_log_abs,
+                                cancellation_log_abs, cancellation_ratio);
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_scaled_complex_from_raw_testing(
+    double complex value, MVMCScaledComplex *result) {
+  MVMCScaledComplex candidate;
+  double complex phase;
+  double log_abs;
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  if (!finite_complex(value)) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (creal(value) == 0.0 && cimag(value) == 0.0) {
+    /* A raw zero has lost its producer scale, so its error is unknown. */
+    *result = scaled_numeric_zero(log(DBL_MAX), -INFINITY, -INFINITY,
+                                  0.0);
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (!decompose_finite_complex(value, &phase, &log_abs)) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (mvmc_scaled_complex_make_finite(phase, log_abs, -INFINITY,
+                                      &candidate) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_scaled_complex_multiply(
+    const MVMCScaledComplex *left, const MVMCScaledComplex *right,
+    MVMCScaledComplex *result) {
+  MVMCScaledComplex candidate;
+  double error_bound = -INFINITY;
+  double output_log_abs;
+  double max_input;
+  if (result == NULL || !valid_scaled_complex(left) ||
+      !valid_scaled_complex(right)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (left->state == MVMC_SCALED_COMPLEX_NONFINITE ||
+      right->state == MVMC_SCALED_COMPLEX_NONFINITE) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (left->state == MVMC_SCALED_COMPLEX_EXACT_ZERO ||
+      right->state == MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+    *result = scaled_exact_zero();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (left->state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO ||
+      right->state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+    if (left->state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+        right->state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+      error_bound = left->log_abs_error_bound +
+                    right->log_abs_error_bound;
+    } else if (left->state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+      error_bound = left->log_abs_error_bound + right->log_abs;
+      if (isfinite(right->log_abs_error_bound)) {
+        error_bound = log_add_bounds(
+            error_bound, left->log_abs_error_bound +
+                             right->log_abs_error_bound);
+      }
+    } else {
+      error_bound = right->log_abs_error_bound + left->log_abs;
+      if (isfinite(left->log_abs_error_bound)) {
+        error_bound = log_add_bounds(
+            error_bound, right->log_abs_error_bound +
+                             left->log_abs_error_bound);
+      }
+    }
+    if (!isfinite(error_bound)) {
+      *result = scaled_nonfinite();
+      return MVMC_PFAFFIAN_STATUS_OK;
+    }
+    max_input = fmax(left->max_input_log_abs, right->max_input_log_abs);
+    *result = scaled_numeric_zero(error_bound, max_input, -INFINITY, 0.0);
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+
+  output_log_abs = left->log_abs + right->log_abs;
+  if (!isfinite(output_log_abs)) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (isfinite(left->log_abs_error_bound)) {
+    error_bound = log_add_bounds(
+        error_bound, left->log_abs_error_bound + right->log_abs);
+  }
+  if (isfinite(right->log_abs_error_bound)) {
+    error_bound = log_add_bounds(
+        error_bound, right->log_abs_error_bound + left->log_abs);
+  }
+  if (isfinite(left->log_abs_error_bound) &&
+      isfinite(right->log_abs_error_bound)) {
+    error_bound = log_add_bounds(
+        error_bound, left->log_abs_error_bound +
+                         right->log_abs_error_bound);
+  }
+  error_bound = log_add_bounds(error_bound,
+                               phase_rounding_error_log(output_log_abs));
+  if (!isfinite(error_bound)) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (mvmc_scaled_complex_make_finite(
+          left->phase * right->phase, output_log_abs, error_bound,
+          &candidate) != MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  candidate.max_input_log_abs =
+      fmax(left->max_input_log_abs, right->max_input_log_abs);
+  candidate.cancellation_log_abs = output_log_abs;
+  candidate.cancellation_ratio = 1.0;
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static int neumaier_add(double value, double *sum, double *compensation) {
+  double updated;
+  if (sum == NULL || compensation == NULL || !isfinite(value)) return 0;
+  updated = *sum + value;
+  if (!isfinite(updated)) return 0;
+  if (fabs(*sum) >= fabs(value)) {
+    *compensation += (*sum - updated) + value;
+  } else {
+    *compensation += (value - updated) + *sum;
+  }
+  if (!isfinite(*compensation)) return 0;
+  *sum = updated;
+  return 1;
+}
+
+MVMCPfaffianStatus mvmc_scaled_complex_sum_ordered(
+    const MVMCScaledComplex *values, size_t value_count,
+    MVMCScaledComplex *result) {
+  MVMCScaledComplex candidate;
+  double scale = -INFINITY;
+  double error_bound = -INFINITY;
+  double max_input = -INFINITY;
+  double real_sum = 0.0, real_compensation = 0.0;
+  double imag_sum = 0.0, imag_compensation = 0.0;
+  double abs_sum = 0.0, abs_compensation = 0.0;
+  double complex central;
+  double central_abs;
+  double central_log;
+  double cancellation_ratio;
+  size_t index;
+  int finite_count = 0;
+  int numeric_count = 0;
+
+  if (result == NULL || values == NULL || value_count == 0) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  for (index = 0; index < value_count; ++index) {
+    if (!valid_scaled_complex(values + index)) {
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (values[index].state == MVMC_SCALED_COMPLEX_NONFINITE) {
+      *result = scaled_nonfinite();
+      return MVMC_PFAFFIAN_STATUS_OK;
+    }
+    max_input = fmax(max_input, values[index].max_input_log_abs);
+    if (values[index].state == MVMC_SCALED_COMPLEX_FINITE_NONZERO) {
+      scale = fmax(scale, values[index].log_abs);
+      ++finite_count;
+    } else if (values[index].state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+      error_bound = log_add_bounds(error_bound,
+                                   values[index].log_abs_error_bound);
+      ++numeric_count;
+    }
+  }
+  if (finite_count == 0) {
+    if (numeric_count == 0) {
+      *result = scaled_exact_zero();
+    } else if (isfinite(error_bound)) {
+      *result = scaled_numeric_zero(error_bound, max_input, -INFINITY, 0.0);
+    } else {
+      *result = scaled_nonfinite();
+    }
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  for (index = 0; index < value_count; ++index) {
+    double magnitude;
+    double complex term;
+    if (values[index].state != MVMC_SCALED_COMPLEX_FINITE_NONZERO) continue;
+    magnitude = exp(values[index].log_abs - scale);
+    term = magnitude * values[index].phase;
+    if (!finite_complex(term) ||
+        !neumaier_add(creal(term), &real_sum, &real_compensation) ||
+        !neumaier_add(cimag(term), &imag_sum, &imag_compensation) ||
+        !neumaier_add(magnitude, &abs_sum, &abs_compensation)) {
+      *result = scaled_nonfinite();
+      return MVMC_PFAFFIAN_STATUS_OK;
+    }
+    error_bound = log_add_bounds(error_bound,
+                                 values[index].log_abs_error_bound);
+  }
+  central = (real_sum + real_compensation) +
+            I * (imag_sum + imag_compensation);
+  central_abs = cabs(central);
+  abs_sum += abs_compensation;
+  if (!finite_complex(central) || !isfinite(abs_sum) || abs_sum <= 0.0) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  cancellation_ratio = fmin(1.0, central_abs / abs_sum);
+  if (central_abs == 0.0) {
+    error_bound = log_add_bounds(
+        error_bound, scale + log(32.0 * DBL_EPSILON * abs_sum));
+    *result = isfinite(error_bound)
+                  ? scaled_numeric_zero(error_bound, max_input, -INFINITY,
+                                        cancellation_ratio)
+                  : scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  central_log = scale + log(central_abs);
+  error_bound = log_add_bounds(
+      error_bound, scale + log(32.0 * DBL_EPSILON * abs_sum));
+  if (!isfinite(central_log) || !isfinite(error_bound)) {
+    *result = scaled_nonfinite();
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (central_log <= error_bound) {
+    *result = scaled_numeric_zero(error_bound, max_input, central_log,
+                                  cancellation_ratio);
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (mvmc_scaled_complex_make_finite(central / central_abs, central_log,
+                                      error_bound, &candidate) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  candidate.max_input_log_abs = max_input;
+  candidate.cancellation_log_abs = central_log;
+  candidate.cancellation_ratio = cancellation_ratio;
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCScaledComplexExportStatus mvmc_scaled_complex_export_common_scale(
+    const MVMCScaledComplex *value, double common_log_scale,
+    double complex *result) {
+  double delta;
+  double magnitude;
+  if (result == NULL || !valid_scaled_complex(value) ||
+      !isfinite(common_log_scale)) {
+    return MVMC_SCALED_EXPORT_INVALID;
+  }
+  switch (value->state) {
+    case MVMC_SCALED_COMPLEX_EXACT_ZERO:
+      *result = 0.0;
+      return MVMC_SCALED_EXPORT_EXACT_ZERO;
+    case MVMC_SCALED_COMPLEX_NUMERIC_ZERO:
+      *result = 0.0;
+      return MVMC_SCALED_EXPORT_NUMERIC_ZERO;
+    case MVMC_SCALED_COMPLEX_NONFINITE:
+      *result = NAN + I * NAN;
+      return MVMC_SCALED_EXPORT_NONFINITE;
+    case MVMC_SCALED_COMPLEX_FINITE_NONZERO:
+      break;
+  }
+  delta = value->log_abs - common_log_scale;
+  if (!isfinite(delta)) return MVMC_SCALED_EXPORT_INVALID;
+  if (delta > log(DBL_MAX)) {
+    *result = NAN + I * NAN;
+    return MVMC_SCALED_EXPORT_OVERFLOW;
+  }
+  if (delta < log(nextafter(0.0, 1.0))) {
+    *result = 0.0;
+    return MVMC_SCALED_EXPORT_UNDERFLOW;
+  }
+  magnitude = exp(delta);
+  if (magnitude == 0.0) {
+    *result = 0.0;
+    return MVMC_SCALED_EXPORT_UNDERFLOW;
+  }
+  *result = magnitude * value->phase;
+  if (!finite_complex(*result)) {
+    *result = NAN + I * NAN;
+    return MVMC_SCALED_EXPORT_OVERFLOW;
+  }
+  return MVMC_SCALED_EXPORT_OK;
+}
+
+static MVMCScaledComplex scaled_exact_weight(double complex weight) {
+  MVMCScaledComplex value;
+  double complex phase;
+  double log_abs;
+  if (!finite_complex(weight)) return scaled_nonfinite();
+  if (creal(weight) == 0.0 && cimag(weight) == 0.0) {
+    return scaled_exact_zero();
+  }
+  if (!decompose_finite_complex(weight, &phase, &log_abs)) {
+    return scaled_nonfinite();
+  }
+  if (mvmc_scaled_complex_make_finite(phase, log_abs, -INFINITY, &value) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return scaled_nonfinite();
+  }
+  return value;
+}
+
+static double zero_pivot_error_log(double matrix_scale, int n) {
+  double bound = 64.0 * DBL_EPSILON * (double)n;
+  if (!isfinite(matrix_scale) || matrix_scale < 0.0) return NAN;
+  if (matrix_scale > DBL_MAX / bound) return log(DBL_MAX);
+  bound *= fmax(matrix_scale, DBL_MIN);
+  if (!isfinite(bound) || bound <= 0.0) return log(DBL_MAX);
+  return log(bound);
+}
+
+static void initialize_scaled_pfaffian_result(
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  result->factor_state = MVMC_PFAFFIAN_VALUE_INVALID;
+  result->factor_info = 0;
+  result->matrix_scale = NAN;
+  result->scaled_min_pivot = NAN;
+  result->value = scaled_nonfinite();
+}
+
+static MVMCPfaffianStatus factorize_real_scaled_value(
+    const double *matrix, int n, int lda, double *factor, int *pivots,
+    double *factor_work, int factor_lwork, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  MVMCAbsolutePfaffianScaledValueResult candidate;
+  MVMCScaledComplex product;
+  double min_pivot = INFINITY;
+  int column, row, info = 0;
+  initialize_scaled_pfaffian_result(&candidate);
+  info = real_matrix_properties(matrix, n, lda, &candidate.matrix_scale);
+  if (info < 0) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    candidate.value = scaled_nonfinite();
+    *result = candidate;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  for (column = 0; column < n; ++column) {
+    pivots[column] = column + 1;
+    for (row = 0; row < n; ++row) {
+      factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+  M_DSKTRF("U", "P", &n, factor, &n, pivots, factor_work,
+           &factor_lwork, &info);
+  candidate.factor_info = info;
+  if (info < 0) return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  if (info > 0) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+    candidate.scaled_min_pivot = 0.0;
+    candidate.value = scaled_exact_zero();
+    *result = candidate;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (mvmc_scaled_complex_make_finite(1.0, 0.0, -INFINITY, &product) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  for (row = 0; row < n; row += 2) {
+    MVMCScaledComplex pivot_value;
+    MVMCScaledComplex updated;
+    double pivot = factor[row + (size_t)(row + 1) * (size_t)n];
+    const double pivot_abs = fabs(pivot);
+    if (!isfinite(pivot)) {
+      candidate.factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+      candidate.value = scaled_nonfinite();
+      *result = candidate;
+      return MVMC_PFAFFIAN_STATUS_OK;
+    }
+    min_pivot = fmin(min_pivot, pivot_abs);
+    if (pivot == 0.0) {
+      pivot_value = scaled_numeric_zero(
+          zero_pivot_error_log(candidate.matrix_scale, n), -INFINITY,
+          -INFINITY, 0.0);
+    } else if (mvmc_scaled_complex_from_raw_testing(pivot, &pivot_value) !=
+               MVMC_PFAFFIAN_STATUS_OK) {
+      return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    }
+    if (pivots[row] - 1 != row) pivot_value.phase = -pivot_value.phase;
+    if (pivots[row + 1] - 1 != row + 1) {
+      pivot_value.phase = -pivot_value.phase;
+    }
+    if (mvmc_scaled_complex_multiply(&product, &pivot_value, &updated) !=
+        MVMC_PFAFFIAN_STATUS_OK) {
+      return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    }
+    product = updated;
+  }
+  candidate.scaled_min_pivot =
+      min_pivot / fmax(candidate.matrix_scale, DBL_MIN);
+  if (!isfinite(candidate.scaled_min_pivot) ||
+      product.state == MVMC_SCALED_COMPLEX_NONFINITE) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    candidate.value = scaled_nonfinite();
+  } else if (candidate.scaled_min_pivot <
+                 effective_pivot_tolerance(scaled_pivot_tolerance, n) ||
+             product.state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_NEAR_PIVOT;
+    candidate.value = product;
+  } else {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+    candidate.value = product;
+  }
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static MVMCPfaffianStatus factorize_complex_scaled_value(
+    const double complex *matrix, int n, int lda, double complex *factor,
+    int *pivots, double complex *factor_work, int factor_lwork,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  MVMCAbsolutePfaffianScaledValueResult candidate;
+  MVMCScaledComplex product;
+  double min_pivot = INFINITY;
+  int column, row, info = 0;
+  initialize_scaled_pfaffian_result(&candidate);
+  info = complex_matrix_properties(matrix, n, lda, &candidate.matrix_scale);
+  if (info < 0) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    candidate.value = scaled_nonfinite();
+    *result = candidate;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (info == 0) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  for (column = 0; column < n; ++column) {
+    pivots[column] = column + 1;
+    for (row = 0; row < n; ++row) {
+      factor[row + (size_t)column * (size_t)n] =
+          matrix[row + (size_t)column * (size_t)lda];
+    }
+  }
+  M_ZSKTRF("U", "P", &n, factor, &n, pivots, factor_work,
+           &factor_lwork, &info);
+  candidate.factor_info = info;
+  if (info < 0) return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  if (info > 0) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+    candidate.scaled_min_pivot = 0.0;
+    candidate.value = scaled_exact_zero();
+    *result = candidate;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  if (mvmc_scaled_complex_make_finite(1.0, 0.0, -INFINITY, &product) !=
+      MVMC_PFAFFIAN_STATUS_OK) {
+    return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+  }
+  for (row = 0; row < n; row += 2) {
+    MVMCScaledComplex pivot_value;
+    MVMCScaledComplex updated;
+    double complex pivot = factor[row + (size_t)(row + 1) * (size_t)n];
+    const double pivot_abs = cabs(pivot);
+    if (!finite_complex(pivot) || !isfinite(pivot_abs)) {
+      candidate.factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+      candidate.value = scaled_nonfinite();
+      *result = candidate;
+      return MVMC_PFAFFIAN_STATUS_OK;
+    }
+    min_pivot = fmin(min_pivot, pivot_abs);
+    if (pivot_abs == 0.0) {
+      pivot_value = scaled_numeric_zero(
+          zero_pivot_error_log(candidate.matrix_scale, n), -INFINITY,
+          -INFINITY, 0.0);
+    } else if (mvmc_scaled_complex_from_raw_testing(pivot, &pivot_value) !=
+               MVMC_PFAFFIAN_STATUS_OK) {
+      return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    }
+    if (pivots[row] - 1 != row) pivot_value.phase = -pivot_value.phase;
+    if (pivots[row + 1] - 1 != row + 1) {
+      pivot_value.phase = -pivot_value.phase;
+    }
+    if (mvmc_scaled_complex_multiply(&product, &pivot_value, &updated) !=
+        MVMC_PFAFFIAN_STATUS_OK) {
+      return MVMC_PFAFFIAN_STATUS_FACTORIZATION_FAILURE;
+    }
+    product = updated;
+  }
+  candidate.scaled_min_pivot =
+      min_pivot / fmax(candidate.matrix_scale, DBL_MIN);
+  if (!isfinite(candidate.scaled_min_pivot) ||
+      product.state == MVMC_SCALED_COMPLEX_NONFINITE) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+    candidate.value = scaled_nonfinite();
+  } else if (candidate.scaled_min_pivot <
+                 effective_pivot_tolerance(scaled_pivot_tolerance, n) ||
+             product.state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_NEAR_PIVOT;
+    candidate.value = product;
+  } else {
+    candidate.factor_state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+    candidate.value = product;
+  }
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_scaled_value_with_workspace(
+    MVMCAbsolutePfaffianRealValueWorkspace *workspace,
+    const double *matrix, int n, int lda, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  size_t matrix_count;
+  if (result == NULL || !mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return result == NULL ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                          : MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (workspace == NULL || workspace->n != n || matrix == NULL || n <= 0 ||
+      (n % 2) != 0 || lda < n || !isfinite(scaled_pivot_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count) ||
+      workspace->matrix_count != matrix_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return factorize_real_scaled_value(
+      matrix, n, lda, workspace->factor, workspace->pivots,
+      workspace->factor_work, workspace->factor_lwork,
+      scaled_pivot_tolerance, result);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_scaled_value_with_workspace(
+    MVMCAbsolutePfaffianComplexValueWorkspace *workspace,
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  size_t matrix_count;
+  if (result == NULL || !mvmc_absolute_pfaffian_strict_fp_enabled()) {
+    return result == NULL ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                          : MVMC_PFAFFIAN_STATUS_UNSUPPORTED_FP_MODE;
+  }
+  if (workspace == NULL || workspace->n != n || matrix == NULL || n <= 0 ||
+      (n % 2) != 0 || lda < n || !isfinite(scaled_pivot_tolerance) ||
+      !checked_square_size(n, sizeof(*matrix), &matrix_count) ||
+      workspace->matrix_count != matrix_count) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  return factorize_complex_scaled_value(
+      matrix, n, lda, workspace->factor, workspace->pivots,
+      workspace->factor_work, workspace->factor_lwork,
+      scaled_pivot_tolerance, result);
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_scaled_value(
+    const double *matrix, int n, int lda, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  MVMCAbsolutePfaffianRealValueWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  status = mvmc_absolute_pfaffian_real_value_workspace_create(n, &workspace);
+  if (status == MVMC_PFAFFIAN_STATUS_OK) {
+    status = mvmc_absolute_pfaffian_real_scaled_value_with_workspace(
+        workspace, matrix, n, lda, scaled_pivot_tolerance, result);
+  }
+  mvmc_absolute_pfaffian_real_value_workspace_destroy(workspace);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_scaled_value(
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result) {
+  MVMCAbsolutePfaffianComplexValueWorkspace *workspace = NULL;
+  MVMCPfaffianStatus status;
+  if (result == NULL) return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  status =
+      mvmc_absolute_pfaffian_complex_value_workspace_create(n, &workspace);
+  if (status == MVMC_PFAFFIAN_STATUS_OK) {
+    status = mvmc_absolute_pfaffian_complex_scaled_value_with_workspace(
+        workspace, matrix, n, lda, scaled_pivot_tolerance, result);
+  }
+  mvmc_absolute_pfaffian_complex_value_workspace_destroy(workspace);
+  return status;
+}
+
+MVMCPfaffianStatus mvmc_projected_scaled_amplitude_values(
+    const MVMCAbsolutePfaffianScaledValueResult *components,
+    const double complex *weights, size_t component_count,
+    MVMCProjectedScaledAmplitudeResult *result) {
+  MVMCProjectedScaledAmplitudeResult candidate;
+  MVMCScaledComplex *terms;
+  double log_sum_abs = -INFINITY;
+  size_t index;
+  MVMCPfaffianStatus status;
+  if (result == NULL || components == NULL || weights == NULL ||
+      component_count == 0 ||
+      component_count > SIZE_MAX / sizeof(*terms)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  terms = (MVMCScaledComplex *)malloc(component_count * sizeof(*terms));
+  if (terms == NULL) return MVMC_PFAFFIAN_STATUS_ALLOCATION_FAILURE;
+  memset(&candidate, 0, sizeof(candidate));
+  candidate.total = scaled_nonfinite();
+  candidate.log_sum_abs = -INFINITY;
+  for (index = 0; index < component_count; ++index) {
+    MVMCScaledComplex scaled_weight;
+    if (!finite_complex(weights[index]) ||
+        !valid_scaled_complex(&components[index].value)) {
+      free(terms);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    switch (components[index].factor_state) {
+      case MVMC_PFAFFIAN_VALUE_WELL_PIVOTED:
+        if (components[index].value.state !=
+            MVMC_SCALED_COMPLEX_FINITE_NONZERO) {
+          free(terms);
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+        ++candidate.well_pivoted_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_NEAR_PIVOT:
+        if (components[index].value.state !=
+                MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            components[index].value.state !=
+                MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+          free(terms);
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+        ++candidate.near_pivot_count;
+        break;
+      case MVMC_PFAFFIAN_VALUE_SINGULAR:
+        if (components[index].value.state !=
+            MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+          free(terms);
+          return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+        }
+        break;
+      case MVMC_PFAFFIAN_VALUE_NONFINITE:
+      case MVMC_PFAFFIAN_VALUE_INVALID:
+        free(terms);
+        return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    if (components[index].value.state == MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+      ++candidate.exact_zero_count;
+    } else if (components[index].value.state ==
+               MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+      ++candidate.numeric_zero_count;
+    } else if (components[index].value.state ==
+               MVMC_SCALED_COMPLEX_NONFINITE) {
+      free(terms);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    scaled_weight = scaled_exact_weight(weights[index]);
+    if (scaled_weight.state == MVMC_SCALED_COMPLEX_NONFINITE) {
+      free(terms);
+      return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+    }
+    status = mvmc_scaled_complex_multiply(
+        &scaled_weight, &components[index].value, terms + index);
+    if (status != MVMC_PFAFFIAN_STATUS_OK ||
+        terms[index].state == MVMC_SCALED_COMPLEX_NONFINITE) {
+      free(terms);
+      return status == MVMC_PFAFFIAN_STATUS_OK
+                 ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+                 : status;
+    }
+    if (terms[index].state == MVMC_SCALED_COMPLEX_FINITE_NONZERO) {
+      log_sum_abs = log_add_bounds(log_sum_abs, terms[index].log_abs);
+    } else if (terms[index].state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+      log_sum_abs = log_add_bounds(log_sum_abs,
+                                   terms[index].log_abs_error_bound);
+    }
+  }
+  status = mvmc_scaled_complex_sum_ordered(terms, component_count,
+                                           &candidate.total);
+  free(terms);
+  if (status != MVMC_PFAFFIAN_STATUS_OK ||
+      candidate.total.state == MVMC_SCALED_COMPLEX_NONFINITE ||
+      !valid_error_log(log_sum_abs)) {
+    return status == MVMC_PFAFFIAN_STATUS_OK
+               ? MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT
+               : status;
+  }
+  candidate.log_sum_abs = log_sum_abs;
+  candidate.valid = 1;
+  *result = candidate;
+  return MVMC_PFAFFIAN_STATUS_OK;
+}
+
+MVMCPfaffianStatus mvmc_projected_scaled_amplitude_value_slice(
+    const MVMCAbsolutePfaffianScaledValueResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCProjectedScaledAmplitudeResult *result) {
+  MVMCProjectedScaledAmplitudeResult candidate;
+  if (result == NULL || qp_total <= 0 || qp_start < 0 || qp_end < qp_start ||
+      qp_end > qp_total ||
+      (size_t)(qp_end - qp_start) != local_component_count ||
+      global_weights == NULL ||
+      (local_component_count != 0 && local_components == NULL)) {
+    return MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT;
+  }
+  if (local_component_count == 0) {
+    memset(&candidate, 0, sizeof(candidate));
+    candidate.valid = 1;
+    candidate.total = scaled_exact_zero();
+    candidate.log_sum_abs = -INFINITY;
+    *result = candidate;
+    return MVMC_PFAFFIAN_STATUS_OK;
+  }
+  return mvmc_projected_scaled_amplitude_values(
+      local_components, global_weights + qp_start, local_component_count,
+      result);
+}
+#endif /* MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE */
+
 const char *mvmc_pfaffian_state_name(MVMCPfaffianState state) {
   switch (state) {
     case MVMC_PFAFFIAN_REGULAR:

--- a/src/mVMC/bounded_krylov_collective.c
+++ b/src/mVMC/bounded_krylov_collective.c
@@ -1,0 +1,743 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "bounded_krylov_collective.h"
+
+#if !defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+#error "bounded_krylov_collective.c is Testing-only"
+#endif
+
+#include <limits.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct MVMCKrylovBoundedCollectiveWorkspace {
+  int rank;
+  int size;
+  size_t allocated_bytes;
+  size_t max_qp_components;
+  size_t max_accumulator_count;
+  int *ranges;
+  int *byte_counts;
+  int *byte_displacements;
+  uint64_t *rank_values;
+  MVMCAbsolutePfaffianScaledValueResult *component_buffer;
+  MVMCScaledComplex *projection_terms;
+  MVMCScaledComplex *rank_accumulator_buffer;
+  MVMCScaledComplex *rank_order_scratch;
+  MVMCScaledComplex *merge_buffer;
+#ifdef _mpi_use
+  MPI_Comm communicator;
+#endif
+};
+
+static int checked_add_size(size_t left, size_t right, size_t *result) {
+  if (result == NULL || left > SIZE_MAX - right) return 0;
+  *result = left + right;
+  return 1;
+}
+
+static int checked_multiply_size(size_t left, size_t right, size_t *result) {
+  if (result == NULL || (left != 0 && right > SIZE_MAX / left)) return 0;
+  *result = left * right;
+  return 1;
+}
+
+static int reserve_aligned(size_t *offset, size_t count, size_t item_size,
+                           size_t alignment, size_t *start) {
+  size_t aligned;
+  size_t bytes;
+  if (offset == NULL || start == NULL || alignment == 0 ||
+      (alignment & (alignment - 1)) != 0 ||
+      *offset > SIZE_MAX - (alignment - 1)) return 0;
+  aligned = (*offset + alignment - 1) & ~(alignment - 1);
+  if (!checked_multiply_size(count, item_size, &bytes) ||
+      !checked_add_size(aligned, bytes, offset)) return 0;
+  *start = aligned;
+  return 1;
+}
+
+static int valid_status(MVMCKrylovStatus status) {
+  return status >= MVMC_KRYLOV_STATUS_OK &&
+         status <= MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+}
+
+static uint64_t double_bits(double value) {
+  uint64_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+static void hash_u64(uint64_t *hash, uint64_t value) {
+  int byte;
+  for (byte = 0; byte < 8; ++byte) {
+    *hash ^= value & UINT64_C(0xff);
+    *hash *= UINT64_C(1099511628211);
+    value >>= 8;
+  }
+}
+
+static int finite_complex(double complex value) {
+  return isfinite(creal(value)) && isfinite(cimag(value));
+}
+
+static int exact_scaled_weight(double complex weight,
+                               MVMCScaledComplex *value) {
+  const double scale = fmax(fabs(creal(weight)), fabs(cimag(weight)));
+  double complex scaled;
+  double magnitude;
+  if (value == NULL || !finite_complex(weight)) return 0;
+  if (scale == 0.0) {
+    return mvmc_scaled_complex_make_exact_zero(value) ==
+           MVMC_PFAFFIAN_STATUS_OK;
+  }
+  scaled = creal(weight) / scale + I * (cimag(weight) / scale);
+  magnitude = hypot(creal(scaled), cimag(scaled));
+  if (!isfinite(magnitude) || magnitude == 0.0) return 0;
+  return mvmc_scaled_complex_make_finite(
+             scaled / magnitude, log(scale) + log(magnitude),
+             -INFINITY, value) == MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static void reset_result(MVMCKrylovBoundedCollectiveResult *result) {
+  if (result == NULL) return;
+  memset(result, 0, sizeof(*result));
+  result->status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  result->failure_rank = -1;
+}
+
+static MVMCKrylovStatus synchronize_status(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status, int result_available,
+    MVMCKrylovBoundedCollectiveResult *result) {
+  MVMCKrylovStatus effective = valid_status(local_status)
+                                      ? local_status
+                                      : MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  int selected_rank = 0;
+#ifndef _mpi_use
+  (void)workspace;
+#endif
+  if (!result_available && effective == MVMC_KRYLOV_STATUS_OK) {
+    effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+#ifdef _mpi_use
+  {
+    struct {
+      int value;
+      int index;
+    } local_selection, global_selection;
+    local_selection.value = (int)effective;
+    local_selection.index = workspace->rank;
+    if (MPI_Allreduce(&local_selection, &global_selection, 1, MPI_2INT,
+                      MPI_MAXLOC, workspace->communicator) != MPI_SUCCESS) {
+      if (result_available) {
+        result->status = MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+      }
+      return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+    }
+    effective = (MVMCKrylovStatus)global_selection.value;
+    selected_rank = global_selection.index;
+  }
+#endif
+  if (result_available) {
+    result->status = effective;
+    result->failure_rank =
+        effective == MVMC_KRYLOV_STATUS_OK ? -1 : selected_rank;
+    result->valid = effective == MVMC_KRYLOV_STATUS_OK;
+  }
+  return effective;
+}
+
+static int valid_scaled_component(
+    const MVMCAbsolutePfaffianScaledValueResult *component,
+    MVMCKrylovStatus *status) {
+  if (component == NULL || status == NULL) return 0;
+  if (component->factor_state < MVMC_PFAFFIAN_VALUE_WELL_PIVOTED ||
+      component->factor_state > MVMC_PFAFFIAN_VALUE_INVALID ||
+      component->factor_state == MVMC_PFAFFIAN_VALUE_INVALID ||
+      component->factor_info < 0 || component->matrix_scale < 0.0 ||
+      component->scaled_min_pivot < 0.0) {
+    *status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    return 0;
+  }
+  if (component->factor_state == MVMC_PFAFFIAN_VALUE_NONFINITE ||
+      !isfinite(component->matrix_scale) ||
+      !isfinite(component->scaled_min_pivot)) {
+    *status = MVMC_KRYLOV_STATUS_NONFINITE;
+    return 0;
+  }
+  if (!mvmc_scaled_complex_is_valid(&component->value) ||
+      component->value.state < MVMC_SCALED_COMPLEX_FINITE_NONZERO ||
+      component->value.state > MVMC_SCALED_COMPLEX_NONFINITE) {
+    *status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    return 0;
+  }
+  if (component->value.state == MVMC_SCALED_COMPLEX_NONFINITE) {
+    *status = MVMC_KRYLOV_STATUS_NONFINITE;
+    return 0;
+  }
+  if ((component->factor_state == MVMC_PFAFFIAN_VALUE_WELL_PIVOTED &&
+       component->value.state != MVMC_SCALED_COMPLEX_FINITE_NONZERO) ||
+      (component->factor_state == MVMC_PFAFFIAN_VALUE_NEAR_PIVOT &&
+       component->value.state != MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+       component->value.state != MVMC_SCALED_COMPLEX_NUMERIC_ZERO) ||
+      (component->factor_state == MVMC_PFAFFIAN_VALUE_SINGULAR &&
+       component->value.state != MVMC_SCALED_COMPLEX_EXACT_ZERO)) {
+    *status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    return 0;
+  }
+  return 1;
+}
+
+static int first_invalid_partition(const int *ranges, int size,
+                                   size_t maximum) {
+  const int qp_total = ranges[0];
+  int rank;
+  if (qp_total < 0 || (size_t)qp_total > maximum) return 0;
+  for (rank = 0; rank < size; ++rank) {
+    const int *range = ranges + (size_t)rank * 3;
+    if (range[0] != qp_total || range[1] < 0 || range[2] < range[1] ||
+        range[2] > qp_total) return rank;
+    if ((rank == 0 && range[1] != 0) ||
+        (rank > 0 &&
+         range[1] != ranges[(size_t)(rank - 1) * 3 + 2])) return rank;
+  }
+  return ranges[(size_t)(size - 1) * 3 + 2] == qp_total ? -1 : size - 1;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_collective_workspace_create(
+    MVMCKrylovBoundedCommunicator communicator,
+    size_t max_qp_components, size_t max_accumulator_count,
+    MVMCKrylovBoundedCollectiveWorkspace **workspace) {
+  MVMCKrylovBoundedCollectiveWorkspace *created = NULL;
+  int size = 1;
+  int rank = 0;
+  int local_valid = workspace != NULL && max_qp_components > 0 &&
+                    max_accumulator_count > 0;
+  size_t offset = sizeof(*created);
+  size_t ranges_offset;
+  size_t counts_offset;
+  size_t displacements_offset;
+  size_t rank_values_offset;
+  size_t component_offset;
+  size_t projection_term_offset;
+  size_t rank_accumulator_offset;
+  size_t rank_scratch_offset;
+  size_t merge_offset;
+  size_t range_count = 0;
+  size_t rank_accumulator_count = 0;
+#ifdef _mpi_use
+  MPI_Comm duplicated = MPI_COMM_NULL;
+  int initialized = 0;
+  int all_valid = 0;
+  uint64_t local_capacities[2];
+  uint64_t minimum_capacities[2];
+  uint64_t maximum_capacities[2];
+  int allocation_ok;
+  int all_allocation_ok;
+  if (workspace != NULL) *workspace = NULL;
+  if (communicator == MPI_COMM_NULL ||
+      MPI_Initialized(&initialized) != MPI_SUCCESS || !initialized ||
+      MPI_Comm_dup(communicator, &duplicated) != MPI_SUCCESS ||
+      MPI_Comm_set_errhandler(duplicated, MPI_ERRORS_RETURN) != MPI_SUCCESS ||
+      MPI_Comm_size(duplicated, &size) != MPI_SUCCESS || size <= 0 ||
+      MPI_Comm_rank(duplicated, &rank) != MPI_SUCCESS) {
+    if (duplicated != MPI_COMM_NULL) MPI_Comm_free(&duplicated);
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+#if SIZE_MAX > UINT64_MAX
+  if (max_qp_components > UINT64_MAX ||
+      max_accumulator_count > UINT64_MAX) local_valid = 0;
+#endif
+  local_capacities[0] = local_valid ? (uint64_t)max_qp_components : 0;
+  local_capacities[1] = local_valid ? (uint64_t)max_accumulator_count : 0;
+  if (MPI_Allreduce(&local_valid, &all_valid, 1, MPI_INT, MPI_MIN,
+                    duplicated) != MPI_SUCCESS ||
+      MPI_Allreduce(local_capacities, minimum_capacities, 2, MPI_UINT64_T,
+                    MPI_MIN, duplicated) != MPI_SUCCESS ||
+      MPI_Allreduce(local_capacities, maximum_capacities, 2, MPI_UINT64_T,
+                    MPI_MAX, duplicated) != MPI_SUCCESS) {
+    MPI_Comm_free(&duplicated);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (!all_valid ||
+      memcmp(minimum_capacities, maximum_capacities,
+             sizeof(minimum_capacities)) != 0) {
+    MPI_Comm_free(&duplicated);
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+#else
+  (void)communicator;
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (!local_valid) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+#endif
+  if (max_qp_components > (size_t)INT_MAX /
+                              sizeof(MVMCAbsolutePfaffianScaledValueResult) ||
+      max_accumulator_count >
+          (size_t)INT_MAX / sizeof(MVMCScaledComplex) ||
+      !checked_multiply_size((size_t)size, 3, &range_count) ||
+      !checked_multiply_size((size_t)size, max_accumulator_count,
+                             &rank_accumulator_count) ||
+      !reserve_aligned(&offset, range_count, sizeof(int),
+                       _Alignof(int), &ranges_offset) ||
+      !reserve_aligned(&offset, (size_t)size, sizeof(int),
+                       _Alignof(int), &counts_offset) ||
+      !reserve_aligned(&offset, (size_t)size, sizeof(int),
+                       _Alignof(int), &displacements_offset) ||
+      !reserve_aligned(&offset, (size_t)size, sizeof(uint64_t),
+                       _Alignof(uint64_t), &rank_values_offset) ||
+      !reserve_aligned(&offset, max_qp_components,
+                       sizeof(MVMCAbsolutePfaffianScaledValueResult),
+                       _Alignof(MVMCAbsolutePfaffianScaledValueResult),
+                       &component_offset) ||
+      !reserve_aligned(&offset, max_qp_components,
+                       sizeof(MVMCScaledComplex),
+                       _Alignof(MVMCScaledComplex),
+                       &projection_term_offset) ||
+      !reserve_aligned(&offset, rank_accumulator_count,
+                       sizeof(MVMCScaledComplex),
+                       _Alignof(MVMCScaledComplex),
+                       &rank_accumulator_offset) ||
+      !reserve_aligned(&offset, (size_t)size, sizeof(MVMCScaledComplex),
+                       _Alignof(MVMCScaledComplex), &rank_scratch_offset) ||
+      !reserve_aligned(&offset, max_accumulator_count,
+                       sizeof(MVMCScaledComplex),
+                       _Alignof(MVMCScaledComplex), &merge_offset)) {
+#ifdef _mpi_use
+    MPI_Comm_free(&duplicated);
+#endif
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  created = (MVMCKrylovBoundedCollectiveWorkspace *)calloc(1, offset);
+#ifdef _mpi_use
+  allocation_ok = created != NULL;
+  if (MPI_Allreduce(&allocation_ok, &all_allocation_ok, 1, MPI_INT, MPI_MIN,
+                    duplicated) != MPI_SUCCESS) {
+    free(created);
+    MPI_Comm_free(&duplicated);
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+  if (!all_allocation_ok) {
+    free(created);
+    MPI_Comm_free(&duplicated);
+    return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+#else
+  if (created == NULL) return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+#endif
+  created->rank = rank;
+  created->size = size;
+  created->allocated_bytes = offset;
+  created->max_qp_components = max_qp_components;
+  created->max_accumulator_count = max_accumulator_count;
+  created->ranges = (int *)((unsigned char *)created + ranges_offset);
+  created->byte_counts = (int *)((unsigned char *)created + counts_offset);
+  created->byte_displacements =
+      (int *)((unsigned char *)created + displacements_offset);
+  created->rank_values =
+      (uint64_t *)((unsigned char *)created + rank_values_offset);
+  created->component_buffer =
+      (MVMCAbsolutePfaffianScaledValueResult *)((unsigned char *)created +
+                                                 component_offset);
+  created->projection_terms =
+      (MVMCScaledComplex *)((unsigned char *)created +
+                            projection_term_offset);
+  created->rank_accumulator_buffer =
+      (MVMCScaledComplex *)((unsigned char *)created +
+                            rank_accumulator_offset);
+  created->rank_order_scratch =
+      (MVMCScaledComplex *)((unsigned char *)created + rank_scratch_offset);
+  created->merge_buffer =
+      (MVMCScaledComplex *)((unsigned char *)created + merge_offset);
+#ifdef _mpi_use
+  created->communicator = duplicated;
+#endif
+  *workspace = created;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+void mvmc_bounded_krylov_collective_workspace_destroy(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  if (workspace == NULL) return;
+#ifdef _mpi_use
+  if (workspace->communicator != MPI_COMM_NULL) {
+    MPI_Comm_free(&workspace->communicator);
+  }
+#endif
+  free(workspace);
+}
+
+size_t mvmc_bounded_krylov_collective_workspace_bytes(
+    const MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  return workspace == NULL ? 0 : workspace->allocated_bytes;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_collective_synchronize(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status, uint64_t local_plan_hash,
+    int local_allocation_ok, MVMCKrylovBoundedCollectiveResult *result) {
+  MVMCKrylovBoundedCollectiveResult discarded;
+  int mismatch_rank = -1;
+  int rank;
+  MVMCKrylovStatus effective = local_status;
+  const int result_available = result != NULL;
+  if (!result_available) result = &discarded;
+  reset_result(result);
+  if (workspace == NULL || workspace->rank_values == NULL) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (local_allocation_ok != 0 && local_allocation_ok != 1) {
+    effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    local_allocation_ok = 1;
+  }
+#ifdef _mpi_use
+  if (MPI_Allgather(&local_plan_hash, 1, MPI_UINT64_T,
+                    workspace->rank_values, 1, MPI_UINT64_T,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  workspace->rank_values[0] = local_plan_hash;
+#endif
+  for (rank = 1; rank < workspace->size; ++rank) {
+    if (workspace->rank_values[rank] != workspace->rank_values[0]) {
+      mismatch_rank = rank;
+      break;
+    }
+  }
+  if (!valid_status(effective)) effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  if (!local_allocation_ok &&
+      effective < MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE) {
+    effective = MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+  if (mismatch_rank == workspace->rank) {
+    effective = MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+  }
+  effective = synchronize_status(workspace, effective, result_available,
+                                 result);
+  result->plan_hash = workspace->rank_values[0];
+  return effective;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_collective_max_u64(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    uint64_t local_value, uint64_t *global_maximum) {
+  uint64_t maximum = local_value;
+  int local_valid;
+  int all_valid;
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  local_valid = global_maximum != NULL;
+#ifdef _mpi_use
+  if (MPI_Allreduce(&local_valid, &all_valid, 1, MPI_INT, MPI_MIN,
+                    workspace->communicator) != MPI_SUCCESS ||
+      MPI_Allreduce(&local_value, &maximum, 1, MPI_UINT64_T, MPI_MAX,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  all_valid = local_valid;
+#endif
+  if (!all_valid) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *global_maximum = maximum;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_collective_gather_scaled_components(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status,
+    const MVMCAbsolutePfaffianScaledValueResult *local_components,
+    size_t local_component_count, int qp_total, int qp_start, int qp_end,
+    MVMCAbsolutePfaffianScaledValueResult *global_components,
+    MVMCKrylovBoundedCollectiveResult *result) {
+  MVMCKrylovBoundedCollectiveResult discarded;
+  const int result_available = result != NULL;
+  MVMCKrylovStatus effective = valid_status(local_status)
+                                      ? local_status
+                                      : MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  int local_range[3] = {qp_total, qp_start, qp_end};
+  int partition_failure_rank;
+  size_t index;
+  if (!result_available) result = &discarded;
+  reset_result(result);
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+#ifdef _mpi_use
+  if (MPI_Allgather(local_range, 3, MPI_INT, workspace->ranges, 3, MPI_INT,
+                    workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  memcpy(workspace->ranges, local_range, sizeof(local_range));
+#endif
+  partition_failure_rank = first_invalid_partition(
+      workspace->ranges, workspace->size, workspace->max_qp_components);
+  if (partition_failure_rank == workspace->rank) {
+    effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (qp_start < 0 || qp_end < qp_start ||
+      local_component_count != (size_t)(qp_end - qp_start) ||
+      (local_component_count != 0 && local_components == NULL) ||
+      (qp_total != 0 && global_components == NULL)) {
+    effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (effective == MVMC_KRYLOV_STATUS_OK) {
+    for (index = 0; index < local_component_count; ++index) {
+      if (!valid_scaled_component(&local_components[index], &effective)) break;
+    }
+  }
+  effective = synchronize_status(workspace, effective, result_available,
+                                 result);
+  if (effective != MVMC_KRYLOV_STATUS_OK) return effective;
+  for (index = 0; index < (size_t)workspace->size; ++index) {
+    const int start = workspace->ranges[index * 3 + 1];
+    const int end = workspace->ranges[index * 3 + 2];
+    workspace->byte_counts[index] =
+        (end - start) * (int)sizeof(*local_components);
+    workspace->byte_displacements[index] =
+        start * (int)sizeof(*local_components);
+  }
+#ifdef _mpi_use
+  if (MPI_Allgatherv(
+          local_component_count == 0 ? workspace->component_buffer
+                                     : local_components,
+          (int)(local_component_count * sizeof(*local_components)), MPI_BYTE,
+          workspace->component_buffer, workspace->byte_counts,
+          workspace->byte_displacements, MPI_BYTE,
+          workspace->communicator) != MPI_SUCCESS) {
+    reset_result(result);
+    result->status = MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+    return result->status;
+  }
+#else
+  if (local_component_count != 0) {
+    memcpy(workspace->component_buffer, local_components,
+           local_component_count * sizeof(*local_components));
+  }
+#endif
+  if (global_components != workspace->component_buffer) {
+    memcpy(global_components, workspace->component_buffer,
+           (size_t)qp_total * sizeof(*global_components));
+  }
+  result->valid = 1;
+  result->status = MVMC_KRYLOV_STATUS_OK;
+  result->failure_rank = -1;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus
+mvmc_bounded_krylov_collective_gather_projected_amplitude(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status,
+    const MVMCAbsolutePfaffianScaledValueResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCKrylovScaledAmplitudeResult *amplitude,
+    MVMCKrylovBoundedCollectiveResult *result) {
+  MVMCKrylovScaledAmplitudeResult candidate;
+  MVMCKrylovBoundedCollectiveResult preflight;
+  MVMCKrylovStatus effective = valid_status(local_status)
+                                      ? local_status
+                                      : MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  uint64_t weight_hash = UINT64_C(1469598103934665603);
+  size_t index;
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  if (qp_total <= 0 || (size_t)qp_total > workspace->max_qp_components ||
+      global_weights == NULL || amplitude == NULL) {
+    effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (qp_total > 0 && global_weights != NULL) {
+    hash_u64(&weight_hash, (uint64_t)(unsigned int)qp_total);
+    for (index = 0; index < (size_t)qp_total; ++index) {
+      if (!finite_complex(global_weights[index])) {
+        effective = MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      hash_u64(&weight_hash, double_bits(creal(global_weights[index])));
+      hash_u64(&weight_hash, double_bits(cimag(global_weights[index])));
+    }
+  }
+  effective = mvmc_bounded_krylov_collective_synchronize(
+      workspace, effective, weight_hash, 1, &preflight);
+  if (effective != MVMC_KRYLOV_STATUS_OK) {
+    if (result != NULL) *result = preflight;
+    return effective;
+  }
+  effective = mvmc_bounded_krylov_collective_gather_scaled_components(
+      workspace, MVMC_KRYLOV_STATUS_OK, local_components,
+      local_component_count, qp_total, qp_start, qp_end,
+      workspace->component_buffer, result);
+  if (effective != MVMC_KRYLOV_STATUS_OK) return effective;
+  memset(&candidate, 0, sizeof(candidate));
+  candidate.local_factorization_count = (uint64_t)local_component_count;
+  candidate.global_factorization_count = (uint64_t)(unsigned int)qp_total;
+  for (index = 0; index < (size_t)qp_total; ++index) {
+    const MVMCAbsolutePfaffianScaledValueResult *component =
+        &workspace->component_buffer[index];
+    MVMCScaledComplex scaled_weight;
+    switch (component->factor_state) {
+      case MVMC_PFAFFIAN_VALUE_WELL_PIVOTED:
+        if (component->value.state !=
+            MVMC_SCALED_COMPLEX_FINITE_NONZERO) {
+          effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+        } else {
+          ++candidate.well_pivoted_component_count;
+        }
+        break;
+      case MVMC_PFAFFIAN_VALUE_NEAR_PIVOT:
+        if (component->value.state !=
+                MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            component->value.state != MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+          effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+        } else {
+          ++candidate.near_pivot_component_count;
+        }
+        break;
+      case MVMC_PFAFFIAN_VALUE_SINGULAR:
+        if (component->value.state != MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+          effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+        }
+        break;
+      case MVMC_PFAFFIAN_VALUE_NONFINITE:
+      case MVMC_PFAFFIAN_VALUE_INVALID:
+        effective = MVMC_KRYLOV_STATUS_NONFINITE;
+        break;
+    }
+    if (component->value.state == MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+      ++candidate.exact_zero_component_count;
+    } else if (component->value.state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO) {
+      ++candidate.numeric_zero_component_count;
+    }
+    if (effective != MVMC_KRYLOV_STATUS_OK ||
+        !exact_scaled_weight(global_weights[index], &scaled_weight) ||
+        mvmc_scaled_complex_multiply(
+            &scaled_weight, &component->value,
+            &workspace->projection_terms[index]) !=
+            MVMC_PFAFFIAN_STATUS_OK ||
+        workspace->projection_terms[index].state ==
+            MVMC_SCALED_COMPLEX_NONFINITE) {
+      if (effective == MVMC_KRYLOV_STATUS_OK) {
+        effective = MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      break;
+    }
+  }
+  if (effective == MVMC_KRYLOV_STATUS_OK &&
+      (mvmc_scaled_complex_sum_ordered(
+           workspace->projection_terms, (size_t)qp_total,
+           &candidate.value) != MVMC_PFAFFIAN_STATUS_OK ||
+       candidate.value.state == MVMC_SCALED_COMPLEX_NONFINITE)) {
+    effective = MVMC_KRYLOV_STATUS_NONFINITE;
+  }
+  if (effective != MVMC_KRYLOV_STATUS_OK) {
+    if (result != NULL) {
+      reset_result(result);
+      result->status = effective;
+    }
+    return effective;
+  }
+  *amplitude = candidate;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_collective_merge_scaled_accumulators(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status,
+    const MVMCScaledComplex *local_values, size_t value_count,
+    MVMCScaledComplex *global_values,
+    MVMCKrylovBoundedCollectiveResult *result) {
+  MVMCKrylovBoundedCollectiveResult discarded;
+  const int result_available = result != NULL;
+  MVMCKrylovStatus effective = valid_status(local_status)
+                                      ? local_status
+                                      : MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  uint64_t local_count;
+  size_t index;
+  int rank;
+  if (!result_available) result = &discarded;
+  reset_result(result);
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+#if SIZE_MAX > UINT64_MAX
+  if (value_count > UINT64_MAX) effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+#endif
+  local_count = effective == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT
+                    ? 0
+                    : (uint64_t)value_count;
+#ifdef _mpi_use
+  if (MPI_Allgather(&local_count, 1, MPI_UINT64_T, workspace->rank_values, 1,
+                    MPI_UINT64_T, workspace->communicator) != MPI_SUCCESS) {
+    return MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+  }
+#else
+  workspace->rank_values[0] = local_count;
+#endif
+  if (value_count > workspace->max_accumulator_count ||
+      (value_count != 0 && (local_values == NULL || global_values == NULL))) {
+    effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  for (rank = 1; rank < workspace->size; ++rank) {
+    if (workspace->rank_values[rank] != workspace->rank_values[0]) {
+      effective = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+      break;
+    }
+  }
+  if (effective == MVMC_KRYLOV_STATUS_OK) {
+    for (index = 0; index < value_count; ++index) {
+      if (!mvmc_scaled_complex_is_valid(&local_values[index]) ||
+          local_values[index].state == MVMC_SCALED_COMPLEX_NONFINITE) {
+        effective = MVMC_KRYLOV_STATUS_NONFINITE;
+        break;
+      }
+    }
+  }
+  effective = synchronize_status(workspace, effective, result_available,
+                                 result);
+  if (effective != MVMC_KRYLOV_STATUS_OK) return effective;
+#ifdef _mpi_use
+  if (MPI_Allgather(
+          value_count == 0 ? workspace->rank_accumulator_buffer : local_values,
+          (int)(value_count * sizeof(*local_values)), MPI_BYTE,
+          workspace->rank_accumulator_buffer,
+          (int)(value_count * sizeof(*local_values)), MPI_BYTE,
+          workspace->communicator) != MPI_SUCCESS) {
+    reset_result(result);
+    result->status = MVMC_KRYLOV_STATUS_COLLECTIVE_FAILURE;
+    return result->status;
+  }
+#else
+  if (value_count != 0) {
+    memcpy(workspace->rank_accumulator_buffer, local_values,
+           value_count * sizeof(*local_values));
+  }
+#endif
+  for (index = 0; index < value_count; ++index) {
+    for (rank = 0; rank < workspace->size; ++rank) {
+      workspace->rank_order_scratch[rank] =
+          workspace->rank_accumulator_buffer[
+              (size_t)rank * value_count + index];
+    }
+    if (mvmc_scaled_complex_sum_ordered(
+            workspace->rank_order_scratch, (size_t)workspace->size,
+            &workspace->merge_buffer[index]) != MVMC_PFAFFIAN_STATUS_OK ||
+        workspace->merge_buffer[index].state ==
+            MVMC_SCALED_COMPLEX_NONFINITE) {
+      reset_result(result);
+      result->status = MVMC_KRYLOV_STATUS_NONFINITE;
+      return result->status;
+    }
+  }
+  if (value_count != 0) {
+    memcpy(global_values, workspace->merge_buffer,
+           value_count * sizeof(*global_values));
+  }
+  result->valid = 1;
+  result->status = MVMC_KRYLOV_STATUS_OK;
+  result->failure_rank = -1;
+  return MVMC_KRYLOV_STATUS_OK;
+}

--- a/src/mVMC/bounded_krylov_engine.c
+++ b/src/mVMC/bounded_krylov_engine.c
@@ -1,0 +1,1278 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#include "bounded_krylov_engine.h"
+
+#if !defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+#error "bounded_krylov_engine.c is Testing-only"
+#endif
+
+#include <float.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct {
+  size_t key_index;
+  size_t canonical_term_index;
+  double complex row_weight;
+} MVMCBoundedNeighbor;
+
+typedef struct {
+  uint64_t epoch;
+  uint64_t access;
+  uint64_t hash;
+  int depth;
+  MVMCScaledComplex value;
+} MVMCBoundedCacheEntry;
+
+struct MVMCKrylovBoundedPlan {
+  MVMCKrylovFockModel model;
+  MVMCKrylovBoundedLimits limits;
+  MVMCKrylovHamiltonianTerm *terms;
+  MVMCKrylovFermionOperator *operators;
+  size_t *term_order;
+  size_t word_count;
+  size_t orbital_count;
+  size_t max_row_transitions;
+  size_t plan_bytes;
+  size_t model_bytes;
+  size_t cache_set_bytes;
+  uint64_t plan_hash;
+};
+
+struct MVMCKrylovBoundedWorkspace {
+  const MVMCKrylovBoundedPlan *plan;
+  size_t allocated_bytes;
+  size_t frame_bytes;
+  size_t scratch_bytes;
+  size_t cache_allocated_bytes;
+  size_t cache_set_count;
+  size_t cache_live_count;
+  uint64_t cache_epoch;
+  uint64_t cache_access;
+  MVMCBoundedNeighbor *neighbors;
+  uint64_t *neighbor_words;
+  MVMCScaledComplex *contributions;
+  uint64_t *scratch_words;
+  MVMCBoundedCacheEntry *cache_entries;
+  uint64_t *cache_words;
+};
+
+typedef struct {
+  MVMCKrylovBoundedWorkspace *workspace;
+  MVMCKrylovScaledAmplitudeCallback amplitude;
+  void *amplitude_context;
+  MVMCKrylovBoundedStatistics *statistics;
+  MVMCKrylovBoundedFailure *failure;
+} MVMCBoundedEvaluation;
+
+typedef struct {
+  double real_sum;
+  double real_compensation;
+  double imag_sum;
+  double imag_compensation;
+} MVMCRawComplexAccumulator;
+
+static int checked_add_size(size_t lhs, size_t rhs, size_t *result) {
+  if (result == NULL || lhs > SIZE_MAX - rhs) return 0;
+  *result = lhs + rhs;
+  return 1;
+}
+
+static int checked_multiply_size(size_t lhs, size_t rhs, size_t *result) {
+  if (result == NULL || (lhs != 0 && rhs > SIZE_MAX / lhs)) return 0;
+  *result = lhs * rhs;
+  return 1;
+}
+
+static int reserve_aligned(size_t *offset, size_t count, size_t item_size,
+                           size_t alignment, size_t *start) {
+  size_t aligned;
+  size_t bytes;
+  if (offset == NULL || start == NULL || alignment == 0 ||
+      (alignment & (alignment - 1)) != 0 ||
+      *offset > SIZE_MAX - (alignment - 1)) {
+    return 0;
+  }
+  aligned = (*offset + alignment - 1) & ~(alignment - 1);
+  if (!checked_multiply_size(count, item_size, &bytes) ||
+      !checked_add_size(aligned, bytes, offset)) {
+    return 0;
+  }
+  *start = aligned;
+  return 1;
+}
+
+static int finite_complex(double complex value) {
+  return isfinite(creal(value)) && isfinite(cimag(value));
+}
+
+static int exact_complex_zero(double complex value) {
+  return creal(value) == 0.0 && cimag(value) == 0.0;
+}
+
+static double wall_seconds(void) {
+  struct timespec now;
+  if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) return -1.0;
+  return (double)now.tv_sec + 1.0e-9 * (double)now.tv_nsec;
+}
+
+static double elapsed_seconds(double start) {
+  const double end = wall_seconds();
+  return start >= 0.0 && end >= start ? end - start : 0.0;
+}
+
+static int increment_u64(uint64_t *value) {
+  if (value == NULL || *value == UINT64_MAX) return 0;
+  ++(*value);
+  return 1;
+}
+
+static int add_u64(uint64_t *value, uint64_t increment) {
+  if (value == NULL || increment > UINT64_MAX - *value) return 0;
+  *value += increment;
+  return 1;
+}
+
+static uint64_t popcount_word(uint64_t value) {
+  uint64_t count = 0;
+  while (value != 0) {
+    value &= value - 1;
+    ++count;
+  }
+  return count;
+}
+
+static int configuration_bit(const uint64_t *words, size_t orbital) {
+  return (int)((words[orbital / 64] >> (orbital % 64)) & UINT64_C(1));
+}
+
+static void configuration_set_bit(uint64_t *words, size_t orbital,
+                                  int value) {
+  const uint64_t mask = UINT64_C(1) << (orbital % 64);
+  if (value) {
+    words[orbital / 64] |= mask;
+  } else {
+    words[orbital / 64] &= ~mask;
+  }
+}
+
+static int configuration_compare(const uint64_t *lhs, const uint64_t *rhs,
+                                 size_t word_count) {
+  size_t word;
+  for (word = 0; word < word_count; ++word) {
+    if (lhs[word] < rhs[word]) return -1;
+    if (lhs[word] > rhs[word]) return 1;
+  }
+  return 0;
+}
+
+static uint64_t configuration_hash(const uint64_t *words, size_t word_count,
+                                   int depth) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  size_t word;
+  hash ^= (uint64_t)(unsigned int)depth;
+  hash *= UINT64_C(1099511628211);
+  for (word = 0; word < word_count; ++word) {
+    uint64_t value = words[word];
+    int byte;
+    for (byte = 0; byte < 8; ++byte) {
+      hash ^= value & UINT64_C(0xff);
+      hash *= UINT64_C(1099511628211);
+      value >>= 8;
+    }
+  }
+  return hash;
+}
+
+static void hash_byte(uint64_t *hash, unsigned char value) {
+  *hash ^= (uint64_t)value;
+  *hash *= UINT64_C(1099511628211);
+}
+
+static void hash_u64(uint64_t *hash, uint64_t value) {
+  int byte;
+  for (byte = 0; byte < 8; ++byte) {
+    hash_byte(hash, (unsigned char)(value & UINT64_C(0xff)));
+    value >>= 8;
+  }
+}
+
+static uint64_t double_bits(double value) {
+  uint64_t bits;
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+static int term_compare_model(const MVMCKrylovFockModel *model,
+                              size_t lhs_index, size_t rhs_index) {
+  const MVMCKrylovHamiltonianTerm *lhs = &model->terms[lhs_index];
+  const MVMCKrylovHamiltonianTerm *rhs = &model->terms[rhs_index];
+  size_t operator_index;
+  if (lhs->operator_count < rhs->operator_count) return -1;
+  if (lhs->operator_count > rhs->operator_count) return 1;
+  for (operator_index = 0; operator_index < lhs->operator_count;
+       ++operator_index) {
+    const MVMCKrylovFermionOperator *lhs_operator =
+        &model->operators[lhs->operator_offset + operator_index];
+    const MVMCKrylovFermionOperator *rhs_operator =
+        &model->operators[rhs->operator_offset + operator_index];
+    if (lhs_operator->kind < rhs_operator->kind) return -1;
+    if (lhs_operator->kind > rhs_operator->kind) return 1;
+    if (lhs_operator->orbital < rhs_operator->orbital) return -1;
+    if (lhs_operator->orbital > rhs_operator->orbital) return 1;
+  }
+  if (double_bits(creal(lhs->coefficient)) <
+      double_bits(creal(rhs->coefficient))) {
+    return -1;
+  }
+  if (double_bits(creal(lhs->coefficient)) >
+      double_bits(creal(rhs->coefficient))) {
+    return 1;
+  }
+  if (double_bits(cimag(lhs->coefficient)) <
+      double_bits(cimag(rhs->coefficient))) {
+    return -1;
+  }
+  if (double_bits(cimag(lhs->coefficient)) >
+      double_bits(cimag(rhs->coefficient))) {
+    return 1;
+  }
+  if (lhs->source_kind < rhs->source_kind) return -1;
+  if (lhs->source_kind > rhs->source_kind) return 1;
+  if (lhs->source_index < rhs->source_index) return -1;
+  if (lhs->source_index > rhs->source_index) return 1;
+  return 0;
+}
+
+static MVMCKrylovStatus validate_model_only(
+    const MVMCKrylovFockModel *model) {
+  size_t term_index;
+  size_t orbital_count;
+  if (model == NULL || model->site_count == 0 ||
+      model->site_count > SIZE_MAX / 2 ||
+      model->up_electron_count > model->site_count ||
+      model->down_electron_count > model->site_count ||
+      (model->pure_spin != 0 && model->pure_spin != 1) ||
+      (model->pure_spin &&
+       model->up_electron_count + model->down_electron_count !=
+           model->site_count) ||
+      (model->term_count != 0 && model->terms == NULL) ||
+      (model->operator_count != 0 && model->operators == NULL)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (!model->hermitian) return MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL;
+  orbital_count = 2 * model->site_count;
+  for (term_index = 0; term_index < model->term_count; ++term_index) {
+    const MVMCKrylovHamiltonianTerm *term = &model->terms[term_index];
+    size_t operator_index;
+    if (!finite_complex(term->coefficient)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    if ((term->operator_count != 2 && term->operator_count != 4) ||
+        term->operator_offset > model->operator_count ||
+        term->operator_count > model->operator_count - term->operator_offset) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+    for (operator_index = 0; operator_index < term->operator_count;
+         ++operator_index) {
+      const MVMCKrylovFermionOperator *operator_item =
+          &model->operators[term->operator_offset + operator_index];
+      if ((operator_item->kind != MVMC_KRYLOV_FERMION_CREATE &&
+           operator_item->kind != MVMC_KRYLOV_FERMION_ANNIHILATE) ||
+          operator_item->orbital >= orbital_count) {
+        return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+      }
+    }
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static uint64_t plan_hash_value(const MVMCKrylovBoundedPlan *plan) {
+  uint64_t hash = UINT64_C(1469598103934665603);
+  size_t canonical_index;
+  hash_u64(&hash, (uint64_t)plan->model.site_count);
+  hash_u64(&hash, (uint64_t)plan->model.up_electron_count);
+  hash_u64(&hash, (uint64_t)plan->model.down_electron_count);
+  hash_u64(&hash, (uint64_t)(unsigned int)plan->model.pure_spin);
+  hash_u64(&hash, (uint64_t)(unsigned int)plan->model.hermitian);
+  hash_u64(&hash, (uint64_t)plan->model.term_count);
+  hash_u64(&hash, plan->limits.amplitude_policy_hash);
+  hash_u64(&hash, (uint64_t)plan->limits.cache_bytes);
+  hash_u64(&hash, (uint64_t)plan->limits.max_row_transitions);
+  hash_u64(&hash, (uint64_t)plan->limits.max_workspace_bytes);
+  hash_u64(&hash, plan->limits.max_node_expansions);
+  hash_u64(&hash, plan->limits.max_terminal_amplitude_calls);
+  hash_u64(&hash, plan->limits.max_total_row_transitions);
+  hash_u64(&hash, (uint64_t)(unsigned int)plan->limits.max_order);
+  for (canonical_index = 0; canonical_index < plan->model.term_count;
+       ++canonical_index) {
+    const MVMCKrylovHamiltonianTerm *term =
+        &plan->terms[plan->term_order[canonical_index]];
+    size_t operator_index;
+    hash_u64(&hash, double_bits(creal(term->coefficient)));
+    hash_u64(&hash, double_bits(cimag(term->coefficient)));
+    hash_u64(&hash, (uint64_t)term->operator_count);
+    hash_u64(&hash, (uint64_t)(uint32_t)term->source_kind);
+    hash_u64(&hash, (uint64_t)term->source_index);
+    for (operator_index = 0; operator_index < term->operator_count;
+         ++operator_index) {
+      const MVMCKrylovFermionOperator *operator_item =
+          &plan->operators[term->operator_offset + operator_index];
+      hash_u64(&hash, (uint64_t)(unsigned int)operator_item->kind);
+      hash_u64(&hash, (uint64_t)operator_item->orbital);
+    }
+  }
+  return hash;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_plan_create(
+    const MVMCKrylovFockModel *model,
+    const MVMCKrylovBoundedLimits *limits,
+    MVMCKrylovBoundedPlan **plan) {
+  MVMCKrylovBoundedPlan *created = NULL;
+  MVMCKrylovStatus status;
+  size_t term_bytes;
+  size_t operator_bytes;
+  size_t order_bytes;
+  size_t plan_bytes = sizeof(*created);
+  size_t max_row = 0;
+  size_t cache_entry_bytes;
+  size_t cache_word_bytes;
+  size_t index;
+  if (plan == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *plan = NULL;
+  status = validate_model_only(model);
+  if (status != MVMC_KRYLOV_STATUS_OK) return status;
+  if (limits == NULL || limits->max_order < 0 ||
+      limits->max_order > MVMC_KRYLOV_MAX_ORDER ||
+      limits->max_workspace_bytes == 0 ||
+      limits->max_node_expansions == 0 ||
+      limits->max_terminal_amplitude_calls == 0 ||
+      limits->max_total_row_transitions == 0 ||
+      !checked_multiply_size(model->term_count,
+                             sizeof(MVMCKrylovHamiltonianTerm), &term_bytes) ||
+      !checked_multiply_size(model->operator_count,
+                             sizeof(MVMCKrylovFermionOperator),
+                             &operator_bytes) ||
+      !checked_multiply_size(model->term_count, sizeof(size_t), &order_bytes) ||
+      !checked_add_size(plan_bytes, term_bytes, &plan_bytes) ||
+      !checked_add_size(plan_bytes, operator_bytes, &plan_bytes) ||
+      !checked_add_size(plan_bytes, order_bytes, &plan_bytes)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  for (index = 0; index < model->term_count; ++index) {
+    if (!exact_complex_zero(model->terms[index].coefficient)) ++max_row;
+  }
+  if (max_row > limits->max_row_transitions) {
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  created = (MVMCKrylovBoundedPlan *)calloc(1, sizeof(*created));
+  if (created == NULL) return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  if (model->term_count != 0) {
+    created->terms = (MVMCKrylovHamiltonianTerm *)malloc(term_bytes);
+    created->term_order = (size_t *)malloc(order_bytes);
+  }
+  if (model->operator_count != 0) {
+    created->operators = (MVMCKrylovFermionOperator *)malloc(operator_bytes);
+  }
+  if ((model->term_count != 0 &&
+       (created->terms == NULL || created->term_order == NULL)) ||
+      (model->operator_count != 0 && created->operators == NULL)) {
+    mvmc_bounded_krylov_plan_destroy(created);
+    return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  }
+  if (term_bytes != 0) memcpy(created->terms, model->terms, term_bytes);
+  if (operator_bytes != 0) {
+    memcpy(created->operators, model->operators, operator_bytes);
+  }
+  created->model = *model;
+  created->model.terms = created->terms;
+  created->model.operators = created->operators;
+  created->limits = *limits;
+  created->word_count = mvmc_krylov_fock_word_count(model->site_count);
+  created->orbital_count = 2 * model->site_count;
+  created->max_row_transitions = max_row;
+  created->plan_bytes = plan_bytes;
+  created->model_bytes = term_bytes + operator_bytes;
+  if (!checked_multiply_size(created->word_count, sizeof(uint64_t),
+                             &cache_word_bytes) ||
+      !checked_add_size(sizeof(MVMCBoundedCacheEntry), cache_word_bytes,
+                        &cache_entry_bytes) ||
+      !checked_multiply_size(MVMC_BOUNDED_KRYLOV_CACHE_WAYS,
+                             cache_entry_bytes,
+                             &created->cache_set_bytes)) {
+    mvmc_bounded_krylov_plan_destroy(created);
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  for (index = 0; index < model->term_count; ++index) {
+    size_t insertion = index;
+    const size_t value = index;
+    while (insertion > 0 &&
+           term_compare_model(&created->model, value,
+                              created->term_order[insertion - 1]) < 0) {
+      created->term_order[insertion] =
+          created->term_order[insertion - 1];
+      --insertion;
+    }
+    created->term_order[insertion] = value;
+  }
+  created->plan_hash = plan_hash_value(created);
+  *plan = created;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+void mvmc_bounded_krylov_plan_destroy(MVMCKrylovBoundedPlan *plan) {
+  if (plan == NULL) return;
+  free(plan->term_order);
+  free(plan->operators);
+  free(plan->terms);
+  free(plan);
+}
+
+size_t mvmc_bounded_krylov_plan_bytes(const MVMCKrylovBoundedPlan *plan) {
+  return plan == NULL ? 0 : plan->plan_bytes;
+}
+
+size_t mvmc_bounded_krylov_plan_model_bytes(
+    const MVMCKrylovBoundedPlan *plan) {
+  return plan == NULL ? 0 : plan->model_bytes;
+}
+
+size_t mvmc_bounded_krylov_plan_max_row_transitions(
+    const MVMCKrylovBoundedPlan *plan) {
+  return plan == NULL ? 0 : plan->max_row_transitions;
+}
+
+size_t mvmc_bounded_krylov_cache_set_bytes(
+    const MVMCKrylovBoundedPlan *plan) {
+  return plan == NULL ? 0 : plan->cache_set_bytes;
+}
+
+uint64_t mvmc_bounded_krylov_plan_hash(
+    const MVMCKrylovBoundedPlan *plan) {
+  return plan == NULL ? 0 : plan->plan_hash;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_workspace_create(
+    const MVMCKrylovBoundedPlan *plan,
+    MVMCKrylovBoundedWorkspace **workspace) {
+  MVMCKrylovBoundedWorkspace *created;
+  size_t offset = sizeof(MVMCKrylovBoundedWorkspace);
+  size_t neighbor_offset;
+  size_t neighbor_word_offset;
+  size_t contribution_offset;
+  size_t scratch_offset;
+  size_t cache_entry_offset;
+  size_t cache_word_offset;
+  size_t frame_slots;
+  size_t cache_slots;
+  size_t frame_words;
+  size_t cache_words;
+  size_t frame_bytes;
+  size_t scratch_bytes;
+  size_t cache_entry_bytes;
+  size_t cache_word_bytes;
+  size_t cache_allocated_bytes;
+  size_t set_count;
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *workspace = NULL;
+  if (plan == NULL || plan->cache_set_bytes == 0 ||
+      !checked_multiply_size((size_t)plan->limits.max_order + 1,
+                             plan->max_row_transitions, &frame_slots) ||
+      !checked_multiply_size(frame_slots, plan->word_count, &frame_words)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  set_count = plan->limits.cache_bytes / plan->cache_set_bytes;
+  if (!checked_multiply_size(set_count,
+                             MVMC_BOUNDED_KRYLOV_CACHE_WAYS,
+                             &cache_slots) ||
+      !checked_multiply_size(cache_slots, plan->word_count, &cache_words) ||
+      !checked_multiply_size(frame_slots, sizeof(MVMCBoundedNeighbor),
+                             &frame_bytes) ||
+      !checked_multiply_size(frame_words, sizeof(uint64_t), &scratch_bytes) ||
+      !checked_add_size(frame_bytes, scratch_bytes, &frame_bytes) ||
+      !checked_multiply_size(frame_slots, sizeof(MVMCScaledComplex),
+                             &scratch_bytes) ||
+      !checked_add_size(frame_bytes, scratch_bytes, &frame_bytes) ||
+      !checked_multiply_size(plan->word_count, sizeof(uint64_t),
+                             &scratch_bytes) ||
+      !checked_multiply_size(cache_slots, sizeof(MVMCBoundedCacheEntry),
+                             &cache_entry_bytes) ||
+      !checked_multiply_size(cache_words, sizeof(uint64_t),
+                             &cache_word_bytes) ||
+      !checked_add_size(cache_entry_bytes, cache_word_bytes,
+                        &cache_allocated_bytes) ||
+      !reserve_aligned(&offset, frame_slots, sizeof(MVMCBoundedNeighbor),
+                       _Alignof(MVMCBoundedNeighbor), &neighbor_offset) ||
+      !reserve_aligned(&offset, frame_words, sizeof(uint64_t),
+                       _Alignof(uint64_t), &neighbor_word_offset) ||
+      !reserve_aligned(&offset, frame_slots, sizeof(MVMCScaledComplex),
+                       _Alignof(MVMCScaledComplex), &contribution_offset) ||
+      !reserve_aligned(&offset, plan->word_count, sizeof(uint64_t),
+                       _Alignof(uint64_t), &scratch_offset) ||
+      !reserve_aligned(&offset, cache_slots, sizeof(MVMCBoundedCacheEntry),
+                       _Alignof(MVMCBoundedCacheEntry), &cache_entry_offset) ||
+      !reserve_aligned(&offset, cache_words, sizeof(uint64_t),
+                       _Alignof(uint64_t), &cache_word_offset)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (offset > plan->limits.max_workspace_bytes) {
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  created = (MVMCKrylovBoundedWorkspace *)calloc(1, offset);
+  if (created == NULL) return MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE;
+  created->plan = plan;
+  created->allocated_bytes = offset;
+  created->frame_bytes = frame_bytes;
+  created->scratch_bytes = scratch_bytes;
+  created->cache_allocated_bytes = cache_allocated_bytes;
+  created->cache_set_count = set_count;
+  created->neighbors = (MVMCBoundedNeighbor *)((unsigned char *)created +
+                                                neighbor_offset);
+  created->neighbor_words = (uint64_t *)((unsigned char *)created +
+                                         neighbor_word_offset);
+  created->contributions = (MVMCScaledComplex *)((unsigned char *)created +
+                                                  contribution_offset);
+  created->scratch_words = (uint64_t *)((unsigned char *)created +
+                                        scratch_offset);
+  created->cache_entries = (MVMCBoundedCacheEntry *)((unsigned char *)created +
+                                                      cache_entry_offset);
+  created->cache_words = (uint64_t *)((unsigned char *)created +
+                                      cache_word_offset);
+  *workspace = created;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+void mvmc_bounded_krylov_workspace_destroy(
+    MVMCKrylovBoundedWorkspace *workspace) {
+  free(workspace);
+}
+
+size_t mvmc_bounded_krylov_workspace_bytes(
+    const MVMCKrylovBoundedWorkspace *workspace) {
+  return workspace == NULL ? 0 : workspace->allocated_bytes;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_testing_force_cache_counters(
+    MVMCKrylovBoundedWorkspace *workspace,
+    uint64_t epoch, uint64_t access_counter) {
+  if (workspace == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  workspace->cache_epoch = epoch;
+  workspace->cache_access = access_counter;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static uint64_t count_occupied_before(const uint64_t *words,
+                                      size_t orbital) {
+  const size_t full_words = orbital / 64;
+  const size_t partial_bits = orbital % 64;
+  uint64_t count = 0;
+  size_t word;
+  for (word = 0; word < full_words; ++word) {
+    count += popcount_word(words[word]);
+  }
+  if (partial_bits != 0) {
+    const uint64_t mask = (UINT64_C(1) << partial_bits) - UINT64_C(1);
+    count += popcount_word(words[full_words] & mask);
+  }
+  return count;
+}
+
+static MVMCKrylovStatus validate_configuration_only(
+    const MVMCKrylovFockModel *model, const uint64_t *words,
+    size_t word_count) {
+  size_t site;
+  size_t up_count = 0;
+  size_t down_count = 0;
+  const size_t orbital_count = 2 * model->site_count;
+  const size_t used_bits = orbital_count % 64;
+  if (words == NULL || word_count != mvmc_krylov_fock_word_count(
+                                        model->site_count)) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  if (used_bits != 0) {
+    const uint64_t used_mask =
+        (UINT64_C(1) << used_bits) - UINT64_C(1);
+    if ((words[word_count - 1] & ~used_mask) != 0) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  for (site = 0; site < model->site_count; ++site) {
+    const int up = configuration_bit(words, site);
+    const int down = configuration_bit(words, site + model->site_count);
+    up_count += (size_t)up;
+    down_count += (size_t)down;
+    if (model->pure_spin && up + down != 1) {
+      return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+    }
+  }
+  if (up_count != model->up_electron_count ||
+      down_count != model->down_electron_count) {
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus apply_term(
+    const MVMCKrylovFockModel *model,
+    const MVMCKrylovHamiltonianTerm *term, const uint64_t *input,
+    size_t word_count, uint64_t *output, int *applied, int *fermion_sign) {
+  size_t reverse_index;
+  int sign = 1;
+  memcpy(output, input, word_count * sizeof(*output));
+  *applied = 0;
+  *fermion_sign = 1;
+  for (reverse_index = term->operator_count; reverse_index > 0;
+       --reverse_index) {
+    const MVMCKrylovFermionOperator *operator_item =
+        &model->operators[term->operator_offset + reverse_index - 1];
+    const int occupied = configuration_bit(output, operator_item->orbital);
+    if ((operator_item->kind == MVMC_KRYLOV_FERMION_CREATE && occupied) ||
+        (operator_item->kind == MVMC_KRYLOV_FERMION_ANNIHILATE &&
+         !occupied)) {
+      return MVMC_KRYLOV_STATUS_OK;
+    }
+    if ((count_occupied_before(output, operator_item->orbital) &
+         UINT64_C(1)) != 0) {
+      sign = -sign;
+    }
+    configuration_set_bit(
+        output, operator_item->orbital,
+        operator_item->kind == MVMC_KRYLOV_FERMION_CREATE);
+  }
+  if (validate_configuration_only(model, output, word_count) !=
+      MVMC_KRYLOV_STATUS_OK) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  *applied = 1;
+  *fermion_sign = sign;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static const uint64_t *neighbor_key(
+    const MVMCKrylovBoundedWorkspace *workspace,
+    const MVMCBoundedNeighbor *neighbor) {
+  return workspace->neighbor_words +
+         neighbor->key_index * workspace->plan->word_count;
+}
+
+static int neighbor_compare(const MVMCBoundedEvaluation *evaluation,
+                            const MVMCBoundedNeighbor *lhs,
+                            const MVMCBoundedNeighbor *rhs) {
+  const int key_order = configuration_compare(
+      neighbor_key(evaluation->workspace, lhs),
+      neighbor_key(evaluation->workspace, rhs),
+      evaluation->workspace->plan->word_count);
+  if (key_order != 0) return key_order;
+  if (lhs->canonical_term_index < rhs->canonical_term_index) return -1;
+  if (lhs->canonical_term_index > rhs->canonical_term_index) return 1;
+  return 0;
+}
+
+static void sort_neighbors(MVMCBoundedEvaluation *evaluation, size_t base,
+                           size_t count) {
+  size_t index;
+  for (index = 1; index < count; ++index) {
+    MVMCBoundedNeighbor value =
+        evaluation->workspace->neighbors[base + index];
+    size_t insertion = index;
+    while (insertion > 0 &&
+           neighbor_compare(evaluation, &value,
+                            &evaluation->workspace->neighbors[
+                                base + insertion - 1]) < 0) {
+      evaluation->workspace->neighbors[base + insertion] =
+          evaluation->workspace->neighbors[base + insertion - 1];
+      --insertion;
+    }
+    evaluation->workspace->neighbors[base + insertion] = value;
+  }
+}
+
+static void raw_accumulator_add_component(double value, double *sum,
+                                          double *compensation) {
+  const double updated = *sum + value;
+  if (fabs(*sum) >= fabs(value)) {
+    *compensation += (*sum - updated) + value;
+  } else {
+    *compensation += (value - updated) + *sum;
+  }
+  *sum = updated;
+}
+
+static int raw_accumulator_add(MVMCRawComplexAccumulator *accumulator,
+                               double complex value) {
+  if (accumulator == NULL || !finite_complex(value)) return 0;
+  raw_accumulator_add_component(creal(value), &accumulator->real_sum,
+                                &accumulator->real_compensation);
+  raw_accumulator_add_component(cimag(value), &accumulator->imag_sum,
+                                &accumulator->imag_compensation);
+  return isfinite(accumulator->real_sum) &&
+         isfinite(accumulator->real_compensation) &&
+         isfinite(accumulator->imag_sum) &&
+         isfinite(accumulator->imag_compensation);
+}
+
+static double complex raw_accumulator_value(
+    const MVMCRawComplexAccumulator *accumulator) {
+  return (accumulator->real_sum + accumulator->real_compensation) +
+         I * (accumulator->imag_sum + accumulator->imag_compensation);
+}
+
+static MVMCKrylovStatus merge_neighbors(MVMCBoundedEvaluation *evaluation,
+                                       size_t base, size_t raw_count,
+                                       size_t *merged_count) {
+  size_t read = 0;
+  size_t write = 0;
+  while (read < raw_count) {
+    MVMCRawComplexAccumulator accumulator;
+    MVMCBoundedNeighbor merged =
+        evaluation->workspace->neighbors[base + read];
+    size_t next = read + 1;
+    memset(&accumulator, 0, sizeof(accumulator));
+    if (!raw_accumulator_add(&accumulator, merged.row_weight)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    while (next < raw_count &&
+           configuration_compare(
+               neighbor_key(evaluation->workspace, &merged),
+               neighbor_key(evaluation->workspace,
+                            &evaluation->workspace->neighbors[base + next]),
+               evaluation->workspace->plan->word_count) == 0) {
+      if (!increment_u64(
+              &evaluation->statistics->merged_duplicate_transitions)) {
+        return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+      }
+      if (!raw_accumulator_add(
+              &accumulator,
+              evaluation->workspace->neighbors[base + next].row_weight)) {
+        return MVMC_KRYLOV_STATUS_NONFINITE;
+      }
+      ++next;
+    }
+    merged.row_weight = raw_accumulator_value(&accumulator);
+    if (!finite_complex(merged.row_weight)) {
+      return MVMC_KRYLOV_STATUS_NONFINITE;
+    }
+    if (exact_complex_zero(merged.row_weight)) {
+      if (!increment_u64(
+              &evaluation->statistics->cancelled_zero_transitions)) {
+        return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+      }
+    } else {
+      evaluation->workspace->neighbors[base + write] = merged;
+      ++write;
+    }
+    read = next;
+  }
+  *merged_count = write;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static int decompose_exact_coefficient(double complex coefficient,
+                                       MVMCScaledComplex *value) {
+  const double scale = fmax(fabs(creal(coefficient)),
+                            fabs(cimag(coefficient)));
+  double complex scaled;
+  double scaled_abs;
+  if (value == NULL || !finite_complex(coefficient)) return 0;
+  if (scale == 0.0) {
+    return mvmc_scaled_complex_make_exact_zero(value) ==
+           MVMC_PFAFFIAN_STATUS_OK;
+  }
+  scaled = (creal(coefficient) / scale) +
+           I * (cimag(coefficient) / scale);
+  scaled_abs = hypot(creal(scaled), cimag(scaled));
+  if (!isfinite(scaled_abs) || scaled_abs == 0.0) return 0;
+  return mvmc_scaled_complex_make_finite(
+             scaled / scaled_abs, log(scale) + log(scaled_abs),
+             -INFINITY, value) == MVMC_PFAFFIAN_STATUS_OK;
+}
+
+static void trace_event(MVMCBoundedEvaluation *evaluation, uint64_t tag,
+                        uint64_t first, uint64_t second) {
+  hash_u64(&evaluation->statistics->trace_hash, tag);
+  hash_u64(&evaluation->statistics->trace_hash, first);
+  hash_u64(&evaluation->statistics->trace_hash, second);
+}
+
+static MVMCKrylovStatus record_failure(
+    MVMCBoundedEvaluation *evaluation, MVMCKrylovStatus status,
+    int depth, const uint64_t *words) {
+  if (evaluation->failure->status == MVMC_KRYLOV_STATUS_OK) {
+    evaluation->failure->status = status;
+    evaluation->failure->depth = depth;
+    evaluation->failure->configuration_hash =
+        words == NULL
+            ? 0
+            : configuration_hash(words, evaluation->workspace->plan->word_count,
+                                 depth < 0 ? 0 : depth);
+  }
+  return status;
+}
+
+static uint64_t *cache_key(MVMCKrylovBoundedWorkspace *workspace,
+                           size_t slot) {
+  return workspace->cache_words + slot * workspace->plan->word_count;
+}
+
+static MVMCKrylovStatus next_cache_access(
+    MVMCKrylovBoundedWorkspace *workspace, uint64_t *access) {
+  if (workspace->cache_access == UINT64_MAX) {
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  ++workspace->cache_access;
+  *access = workspace->cache_access;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus cache_lookup(MVMCBoundedEvaluation *evaluation,
+                                    int depth, const uint64_t *words,
+                                    MVMCScaledComplex *value, int *hit) {
+  MVMCKrylovBoundedWorkspace *workspace = evaluation->workspace;
+  const uint64_t hash = configuration_hash(
+      words, workspace->plan->word_count, depth);
+  const double start = wall_seconds();
+  size_t way;
+  *hit = 0;
+  if (workspace->cache_set_count == 0) {
+    evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+    return MVMC_KRYLOV_STATUS_OK;
+  }
+  {
+    const size_t set = (size_t)(hash % workspace->cache_set_count);
+    const size_t base = set * MVMC_BOUNDED_KRYLOV_CACHE_WAYS;
+    for (way = 0; way < MVMC_BOUNDED_KRYLOV_CACHE_WAYS; ++way) {
+      const size_t slot = base + way;
+      MVMCBoundedCacheEntry *entry = &workspace->cache_entries[slot];
+      if (entry->epoch == workspace->cache_epoch &&
+          entry->hash == hash && entry->depth == depth &&
+          configuration_compare(cache_key(workspace, slot), words,
+                                workspace->plan->word_count) == 0) {
+        MVMCKrylovStatus status =
+            next_cache_access(workspace, &entry->access);
+        if (status != MVMC_KRYLOV_STATUS_OK) {
+          evaluation->statistics->cache_wall_seconds +=
+              elapsed_seconds(start);
+          return status;
+        }
+        *value = entry->value;
+        *hit = 1;
+        evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+        return MVMC_KRYLOV_STATUS_OK;
+      }
+    }
+  }
+  evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus cache_insert(MVMCBoundedEvaluation *evaluation,
+                                    int depth, const uint64_t *words,
+                                    const MVMCScaledComplex *value) {
+  MVMCKrylovBoundedWorkspace *workspace = evaluation->workspace;
+  const uint64_t hash = configuration_hash(
+      words, workspace->plan->word_count, depth);
+  const double start = wall_seconds();
+  size_t victim = 0;
+  size_t way;
+  uint64_t access;
+  int found_empty = 0;
+  if (workspace->cache_set_count == 0) {
+    evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+    return MVMC_KRYLOV_STATUS_OK;
+  }
+  {
+    const size_t set = (size_t)(hash % workspace->cache_set_count);
+    const size_t base = set * MVMC_BOUNDED_KRYLOV_CACHE_WAYS;
+    victim = base;
+    for (way = 0; way < MVMC_BOUNDED_KRYLOV_CACHE_WAYS; ++way) {
+      const size_t slot = base + way;
+      MVMCBoundedCacheEntry *entry = &workspace->cache_entries[slot];
+      if (entry->epoch != workspace->cache_epoch) {
+        victim = slot;
+        found_empty = 1;
+        break;
+      }
+      if (entry->access < workspace->cache_entries[victim].access) {
+        victim = slot;
+      }
+    }
+  }
+  if (next_cache_access(workspace, &access) != MVMC_KRYLOV_STATUS_OK) {
+    evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  if (!increment_u64(&evaluation->statistics->cache_insertions) ||
+      (!found_empty &&
+       !increment_u64(&evaluation->statistics->cache_evictions))) {
+    evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  if (found_empty) {
+    ++workspace->cache_live_count;
+    if (workspace->cache_live_count >
+        evaluation->statistics->cache_entries_peak) {
+      evaluation->statistics->cache_entries_peak =
+          workspace->cache_live_count;
+    }
+  }
+  workspace->cache_entries[victim].epoch = workspace->cache_epoch;
+  workspace->cache_entries[victim].access = access;
+  workspace->cache_entries[victim].hash = hash;
+  workspace->cache_entries[victim].depth = depth;
+  workspace->cache_entries[victim].value = *value;
+  memcpy(cache_key(workspace, victim), words,
+         workspace->plan->word_count * sizeof(*words));
+  evaluation->statistics->cache_wall_seconds += elapsed_seconds(start);
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus accumulate_amplitude_statistics(
+    MVMCBoundedEvaluation *evaluation,
+    const MVMCKrylovScaledAmplitudeResult *amplitude) {
+  if (!add_u64(&evaluation->statistics->well_pivoted_component_count,
+               amplitude->well_pivoted_component_count) ||
+      !add_u64(&evaluation->statistics->near_pivot_component_count,
+               amplitude->near_pivot_component_count) ||
+      !add_u64(&evaluation->statistics->exact_zero_component_count,
+               amplitude->exact_zero_component_count) ||
+      !add_u64(&evaluation->statistics->numeric_zero_component_count,
+               amplitude->numeric_zero_component_count) ||
+      !add_u64(&evaluation->statistics->local_factorization_count,
+               amplitude->local_factorization_count) ||
+      !add_u64(&evaluation->statistics->global_factorization_count,
+               amplitude->global_factorization_count)) {
+    return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus evaluate_node(MVMCBoundedEvaluation *evaluation,
+                                     int depth,
+                                     const uint64_t *configuration,
+                                     MVMCScaledComplex *value) {
+  MVMCKrylovBoundedWorkspace *workspace = evaluation->workspace;
+  const MVMCKrylovBoundedPlan *plan = workspace->plan;
+  MVMCKrylovStatus status;
+  int cache_hit = 0;
+  if (depth < 0 || depth > plan->limits.max_order ||
+      !increment_u64(&evaluation->statistics->recursion_calls[depth])) {
+    return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                          depth, configuration);
+  }
+  status = cache_lookup(evaluation, depth, configuration, value, &cache_hit);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    return record_failure(evaluation, status, depth, configuration);
+  }
+  if (cache_hit) {
+    if (!increment_u64(&evaluation->statistics->cache_hits[depth])) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                            depth, configuration);
+    }
+    trace_event(evaluation, UINT64_C(0x484954),
+                (uint64_t)(unsigned int)depth,
+                configuration_hash(configuration, plan->word_count, depth));
+    return MVMC_KRYLOV_STATUS_OK;
+  }
+  if (!increment_u64(&evaluation->statistics->cache_misses[depth]) ||
+      evaluation->statistics->node_expansions >=
+          plan->limits.max_node_expansions ||
+      !increment_u64(&evaluation->statistics->node_expansions)) {
+    return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                          depth, configuration);
+  }
+  trace_event(evaluation, UINT64_C(0x4d495353),
+              (uint64_t)(unsigned int)depth,
+              configuration_hash(configuration, plan->word_count, depth));
+
+  if (depth == 0) {
+    MVMCKrylovScaledAmplitudeResult amplitude;
+    const double start = wall_seconds();
+    if (evaluation->statistics->terminal_amplitude_calls >=
+            plan->limits.max_terminal_amplitude_calls ||
+        !increment_u64(
+            &evaluation->statistics->terminal_amplitude_calls)) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                            depth, configuration);
+    }
+    memset(&amplitude, 0, sizeof(amplitude));
+    status = evaluation->amplitude(configuration, plan->word_count,
+                                   evaluation->amplitude_context, &amplitude);
+    evaluation->statistics->amplitude_wall_seconds += elapsed_seconds(start);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      if (status < MVMC_KRYLOV_STATUS_INVALID_ARGUMENT ||
+          status > MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE) {
+        status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+      }
+      return record_failure(evaluation, status, depth, configuration);
+    }
+    if (!mvmc_scaled_complex_is_valid(&amplitude.value) ||
+        amplitude.value.state == MVMC_SCALED_COMPLEX_NONFINITE) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE,
+                            depth, configuration);
+    }
+    status = accumulate_amplitude_statistics(evaluation, &amplitude);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      return record_failure(evaluation, status, depth, configuration);
+    }
+    trace_event(evaluation, UINT64_C(0x414d50),
+                configuration_hash(configuration, plan->word_count, 0),
+                (uint64_t)amplitude.value.state);
+    *value = amplitude.value;
+  } else {
+    const size_t base = (size_t)depth * plan->max_row_transitions;
+    size_t raw_count = 0;
+    size_t merged_count = 0;
+    size_t canonical_index;
+    size_t neighbor_index;
+    const double connectivity_start = wall_seconds();
+    for (canonical_index = 0; canonical_index < plan->model.term_count;
+         ++canonical_index) {
+      const MVMCKrylovHamiltonianTerm *term =
+          &plan->terms[plan->term_order[canonical_index]];
+      MVMCBoundedNeighbor *neighbor;
+      int applied;
+      int fermion_sign;
+      if (exact_complex_zero(term->coefficient)) continue;
+      status = apply_term(&plan->model, term, configuration,
+                          plan->word_count, workspace->scratch_words,
+                          &applied, &fermion_sign);
+      if (status != MVMC_KRYLOV_STATUS_OK) {
+        return record_failure(evaluation, status, depth, configuration);
+      }
+      if (!applied) continue;
+      if (raw_count >= plan->max_row_transitions ||
+          evaluation->statistics->raw_row_transitions >=
+              plan->limits.max_total_row_transitions ||
+          !increment_u64(
+              &evaluation->statistics->raw_row_transitions)) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                              depth, configuration);
+      }
+      neighbor = &workspace->neighbors[base + raw_count];
+      neighbor->key_index = base + raw_count;
+      neighbor->canonical_term_index = canonical_index;
+      neighbor->row_weight = conj(term->coefficient * (double)fermion_sign);
+      if (!finite_complex(neighbor->row_weight)) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE,
+                              depth, configuration);
+      }
+      memcpy(workspace->neighbor_words +
+                 (base + raw_count) * plan->word_count,
+             workspace->scratch_words,
+             plan->word_count * sizeof(*workspace->scratch_words));
+      ++raw_count;
+    }
+    if (raw_count > evaluation->statistics->row_transition_peak) {
+      evaluation->statistics->row_transition_peak = raw_count;
+    }
+    sort_neighbors(evaluation, base, raw_count);
+    status = merge_neighbors(evaluation, base, raw_count, &merged_count);
+    evaluation->statistics->connectivity_wall_seconds +=
+        elapsed_seconds(connectivity_start);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      return record_failure(evaluation, status, depth, configuration);
+    }
+    trace_event(evaluation, UINT64_C(0x524f57),
+                configuration_hash(configuration, plan->word_count, depth),
+                (uint64_t)merged_count);
+    for (neighbor_index = 0; neighbor_index < merged_count;
+         ++neighbor_index) {
+      const MVMCBoundedNeighbor neighbor =
+          workspace->neighbors[base + neighbor_index];
+      const uint64_t *neighbor_configuration =
+          neighbor_key(workspace, &neighbor);
+      MVMCScaledComplex child;
+      MVMCScaledComplex row_weight;
+      status = evaluate_node(evaluation, depth - 1,
+                             neighbor_configuration, &child);
+      if (status != MVMC_KRYLOV_STATUS_OK) return status;
+      if (!decompose_exact_coefficient(neighbor.row_weight, &row_weight) ||
+          mvmc_scaled_complex_multiply(
+              &row_weight, &child,
+              &workspace->contributions[base + neighbor_index]) !=
+              MVMC_PFAFFIAN_STATUS_OK ||
+          workspace->contributions[base + neighbor_index].state ==
+              MVMC_SCALED_COMPLEX_NONFINITE) {
+        return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE,
+                              depth, configuration);
+      }
+    }
+    if (merged_count == 0) {
+      if (mvmc_scaled_complex_make_exact_zero(value) !=
+          MVMC_PFAFFIAN_STATUS_OK) {
+        return record_failure(evaluation,
+                              MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE,
+                              depth, configuration);
+      }
+    } else if (mvmc_scaled_complex_sum_ordered(
+                   workspace->contributions + base, merged_count, value) !=
+                   MVMC_PFAFFIAN_STATUS_OK ||
+               value->state == MVMC_SCALED_COMPLEX_NONFINITE) {
+      return record_failure(evaluation, MVMC_KRYLOV_STATUS_NONFINITE,
+                            depth, configuration);
+    }
+  }
+  if ((value->state == MVMC_SCALED_COMPLEX_EXACT_ZERO &&
+       !increment_u64(
+           &evaluation->statistics->computed_exact_zero_values)) ||
+      (value->state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+       !increment_u64(
+           &evaluation->statistics->computed_numeric_zero_values))) {
+    return record_failure(evaluation, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                          depth, configuration);
+  }
+  status = cache_insert(evaluation, depth, configuration, value);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    return record_failure(evaluation, status, depth, configuration);
+  }
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static void initialize_result(MVMCKrylovBoundedResult *result) {
+  int order;
+  memset(result, 0, sizeof(*result));
+  result->status = MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  result->evaluated_order = -1;
+  result->statistics.requested_order = -1;
+  result->statistics.completed_order = -1;
+  result->failure.status = MVMC_KRYLOV_STATUS_OK;
+  result->failure.depth = -1;
+  for (order = 0; order <= MVMC_KRYLOV_MAX_ORDER; ++order) {
+    (void)mvmc_scaled_complex_make_exact_zero(&result->value[order]);
+  }
+}
+
+static void invalidate_partial_values(MVMCKrylovBoundedResult *result,
+                                      MVMCKrylovStatus status) {
+  int order;
+  for (order = 0; order <= MVMC_KRYLOV_MAX_ORDER; ++order) {
+    (void)mvmc_scaled_complex_make_exact_zero(&result->value[order]);
+  }
+  result->valid = 0;
+  result->status = status;
+  result->evaluated_order = -1;
+  result->statistics.completed_order = -1;
+}
+
+static MVMCKrylovStatus reset_cache(MVMCBoundedEvaluation *evaluation) {
+  MVMCKrylovBoundedWorkspace *workspace = evaluation->workspace;
+  const double start = wall_seconds();
+  if (workspace->cache_epoch == UINT64_MAX) {
+    size_t cache_slots;
+    if (!checked_multiply_size(workspace->cache_set_count,
+                               MVMC_BOUNDED_KRYLOV_CACHE_WAYS,
+                               &cache_slots)) {
+      return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+    }
+    memset(workspace->cache_entries, 0,
+           cache_slots * sizeof(*workspace->cache_entries));
+    workspace->cache_epoch = 1;
+    if (!increment_u64(
+            &evaluation->statistics->cache_epoch_full_clears)) {
+      return MVMC_KRYLOV_STATUS_RESOURCE_LIMIT;
+    }
+  } else {
+    ++workspace->cache_epoch;
+    if (workspace->cache_epoch == 0) workspace->cache_epoch = 1;
+  }
+  workspace->cache_live_count = 0;
+  evaluation->statistics->reset_seconds += elapsed_seconds(start);
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+MVMCKrylovStatus mvmc_bounded_krylov_evaluate(
+    MVMCKrylovBoundedWorkspace *workspace,
+    const uint64_t *root_configuration_words, size_t root_word_count,
+    MVMCKrylovScaledAmplitudeCallback amplitude, void *amplitude_context,
+    MVMCKrylovBoundedResult *result) {
+  MVMCKrylovBoundedResult candidate;
+  MVMCBoundedEvaluation evaluation;
+  MVMCKrylovStatus status;
+  double total_start;
+  double evaluation_start;
+  int order;
+  size_t word;
+  if (result == NULL) return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  initialize_result(&candidate);
+  if (workspace == NULL || workspace->plan == NULL ||
+      root_configuration_words == NULL || amplitude == NULL ||
+      root_word_count != workspace->plan->word_count) {
+    *result = candidate;
+    return MVMC_KRYLOV_STATUS_INVALID_ARGUMENT;
+  }
+  status = validate_configuration_only(
+      &workspace->plan->model, root_configuration_words, root_word_count);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    candidate.status = status;
+    candidate.failure.status = status;
+    *result = candidate;
+    return status;
+  }
+  candidate.statistics.root_evaluations = 1;
+  candidate.statistics.requested_order = workspace->plan->limits.max_order;
+  candidate.statistics.plan_bytes = workspace->plan->plan_bytes;
+  candidate.statistics.model_bytes = workspace->plan->model_bytes;
+  candidate.statistics.workspace_bytes = workspace->allocated_bytes;
+  candidate.statistics.frame_bytes = workspace->frame_bytes;
+  candidate.statistics.scratch_bytes = workspace->scratch_bytes;
+  candidate.statistics.cache_requested_bytes =
+      workspace->plan->limits.cache_bytes;
+  candidate.statistics.cache_allocated_bytes =
+      workspace->cache_allocated_bytes;
+  candidate.statistics.cache_set_count = workspace->cache_set_count;
+  candidate.statistics.trace_hash = UINT64_C(1469598103934665603);
+  hash_u64(&candidate.statistics.trace_hash, workspace->plan->plan_hash);
+  for (word = 0; word < root_word_count; ++word) {
+    hash_u64(&candidate.statistics.trace_hash,
+             root_configuration_words[word]);
+  }
+  evaluation.workspace = workspace;
+  evaluation.amplitude = amplitude;
+  evaluation.amplitude_context = amplitude_context;
+  evaluation.statistics = &candidate.statistics;
+  evaluation.failure = &candidate.failure;
+  total_start = wall_seconds();
+  status = reset_cache(&evaluation);
+  if (status != MVMC_KRYLOV_STATUS_OK) {
+    candidate.failure.status = status;
+    candidate.failure.depth = -1;
+    invalidate_partial_values(&candidate, status);
+    candidate.statistics.total_seconds = elapsed_seconds(total_start);
+    *result = candidate;
+    return status;
+  }
+  evaluation_start = wall_seconds();
+  for (order = 0; order <= workspace->plan->limits.max_order; ++order) {
+    const double depth_start = wall_seconds();
+    status = evaluate_node(&evaluation, order, root_configuration_words,
+                           &candidate.value[order]);
+    candidate.statistics.depth_wall_seconds[order] =
+        elapsed_seconds(depth_start);
+    if (status != MVMC_KRYLOV_STATUS_OK) {
+      candidate.statistics.evaluation_wall_seconds =
+          elapsed_seconds(evaluation_start);
+      invalidate_partial_values(&candidate, status);
+      candidate.statistics.total_seconds = elapsed_seconds(total_start);
+      *result = candidate;
+      return status;
+    }
+    candidate.statistics.completed_order = order;
+  }
+  candidate.statistics.evaluation_wall_seconds =
+      elapsed_seconds(evaluation_start);
+  candidate.valid = 1;
+  candidate.status = MVMC_KRYLOV_STATUS_OK;
+  candidate.evaluated_order = workspace->plan->limits.max_order;
+  candidate.statistics.total_seconds = elapsed_seconds(total_start);
+  *result = candidate;
+  return MVMC_KRYLOV_STATUS_OK;
+}

--- a/src/mVMC/include/absolute_pfaffian.h
+++ b/src/mVMC/include/absolute_pfaffian.h
@@ -235,6 +235,7 @@ MVMCPfaffianStatus mvmc_scaled_complex_make_numeric_zero(
     double log_abs_error_bound, double max_input_log_abs,
     double cancellation_log_abs, double cancellation_ratio,
     MVMCScaledComplex *result);
+int mvmc_scaled_complex_is_valid(const MVMCScaledComplex *value);
 MVMCPfaffianStatus mvmc_scaled_complex_from_raw_testing(
     double complex value, MVMCScaledComplex *result);
 MVMCPfaffianStatus mvmc_scaled_complex_multiply(

--- a/src/mVMC/include/absolute_pfaffian.h
+++ b/src/mVMC/include/absolute_pfaffian.h
@@ -79,6 +79,57 @@ typedef struct MVMCAbsolutePfaffianRealValueWorkspace
 typedef struct MVMCAbsolutePfaffianComplexValueWorkspace
     MVMCAbsolutePfaffianComplexValueWorkspace;
 
+#if defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+/*
+ * Testing-gated P4 numeric core.  Production producers must retain the
+ * phase/log representation until the P4-C promotion gate has passed.
+ */
+typedef enum {
+  MVMC_SCALED_COMPLEX_FINITE_NONZERO = 0,
+  MVMC_SCALED_COMPLEX_EXACT_ZERO,
+  MVMC_SCALED_COMPLEX_NUMERIC_ZERO,
+  MVMC_SCALED_COMPLEX_NONFINITE
+} MVMCScaledComplexState;
+
+typedef enum {
+  MVMC_SCALED_EXPORT_OK = 0,
+  MVMC_SCALED_EXPORT_EXACT_ZERO,
+  MVMC_SCALED_EXPORT_NUMERIC_ZERO,
+  MVMC_SCALED_EXPORT_UNDERFLOW,
+  MVMC_SCALED_EXPORT_OVERFLOW,
+  MVMC_SCALED_EXPORT_NONFINITE,
+  MVMC_SCALED_EXPORT_INVALID
+} MVMCScaledComplexExportStatus;
+
+typedef struct {
+  MVMCScaledComplexState state;
+  double complex phase;
+  double log_abs;
+  double log_abs_error_bound;
+  double max_input_log_abs;
+  double cancellation_log_abs;
+  double cancellation_ratio;
+} MVMCScaledComplex;
+
+typedef struct {
+  MVMCPfaffianValueState factor_state;
+  int factor_info;
+  double matrix_scale;
+  double scaled_min_pivot;
+  MVMCScaledComplex value;
+} MVMCAbsolutePfaffianScaledValueResult;
+
+typedef struct {
+  int valid;
+  MVMCScaledComplex total;
+  double log_sum_abs;
+  size_t well_pivoted_count;
+  size_t near_pivot_count;
+  size_t exact_zero_count;
+  size_t numeric_zero_count;
+} MVMCProjectedScaledAmplitudeResult;
+#endif
+
 /*
  * Reusable factorization workspaces for sampler hot paths.  Creation may
  * allocate and query LAPACK/PFAPACK workspace sizes; evaluation with an
@@ -172,6 +223,59 @@ MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_value(
     const double complex *matrix, int n, int lda,
     double scaled_pivot_tolerance,
     MVMCAbsolutePfaffianValueResult *result);
+
+#if defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+/* Pure scaled-complex operations.  Error returns preserve *result. */
+MVMCPfaffianStatus mvmc_scaled_complex_make_finite(
+    double complex phase, double log_abs, double log_abs_error_bound,
+    MVMCScaledComplex *result);
+MVMCPfaffianStatus mvmc_scaled_complex_make_exact_zero(
+    MVMCScaledComplex *result);
+MVMCPfaffianStatus mvmc_scaled_complex_make_numeric_zero(
+    double log_abs_error_bound, double max_input_log_abs,
+    double cancellation_log_abs, double cancellation_ratio,
+    MVMCScaledComplex *result);
+MVMCPfaffianStatus mvmc_scaled_complex_from_raw_testing(
+    double complex value, MVMCScaledComplex *result);
+MVMCPfaffianStatus mvmc_scaled_complex_multiply(
+    const MVMCScaledComplex *left, const MVMCScaledComplex *right,
+    MVMCScaledComplex *result);
+MVMCPfaffianStatus mvmc_scaled_complex_sum_ordered(
+    const MVMCScaledComplex *values, size_t value_count,
+    MVMCScaledComplex *result);
+MVMCScaledComplexExportStatus mvmc_scaled_complex_export_common_scale(
+    const MVMCScaledComplex *value, double common_log_scale,
+    double complex *result);
+
+/* Value-only Pfaffian path that never forms the raw pivot product. */
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_scaled_value_with_workspace(
+    MVMCAbsolutePfaffianRealValueWorkspace *workspace,
+    const double *matrix, int n, int lda, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result);
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_scaled_value_with_workspace(
+    MVMCAbsolutePfaffianComplexValueWorkspace *workspace,
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result);
+MVMCPfaffianStatus mvmc_absolute_pfaffian_real_scaled_value(
+    const double *matrix, int n, int lda, double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result);
+MVMCPfaffianStatus mvmc_absolute_pfaffian_complex_scaled_value(
+    const double complex *matrix, int n, int lda,
+    double scaled_pivot_tolerance,
+    MVMCAbsolutePfaffianScaledValueResult *result);
+
+/* Canonical global-QP ordered aggregation and its rank-local slice form. */
+MVMCPfaffianStatus mvmc_projected_scaled_amplitude_values(
+    const MVMCAbsolutePfaffianScaledValueResult *components,
+    const double complex *weights, size_t component_count,
+    MVMCProjectedScaledAmplitudeResult *result);
+MVMCPfaffianStatus mvmc_projected_scaled_amplitude_value_slice(
+    const MVMCAbsolutePfaffianScaledValueResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCProjectedScaledAmplitudeResult *result);
+#endif
 
 /*
  * Sum QPFullWeight[q] * PfM[q] without consulting inverse availability.

--- a/src/mVMC/include/bounded_krylov_collective.h
+++ b/src/mVMC/include/bounded_krylov_collective.h
@@ -1,0 +1,108 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_BOUNDED_KRYLOV_COLLECTIVE_H
+#define MVMC_BOUNDED_KRYLOV_COLLECTIVE_H
+
+#if defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+
+#include "bounded_krylov_engine.h"
+
+#ifdef _mpi_use
+#include <mpi.h>
+typedef MPI_Comm MVMCKrylovBoundedCommunicator;
+#else
+typedef int MVMCKrylovBoundedCommunicator;
+#endif
+
+typedef struct MVMCKrylovBoundedCollectiveWorkspace
+    MVMCKrylovBoundedCollectiveWorkspace;
+
+typedef struct {
+  int valid;
+  MVMCKrylovStatus status;
+  int failure_rank;
+  uint64_t plan_hash;
+} MVMCKrylovBoundedCollectiveResult;
+
+/*
+ * Creation is collective.  The communicator is duplicated and all buffers
+ * for QP gathers and rank-ordered accumulator merges are allocated here.
+ * Calls using the workspace allocate no memory.  Every later collective call
+ * requires a valid workspace on every rank and the same call order.
+ */
+MVMCKrylovStatus mvmc_bounded_krylov_collective_workspace_create(
+    MVMCKrylovBoundedCommunicator communicator,
+    size_t max_qp_components, size_t max_accumulator_count,
+    MVMCKrylovBoundedCollectiveWorkspace **workspace);
+void mvmc_bounded_krylov_collective_workspace_destroy(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace);
+size_t mvmc_bounded_krylov_collective_workspace_bytes(
+    const MVMCKrylovBoundedCollectiveWorkspace *workspace);
+
+/*
+ * Synchronize plan identity, allocation readiness, and a local evaluation or
+ * callback status.  The highest enum severity wins; ties use the lowest rank.
+ * A plan mismatch is INTERNAL_INVARIANT_FAILURE.  All ranks receive the same
+ * status and failure rank.
+ */
+MVMCKrylovStatus mvmc_bounded_krylov_collective_synchronize(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status, uint64_t local_plan_hash,
+    int local_allocation_ok, MVMCKrylovBoundedCollectiveResult *result);
+
+MVMCKrylovStatus mvmc_bounded_krylov_collective_max_u64(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    uint64_t local_value, uint64_t *global_maximum);
+
+/*
+ * Gather a rank-ordered contiguous partition [0, qp_total) into global QP
+ * order.  Empty local slices are valid.  global_components is committed only
+ * after every rank, range, and scaled component has passed validation.
+ */
+MVMCKrylovStatus mvmc_bounded_krylov_collective_gather_scaled_components(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status,
+    const MVMCAbsolutePfaffianScaledValueResult *local_components,
+    size_t local_component_count, int qp_total, int qp_start, int qp_end,
+    MVMCAbsolutePfaffianScaledValueResult *global_components,
+    MVMCKrylovBoundedCollectiveResult *result);
+
+/*
+ * Allocation-free global-QP projection for terminal-amplitude callbacks.
+ * The weight array must be replicated; an exact stable-hash audit rejects a
+ * mismatch before gathering.  The returned amplitude is committed only on
+ * collective success.
+ */
+MVMCKrylovStatus
+mvmc_bounded_krylov_collective_gather_projected_amplitude(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status,
+    const MVMCAbsolutePfaffianScaledValueResult *local_components,
+    size_t local_component_count, const double complex *global_weights,
+    int qp_total, int qp_start, int qp_end,
+    MVMCKrylovScaledAmplitudeResult *amplitude,
+    MVMCKrylovBoundedCollectiveResult *result);
+
+/*
+ * Merge one equal-length scaled accumulator array per rank.  For every array
+ * index, operands are summed in increasing communicator-rank order.  Output
+ * is transactional and identical on all ranks.
+ */
+MVMCKrylovStatus mvmc_bounded_krylov_collective_merge_scaled_accumulators(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace,
+    MVMCKrylovStatus local_status,
+    const MVMCScaledComplex *local_values, size_t value_count,
+    MVMCScaledComplex *global_values,
+    MVMCKrylovBoundedCollectiveResult *result);
+
+#endif /* MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE */
+
+#endif /* MVMC_BOUNDED_KRYLOV_COLLECTIVE_H */

--- a/src/mVMC/include/bounded_krylov_engine.h
+++ b/src/mVMC/include/bounded_krylov_engine.h
@@ -1,0 +1,153 @@
+/*
+mVMC - A numerical solver package for a wide range of quantum lattice models
+Copyright (C) 2016 The University of Tokyo, All rights reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+#ifndef MVMC_BOUNDED_KRYLOV_ENGINE_H
+#define MVMC_BOUNDED_KRYLOV_ENGINE_H
+
+#if defined(MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+
+#include "absolute_pfaffian.h"
+#include "krylov_fock_reference.h"
+
+#include <complex.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define MVMC_BOUNDED_KRYLOV_CACHE_WAYS 4
+
+typedef struct {
+  uint64_t amplitude_policy_hash;
+  size_t cache_bytes;
+  size_t max_row_transitions;
+  size_t max_workspace_bytes;
+  uint64_t max_node_expansions;
+  uint64_t max_terminal_amplitude_calls;
+  uint64_t max_total_row_transitions;
+  int max_order;
+} MVMCKrylovBoundedLimits;
+
+typedef struct {
+  MVMCScaledComplex value;
+  uint64_t well_pivoted_component_count;
+  uint64_t near_pivot_component_count;
+  uint64_t exact_zero_component_count;
+  uint64_t numeric_zero_component_count;
+  uint64_t local_factorization_count;
+  uint64_t global_factorization_count;
+} MVMCKrylovScaledAmplitudeResult;
+
+typedef MVMCKrylovStatus (*MVMCKrylovScaledAmplitudeCallback)(
+    const uint64_t *configuration_words, size_t word_count,
+    void *context, MVMCKrylovScaledAmplitudeResult *result);
+
+typedef struct {
+  uint64_t root_evaluations;
+  int requested_order;
+  int completed_order;
+  uint64_t node_expansions;
+  uint64_t recursion_calls[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t cache_hits[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t cache_misses[MVMC_KRYLOV_MAX_ORDER + 1];
+  uint64_t cache_insertions;
+  uint64_t cache_evictions;
+  uint64_t cache_epoch_full_clears;
+  uint64_t raw_row_transitions;
+  uint64_t merged_duplicate_transitions;
+  uint64_t cancelled_zero_transitions;
+  uint64_t terminal_amplitude_calls;
+  uint64_t well_pivoted_component_count;
+  uint64_t near_pivot_component_count;
+  uint64_t exact_zero_component_count;
+  uint64_t numeric_zero_component_count;
+  uint64_t local_factorization_count;
+  uint64_t global_factorization_count;
+  uint64_t computed_exact_zero_values;
+  uint64_t computed_numeric_zero_values;
+  uint64_t trace_hash;
+  size_t row_transition_peak;
+  size_t cache_entries_peak;
+  size_t plan_bytes;
+  size_t model_bytes;
+  size_t workspace_bytes;
+  size_t frame_bytes;
+  size_t scratch_bytes;
+  size_t cache_requested_bytes;
+  size_t cache_allocated_bytes;
+  size_t cache_set_count;
+  uint64_t engine_heap_allocations;
+  double reset_seconds;
+  double total_seconds;
+  double evaluation_wall_seconds;
+  double depth_wall_seconds[MVMC_KRYLOV_MAX_ORDER + 1];
+  double amplitude_wall_seconds;
+  double connectivity_wall_seconds;
+  double cache_wall_seconds;
+} MVMCKrylovBoundedStatistics;
+
+typedef struct {
+  MVMCKrylovStatus status;
+  int depth;
+  uint64_t configuration_hash;
+} MVMCKrylovBoundedFailure;
+
+typedef struct {
+  int valid;
+  MVMCKrylovStatus status;
+  int evaluated_order;
+  MVMCScaledComplex value[MVMC_KRYLOV_MAX_ORDER + 1];
+  MVMCKrylovBoundedStatistics statistics;
+  MVMCKrylovBoundedFailure failure;
+} MVMCKrylovBoundedResult;
+
+typedef struct MVMCKrylovBoundedPlan MVMCKrylovBoundedPlan;
+typedef struct MVMCKrylovBoundedWorkspace MVMCKrylovBoundedWorkspace;
+
+MVMCKrylovStatus mvmc_bounded_krylov_plan_create(
+    const MVMCKrylovFockModel *model,
+    const MVMCKrylovBoundedLimits *limits,
+    MVMCKrylovBoundedPlan **plan);
+void mvmc_bounded_krylov_plan_destroy(MVMCKrylovBoundedPlan *plan);
+size_t mvmc_bounded_krylov_plan_bytes(const MVMCKrylovBoundedPlan *plan);
+size_t mvmc_bounded_krylov_plan_model_bytes(
+    const MVMCKrylovBoundedPlan *plan);
+size_t mvmc_bounded_krylov_plan_max_row_transitions(
+    const MVMCKrylovBoundedPlan *plan);
+size_t mvmc_bounded_krylov_cache_set_bytes(
+    const MVMCKrylovBoundedPlan *plan);
+uint64_t mvmc_bounded_krylov_plan_hash(
+    const MVMCKrylovBoundedPlan *plan);
+
+MVMCKrylovStatus mvmc_bounded_krylov_workspace_create(
+    const MVMCKrylovBoundedPlan *plan,
+    MVMCKrylovBoundedWorkspace **workspace);
+void mvmc_bounded_krylov_workspace_destroy(
+    MVMCKrylovBoundedWorkspace *workspace);
+size_t mvmc_bounded_krylov_workspace_bytes(
+    const MVMCKrylovBoundedWorkspace *workspace);
+
+/*
+ * Success commits v[0..max_order].  Failure commits an invalid diagnostic
+ * snapshot whose value array is sanitized to exact zero; no completed prefix
+ * is exposed as a mathematical result.
+ */
+MVMCKrylovStatus mvmc_bounded_krylov_evaluate(
+    MVMCKrylovBoundedWorkspace *workspace,
+    const uint64_t *root_configuration_words, size_t root_word_count,
+    MVMCKrylovScaledAmplitudeCallback amplitude, void *amplitude_context,
+    MVMCKrylovBoundedResult *result);
+
+/* Testing hooks for deterministic wrap and failure fixtures. */
+MVMCKrylovStatus mvmc_bounded_krylov_testing_force_cache_counters(
+    MVMCKrylovBoundedWorkspace *workspace,
+    uint64_t epoch, uint64_t access_counter);
+
+#endif /* MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE */
+
+#endif /* MVMC_BOUNDED_KRYLOV_ENGINE_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,6 +68,39 @@ if(MPI_FOUND)
                 ${MPIEXEC_POSTFLAGS})
 endif()
 
+add_executable(scaled_pfaffian_unit
+    scaled_pfaffian_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(scaled_pfaffian_unit PRIVATE
+    MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+target_include_directories(scaled_pfaffian_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(scaled_pfaffian_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(scaled_pfaffian_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(Require_BLIS)
+    target_link_libraries(scaled_pfaffian_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(scaled_pfaffian_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME ScaledPfaffian_Unit COMMAND scaled_pfaffian_unit)
+if(MPI_FOUND)
+    add_test(NAME ScaledPfaffian_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS} $<TARGET_FILE:scaled_pfaffian_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME ScaledPfaffian_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS} $<TARGET_FILE:scaled_pfaffian_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(ScaledPfaffian_Unit_Rank2_mpi PROPERTIES PROCESSORS 2)
+    set_tests_properties(ScaledPfaffian_Unit_Rank4_mpi PROPERTIES PROCESSORS 4)
+endif()
+
 add_executable(classic_pfaffian_state_unit
     classic_pfaffian_state_unit.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/classic_pfaffian_matrix.c

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -239,6 +239,136 @@ target_link_libraries(absolute_krylov_reference_unit m)
 add_test(NAME AbsoluteKrylovReference_Unit
     COMMAND absolute_krylov_reference_unit)
 
+add_executable(bounded_krylov_engine_unit
+    bounded_krylov_engine_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/bounded_krylov_engine.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(bounded_krylov_engine_unit PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE
+    MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+target_include_directories(bounded_krylov_engine_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(bounded_krylov_engine_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(bounded_krylov_engine_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(bounded_krylov_engine_unit stdc++)
+endif()
+if(Require_BLIS)
+    target_link_libraries(bounded_krylov_engine_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(bounded_krylov_engine_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME BoundedKrylovEngine_Unit
+    COMMAND bounded_krylov_engine_unit)
+if(MPI_FOUND)
+    add_test(NAME BoundedKrylovEngine_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS} $<TARGET_FILE:bounded_krylov_engine_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME BoundedKrylovEngine_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS} $<TARGET_FILE:bounded_krylov_engine_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(BoundedKrylovEngine_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(BoundedKrylovEngine_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
+
+add_executable(bounded_krylov_collective_unit
+    bounded_krylov_collective_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/bounded_krylov_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(bounded_krylov_collective_unit PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE
+    MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+target_include_directories(bounded_krylov_collective_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(bounded_krylov_collective_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(bounded_krylov_collective_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(bounded_krylov_collective_unit stdc++)
+endif()
+if(Require_BLIS)
+    target_link_libraries(bounded_krylov_collective_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(bounded_krylov_collective_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME BoundedKrylovCollective_Unit
+    COMMAND bounded_krylov_collective_unit)
+if(MPI_FOUND)
+    add_test(NAME BoundedKrylovCollective_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:bounded_krylov_collective_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME BoundedKrylovCollective_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:bounded_krylov_collective_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(BoundedKrylovCollective_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(BoundedKrylovCollective_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
+
+add_executable(bounded_krylov_integration_unit
+    bounded_krylov_integration_unit.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/bounded_krylov_engine.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/bounded_krylov_collective.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c
+    ${CMAKE_SOURCE_DIR}/src/mVMC/absolute_pfaffian.c)
+target_compile_definitions(bounded_krylov_integration_unit PRIVATE
+    MVMC_ENABLE_ABSOLUTE_KRYLOV_REFERENCE
+    MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE)
+target_include_directories(bounded_krylov_integration_unit PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/mVMC/include)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(bounded_krylov_integration_unit PRIVATE
+        -Wall -Wextra -Wpedantic -Werror)
+endif()
+target_link_libraries(bounded_krylov_integration_unit pfapack ltl2inv
+    ${LAPACK_LIBRARIES} m)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(bounded_krylov_integration_unit stdc++)
+endif()
+if(Require_BLIS)
+    target_link_libraries(bounded_krylov_integration_unit blis pthread)
+endif()
+if(MPI_FOUND)
+    target_link_libraries(bounded_krylov_integration_unit ${MPI_C_LIBRARIES})
+endif()
+add_test(NAME BoundedKrylovIntegration_Unit
+    COMMAND bounded_krylov_integration_unit)
+if(MPI_FOUND)
+    add_test(NAME BoundedKrylovIntegration_Unit_Rank2_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:bounded_krylov_integration_unit>
+                ${MPIEXEC_POSTFLAGS})
+    add_test(NAME BoundedKrylovIntegration_Unit_Rank4_mpi
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4
+                ${MPIEXEC_PREFLAGS}
+                $<TARGET_FILE:bounded_krylov_integration_unit>
+                ${MPIEXEC_POSTFLAGS})
+    set_tests_properties(BoundedKrylovIntegration_Unit_Rank2_mpi PROPERTIES
+        PROCESSORS 2)
+    set_tests_properties(BoundedKrylovIntegration_Unit_Rank4_mpi PROPERTIES
+        PROCESSORS 4)
+endif()
+
 add_executable(classic_krylov_amplitude_unit
     classic_krylov_amplitude_unit.c
     ${CMAKE_SOURCE_DIR}/src/mVMC/krylov_fock_reference.c

--- a/test/absolute_krylov_reference_unit.c
+++ b/test/absolute_krylov_reference_unit.c
@@ -676,6 +676,19 @@ static void TestFailuresAndLimits(void) {
   {
     MVMCKrylovHamiltonianTerm invalid_terms[2];
     memcpy(invalid_terms, terms, sizeof(invalid_terms));
+    invalid_terms[0].operator_count = 3;
+    model.terms = invalid_terms;
+    status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "odd fermion operator count accepted");
+    CheckAtomicFailure(&result, MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+                       "odd operator count");
+    model.terms = terms;
+  }
+
+  {
+    MVMCKrylovHamiltonianTerm invalid_terms[2];
+    memcpy(invalid_terms, terms, sizeof(invalid_terms));
     invalid_terms[0].coefficient = NAN + 0.0 * I;
     model.terms = invalid_terms;
     status = Evaluate(&model, UINT64_C(1), &limits, &amplitude, &result);

--- a/test/absolute_pfaffian_unit.c
+++ b/test/absolute_pfaffian_unit.c
@@ -703,6 +703,26 @@ static void test_value_only_api(void) {
             MVMC_PFAFFIAN_STATUS_OK &&
             value.pfaffian == full.pfaffian,
         "value-only real workspace reuse second evaluation");
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, NULL, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only real null matrix fails atomically");
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, 2, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only real workspace dimension mismatch fails atomically");
+  CHECK(mvmc_absolute_pfaffian_real_value_with_workspace(
+            real_workspace, matrix, n, n - 1, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only real bad leading dimension fails atomically");
+  CHECK(mvmc_absolute_pfaffian_real_value(
+            matrix, INT_MAX - 1, INT_MAX - 1, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only real overflowing matrix extent fails atomically");
 
   memset(matrix, 0, sizeof(matrix));
   set_real_pair(matrix, n, 0, 1, 1.0);
@@ -752,6 +772,26 @@ static void test_value_only_api(void) {
             value.state == MVMC_PFAFFIAN_VALUE_WELL_PIVOTED &&
             close_complex(value.pfaffian, full.pfaffian, 1.0e-15),
         "value-only complex phase matches full P1");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, NULL, n, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only complex null matrix fails atomically");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, 2, n, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only complex workspace dimension mismatch fails atomically");
+  CHECK(mvmc_absolute_pfaffian_complex_value_with_workspace(
+            complex_workspace, complex_matrix, n, n - 1, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only complex bad leading dimension fails atomically");
+  CHECK(mvmc_absolute_pfaffian_complex_value(
+            complex_matrix, INT_MAX - 1, INT_MAX - 1, 0.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            value.state == MVMC_PFAFFIAN_VALUE_INVALID,
+        "value-only complex overflowing matrix extent fails atomically");
   memset(complex_matrix, 0, sizeof(complex_matrix));
   set_complex_pair(complex_matrix, n, 0, 1, 1.0 + I);
   set_complex_pair(complex_matrix, n, 2, 3, 1.0e-15 - 0.5e-15 * I);

--- a/test/bounded_krylov_collective_unit.c
+++ b/test/bounded_krylov_collective_unit.c
@@ -1,0 +1,533 @@
+#include "bounded_krylov_collective.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failures = 0;
+static int world_rank = 0;
+static int world_size = 1;
+
+#define CHECK(condition, ...)                                                   \
+  do {                                                                          \
+    if (!(condition)) {                                                         \
+      fprintf(stderr, "BoundedKrylovCollective_Unit FAIL rank %d: ",          \
+              world_rank);                                                      \
+      fprintf(stderr, __VA_ARGS__);                                             \
+      fprintf(stderr, " (line %d)\n", __LINE__);                              \
+      ++failures;                                                               \
+    }                                                                           \
+  } while (0)
+
+static MVMCScaledComplex finite_value(double complex raw) {
+  MVMCScaledComplex value;
+  memset(&value, 0, sizeof(value));
+  CHECK(creal(raw) != 0.0 || cimag(raw) != 0.0,
+        "finite fixture cannot import raw zero");
+  CHECK(mvmc_scaled_complex_from_raw_testing(raw, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            value.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO,
+        "finite scaled fixture construction failed");
+  return value;
+}
+
+static MVMCAbsolutePfaffianScaledValueResult component_value(
+    double complex raw) {
+  MVMCAbsolutePfaffianScaledValueResult component;
+  memset(&component, 0, sizeof(component));
+  component.matrix_scale = 1.0;
+  component.scaled_min_pivot = 0.5;
+  if (creal(raw) == 0.0 && cimag(raw) == 0.0) {
+    component.factor_state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+    component.factor_info = 1;
+    CHECK(mvmc_scaled_complex_make_exact_zero(&component.value) ==
+              MVMC_PFAFFIAN_STATUS_OK,
+          "exact-zero component construction failed");
+  } else {
+    component.factor_state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+    component.value = finite_value(raw);
+  }
+  return component;
+}
+
+static int scaled_fields_bitwise_equal(const MVMCScaledComplex *left,
+                                       const MVMCScaledComplex *right) {
+  return left->state == right->state &&
+         memcmp(&left->phase, &right->phase, sizeof(left->phase)) == 0 &&
+         memcmp(&left->log_abs, &right->log_abs,
+                sizeof(left->log_abs)) == 0 &&
+         memcmp(&left->log_abs_error_bound, &right->log_abs_error_bound,
+                sizeof(left->log_abs_error_bound)) == 0 &&
+         memcmp(&left->max_input_log_abs, &right->max_input_log_abs,
+                sizeof(left->max_input_log_abs)) == 0 &&
+         memcmp(&left->cancellation_log_abs,
+                &right->cancellation_log_abs,
+                sizeof(left->cancellation_log_abs)) == 0 &&
+         memcmp(&left->cancellation_ratio, &right->cancellation_ratio,
+                sizeof(left->cancellation_ratio)) == 0;
+}
+
+static int component_fields_bitwise_equal(
+    const MVMCAbsolutePfaffianScaledValueResult *left,
+    const MVMCAbsolutePfaffianScaledValueResult *right) {
+  return left->factor_state == right->factor_state &&
+         left->factor_info == right->factor_info &&
+         memcmp(&left->matrix_scale, &right->matrix_scale,
+                sizeof(left->matrix_scale)) == 0 &&
+         memcmp(&left->scaled_min_pivot, &right->scaled_min_pivot,
+                sizeof(left->scaled_min_pivot)) == 0 &&
+         scaled_fields_bitwise_equal(&left->value, &right->value);
+}
+
+static void rank_partition(int total, int rank, int size,
+                           int *start, int *end) {
+  *start = total * rank / size;
+  *end = total * (rank + 1) / size;
+}
+
+static void test_workspace_creation(void) {
+  MVMCKrylovBoundedCollectiveWorkspace *workspace = NULL;
+  MVMCKrylovStatus status;
+#ifdef _mpi_use
+  const size_t mismatched = world_rank == world_size - 1 ? 5U : 4U;
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      MPI_COMM_WORLD, mismatched, 3, &workspace);
+  if (world_size > 1) {
+    CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+          "rank-mismatched creation capacity was accepted");
+  } else {
+    CHECK(status == MVMC_KRYLOV_STATUS_OK && workspace != NULL,
+          "single-rank creation fixture failed");
+    mvmc_bounded_krylov_collective_workspace_destroy(workspace);
+    workspace = NULL;
+  }
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      MPI_COMM_WORLD, SIZE_MAX, 3, &workspace);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "overflowing QP capacity was accepted");
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      MPI_COMM_WORLD, 4, SIZE_MAX, &workspace);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "overflowing accumulator capacity was accepted");
+#else
+  status = mvmc_bounded_krylov_collective_workspace_create(0, 0, 3,
+                                                            &workspace);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "zero QP capacity was accepted");
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      0, SIZE_MAX, 3, &workspace);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "overflowing QP capacity was accepted");
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      0, 4, SIZE_MAX, &workspace);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "overflowing accumulator capacity was accepted");
+#endif
+}
+
+static void test_synchronize(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  const int target = world_size - 1;
+  const uint64_t hash = UINT64_C(0x123456789abcdef0);
+  MVMCKrylovBoundedCollectiveResult result;
+  MVMCKrylovStatus status;
+  status = mvmc_bounded_krylov_collective_synchronize(
+      workspace, MVMC_KRYLOV_STATUS_OK, hash, 1, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+            result.failure_rank == -1 && result.plan_hash == hash,
+        "equal plan synchronization failed");
+
+  status = mvmc_bounded_krylov_collective_synchronize(
+      workspace, MVMC_KRYLOV_STATUS_OK,
+      world_rank == target && world_size > 1 ? hash + 1 : hash, 1, &result);
+  if (world_size > 1) {
+    CHECK(status == MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE &&
+              !result.valid && result.failure_rank == target,
+          "bad plan hash was not propagated from target rank");
+  } else {
+    CHECK(status == MVMC_KRYLOV_STATUS_OK,
+          "single-rank plan hash synchronization failed");
+  }
+
+  status = mvmc_bounded_krylov_collective_synchronize(
+      workspace, MVMC_KRYLOV_STATUS_OK, hash,
+      world_rank == target ? 0 : 1, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_ALLOCATION_FAILURE &&
+            result.failure_rank == target,
+        "one-rank allocation failure did not propagate");
+
+  status = mvmc_bounded_krylov_collective_synchronize(
+      workspace, MVMC_KRYLOV_STATUS_OK, hash,
+      world_rank == target ? 2 : 1, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            result.failure_rank == target,
+        "one-rank invalid allocation flag did not remain collective");
+
+  status = mvmc_bounded_krylov_collective_synchronize(
+      workspace,
+      world_rank == target ? MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE
+                           : MVMC_KRYLOV_STATUS_OK,
+      hash, 1, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE &&
+            result.failure_rank == target,
+        "one-rank callback failure did not propagate");
+
+  status = mvmc_bounded_krylov_collective_synchronize(
+      workspace, MVMC_KRYLOV_STATUS_OK, hash, 1,
+      world_rank == target ? NULL : &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "rank-local null result did not remain collective");
+  if (world_rank != target) {
+    CHECK(result.failure_rank == target,
+          "null-result failure rank mismatch");
+  }
+}
+
+static void test_max_u64(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  uint64_t maximum = 0;
+  const int target = world_size - 1;
+  CHECK(mvmc_bounded_krylov_collective_max_u64(
+            workspace, (uint64_t)(world_rank + 3), &maximum) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            maximum == (uint64_t)(world_size + 2),
+        "max_u64 mismatch");
+  CHECK(mvmc_bounded_krylov_collective_max_u64(
+            workspace, (uint64_t)world_rank,
+            world_rank == target ? NULL : &maximum) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "rank-local null max output did not propagate");
+}
+
+static void test_component_gather(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  const MVMCAbsolutePfaffianScaledValueResult expected[4] = {
+      component_value(1.0 + 2.0 * I),
+      component_value(0.0),
+      component_value(-0.25 + 0.5 * I),
+      component_value(3.0 - I),
+  };
+  MVMCAbsolutePfaffianScaledValueResult local[4];
+  MVMCAbsolutePfaffianScaledValueResult global[4];
+  MVMCKrylovBoundedCollectiveResult result;
+  MVMCKrylovStatus status;
+  int start;
+  int end;
+  int index;
+  int total = 2;
+  rank_partition(total, world_rank, world_size, &start, &end);
+  memset(local, 0, sizeof(local));
+  memset(global, 0x5a, sizeof(global));
+  for (index = start; index < end; ++index) {
+    local[index - start] = expected[index];
+  }
+  status = mvmc_bounded_krylov_collective_gather_scaled_components(
+      workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+      total, start, end, global, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+            component_fields_bitwise_equal(&global[0], &expected[0]) &&
+            component_fields_bitwise_equal(&global[1], &expected[1]),
+        "global QP-order gather failed, including empty slices");
+
+  total = 4;
+  rank_partition(total, world_rank, world_size, &start, &end);
+  for (index = start; index < end; ++index) {
+    local[index - start] = expected[index];
+  }
+  status = mvmc_bounded_krylov_collective_gather_scaled_components(
+      workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+      total, start, end, global, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK &&
+            component_fields_bitwise_equal(&global[0], &expected[0]) &&
+            component_fields_bitwise_equal(&global[1], &expected[1]) &&
+            component_fields_bitwise_equal(&global[2], &expected[2]) &&
+            component_fields_bitwise_equal(&global[3], &expected[3]),
+        "four-component global gather order mismatch");
+
+  {
+    const int target = world_size - 1;
+    MVMCAbsolutePfaffianScaledValueResult sentinel[4];
+    memcpy(sentinel, global, sizeof(sentinel));
+    rank_partition(total, world_rank, world_size, &start, &end);
+    status = mvmc_bounded_krylov_collective_gather_scaled_components(
+        workspace,
+        world_rank == target ? MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE
+                             : MVMC_KRYLOV_STATUS_OK,
+        local, (size_t)(end - start), total, start, end, global, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE &&
+              result.failure_rank == target &&
+              memcmp(global, sentinel, sizeof(sentinel)) == 0,
+          "failed gather changed global output or lost failure rank");
+  }
+
+  rank_partition(total, world_rank, world_size, &start, &end);
+  if (end > start && world_rank == world_size - 1) {
+    local[0].value.state = MVMC_SCALED_COMPLEX_NONFINITE;
+  }
+  status = mvmc_bounded_krylov_collective_gather_scaled_components(
+      workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+      total, start, end, global, &result);
+  if (world_size == 1 || end > start) {
+    CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+          "nonfinite rank-local component was accepted");
+  }
+
+  rank_partition(total, world_rank, world_size, &start, &end);
+  for (index = start; index < end; ++index) {
+    local[index - start] = expected[index];
+  }
+  if (end > start && world_rank == world_size - 1) {
+    local[0].factor_state = MVMC_PFAFFIAN_VALUE_NONFINITE;
+  }
+  status = mvmc_bounded_krylov_collective_gather_scaled_components(
+      workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+      total, start, end, global, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_NONFINITE,
+        "nonfinite factor state was not propagated");
+
+  for (index = start; index < end; ++index) {
+    local[index - start] = expected[index];
+  }
+  if (end > start && world_rank == world_size - 1) {
+    local[0].factor_state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+    CHECK(mvmc_scaled_complex_make_exact_zero(&local[0].value) ==
+              MVMC_PFAFFIAN_STATUS_OK,
+          "inconsistent factor/value fixture construction failed");
+  }
+  status = mvmc_bounded_krylov_collective_gather_scaled_components(
+      workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+      total, start, end, global, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+        "inconsistent factor/value state was accepted");
+}
+
+static void test_projected_amplitude(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  const MVMCAbsolutePfaffianScaledValueResult components[4] = {
+      component_value(1.0 + 2.0 * I),
+      component_value(0.0),
+      component_value(-0.25 + 0.5 * I),
+      component_value(3.0 - I),
+  };
+  double complex weights[4] = {1.0, -0.5 + 0.25 * I, 2.0, -I};
+  MVMCAbsolutePfaffianScaledValueResult local[4];
+  MVMCProjectedScaledAmplitudeResult oracle;
+  MVMCKrylovScaledAmplitudeResult amplitude;
+  MVMCKrylovScaledAmplitudeResult sentinel;
+  MVMCKrylovBoundedCollectiveResult result;
+  MVMCKrylovStatus status;
+  int start;
+  int end;
+  int index;
+  rank_partition(4, world_rank, world_size, &start, &end);
+  for (index = start; index < end; ++index) {
+    local[index - start] = components[index];
+  }
+  CHECK(mvmc_projected_scaled_amplitude_values(components, weights, 4,
+                                                &oracle) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "allocating P4-A projection oracle failed");
+  memset(&amplitude, 0x5a, sizeof(amplitude));
+  status =
+      mvmc_bounded_krylov_collective_gather_projected_amplitude(
+          workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+          weights, 4, start, end, &amplitude, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+            scaled_fields_bitwise_equal(&amplitude.value, &oracle.total) &&
+            amplitude.well_pivoted_component_count == 3 &&
+            amplitude.exact_zero_component_count == 1 &&
+            amplitude.local_factorization_count ==
+                (uint64_t)(unsigned int)(end - start) &&
+            amplitude.global_factorization_count == 4,
+        "allocation-free projected amplitude disagrees with P4-A oracle");
+
+  rank_partition(1, world_rank, world_size, &start, &end);
+  if (end > start) local[0] = components[0];
+  status =
+      mvmc_bounded_krylov_collective_gather_projected_amplitude(
+          workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+          weights, 1, start, end, &amplitude, &result);
+  {
+    double complex qp_one_raw = NAN + I * NAN;
+    CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+              mvmc_scaled_complex_export_common_scale(
+                  &amplitude.value, 0.0, &qp_one_raw) ==
+                  MVMC_SCALED_EXPORT_OK &&
+              cabs(qp_one_raw - (1.0 + 2.0 * I)) <= 1.0e-14 &&
+              amplitude.global_factorization_count == 1,
+          "QP=1 projection with empty rank slices failed");
+  }
+
+  sentinel = amplitude;
+  rank_partition(4, world_rank, world_size, &start, &end);
+  for (index = start; index < end; ++index) {
+    local[index - start] = components[index];
+  }
+  if (world_rank == world_size - 1 && world_size > 1) weights[0] += 1.0;
+  status =
+      mvmc_bounded_krylov_collective_gather_projected_amplitude(
+          workspace, MVMC_KRYLOV_STATUS_OK, local, (size_t)(end - start),
+          weights, 4, start, end, &amplitude, &result);
+  if (world_size > 1) {
+    CHECK(status == MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE &&
+              memcmp(&amplitude, &sentinel, sizeof(amplitude)) == 0,
+          "replicated QP-weight mismatch was accepted or changed output");
+  } else {
+    CHECK(status == MVMC_KRYLOV_STATUS_OK,
+          "single-rank changed-weight projection failed");
+  }
+}
+
+static void test_ordered_accumulator_merge(
+    MVMCKrylovBoundedCollectiveWorkspace *workspace) {
+  MVMCScaledComplex local[3];
+  MVMCScaledComplex global[3];
+  MVMCScaledComplex expected[3];
+  MVMCScaledComplex *rank_values =
+      (MVMCScaledComplex *)calloc((size_t)world_size, sizeof(*rank_values));
+  MVMCKrylovBoundedCollectiveResult result;
+  MVMCKrylovStatus status;
+  int rank;
+  int index;
+  CHECK(rank_values != NULL, "test rank scratch allocation failed");
+  if (rank_values == NULL) return;
+  local[0] = finite_value((double)(world_rank + 1));
+  if (world_rank == 0) {
+    local[1] = finite_value(1.0e16);
+  } else if (world_rank == 1) {
+    local[1] = finite_value(1.0);
+  } else if (world_rank == 2) {
+    local[1] = finite_value(-1.0e16);
+  } else {
+    local[1] = finite_value(2.0);
+  }
+  if ((world_rank & 1) == 0) {
+    CHECK(mvmc_scaled_complex_make_exact_zero(&local[2]) ==
+              MVMC_PFAFFIAN_STATUS_OK,
+          "merge exact-zero fixture failed");
+  } else {
+    local[2] = finite_value((double)world_rank * I);
+  }
+  for (index = 0; index < 3; ++index) {
+    for (rank = 0; rank < world_size; ++rank) {
+      if (index == 0) {
+        rank_values[rank] = finite_value((double)(rank + 1));
+      } else if (index == 1) {
+        rank_values[rank] = finite_value(
+            rank == 0 ? 1.0e16
+                      : (rank == 1 ? 1.0 : (rank == 2 ? -1.0e16 : 2.0)));
+      } else if ((rank & 1) == 0) {
+        CHECK(mvmc_scaled_complex_make_exact_zero(&rank_values[rank]) ==
+                  MVMC_PFAFFIAN_STATUS_OK,
+              "expected exact-zero fixture failed");
+      } else {
+        rank_values[rank] = finite_value((double)rank * I);
+      }
+    }
+    CHECK(mvmc_scaled_complex_sum_ordered(rank_values, (size_t)world_size,
+                                           &expected[index]) ==
+              MVMC_PFAFFIAN_STATUS_OK,
+          "independent ordered merge construction failed");
+  }
+  status = mvmc_bounded_krylov_collective_merge_scaled_accumulators(
+      workspace, MVMC_KRYLOV_STATUS_OK, local, 3, global, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+            scaled_fields_bitwise_equal(&global[0], &expected[0]) &&
+            scaled_fields_bitwise_equal(&global[1], &expected[1]) &&
+            scaled_fields_bitwise_equal(&global[2], &expected[2]),
+        "rank-ordered scaled accumulator merge mismatch");
+
+  {
+    const int target = world_size - 1;
+    MVMCScaledComplex sentinel[3];
+    memcpy(sentinel, global, sizeof(sentinel));
+    status = mvmc_bounded_krylov_collective_merge_scaled_accumulators(
+        workspace,
+        world_rank == target ? MVMC_KRYLOV_STATUS_RESOURCE_LIMIT
+                             : MVMC_KRYLOV_STATUS_OK,
+        local, 3, global, &result);
+    CHECK(status == MVMC_KRYLOV_STATUS_RESOURCE_LIMIT &&
+              result.failure_rank == target &&
+              memcmp(global, sentinel, sizeof(sentinel)) == 0,
+          "failed ordered merge changed output or failure rank");
+  }
+
+  status = mvmc_bounded_krylov_collective_merge_scaled_accumulators(
+      workspace, MVMC_KRYLOV_STATUS_OK, local,
+      world_rank == world_size - 1 && world_size > 1 ? 2U : 3U,
+      global, &result);
+  if (world_size > 1) {
+    CHECK(status == MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "rank-mismatched accumulator count was accepted");
+  } else {
+    CHECK(status == MVMC_KRYLOV_STATUS_OK,
+          "single-rank shortened accumulator merge failed");
+  }
+  free(rank_values);
+}
+
+int main(int argc, char **argv) {
+  MVMCKrylovBoundedCollectiveWorkspace *workspace = NULL;
+  MVMCKrylovStatus status;
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  test_workspace_creation();
+#ifdef _mpi_use
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      MPI_COMM_WORLD, 4, 3, &workspace);
+#else
+  status = mvmc_bounded_krylov_collective_workspace_create(0, 4, 3,
+                                                            &workspace);
+#endif
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && workspace != NULL &&
+            mvmc_bounded_krylov_collective_workspace_bytes(workspace) > 0,
+        "collective workspace creation failed");
+  if (workspace != NULL) {
+    test_synchronize(workspace);
+    test_max_u64(workspace);
+    test_component_gather(workspace);
+    test_projected_amplitude(workspace);
+    test_ordered_accumulator_merge(workspace);
+  }
+  mvmc_bounded_krylov_collective_workspace_destroy(workspace);
+
+#ifdef _mpi_use
+  {
+    int global_failures = 0;
+    MPI_Allreduce(&failures, &global_failures, 1, MPI_INT, MPI_SUM,
+                  MPI_COMM_WORLD);
+    failures = global_failures;
+  }
+#endif
+  if (failures != 0) {
+    if (world_rank == 0) {
+      fprintf(stderr, "BoundedKrylovCollective_Unit: %d failure(s)\n",
+              failures);
+    }
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return EXIT_FAILURE;
+  }
+  if (world_rank == 0) {
+    printf("BoundedKrylovCollective_Unit: PASS (%d rank%s)\n", world_size,
+           world_size == 1 ? "" : "s");
+  }
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return EXIT_SUCCESS;
+}

--- a/test/bounded_krylov_engine_unit.c
+++ b/test/bounded_krylov_engine_unit.c
@@ -15,6 +15,9 @@ static int failures = 0;
 static int world_rank = 0;
 static int world_size = 1;
 
+_Static_assert(sizeof(double) == sizeof(uint64_t),
+               "bitwise scaled-value tests require 64-bit double storage");
+
 #define CHECK(condition, ...)                                                   \
   do {                                                                          \
     if (!(condition)) {                                                         \
@@ -42,6 +45,32 @@ static uint64_t hash_u64_value(uint64_t hash, uint64_t value) {
     value >>= 8;
   }
   return hash;
+}
+
+static void scaled_value_field_bits(const MVMCScaledComplex *value,
+                                    uint64_t bits[8]) {
+  double fields[7];
+  size_t field;
+  bits[0] = (uint64_t)(unsigned int)value->state;
+  fields[0] = creal(value->phase);
+  fields[1] = cimag(value->phase);
+  fields[2] = value->log_abs;
+  fields[3] = value->log_abs_error_bound;
+  fields[4] = value->max_input_log_abs;
+  fields[5] = value->cancellation_log_abs;
+  fields[6] = value->cancellation_ratio;
+  for (field = 0; field < 7; ++field) {
+    memcpy(&bits[field + 1], &fields[field], sizeof(bits[field + 1]));
+  }
+}
+
+static int scaled_values_bitwise_equal(const MVMCScaledComplex *left,
+                                       const MVMCScaledComplex *right) {
+  uint64_t left_bits[8];
+  uint64_t right_bits[8];
+  scaled_value_field_bits(left, left_bits);
+  scaled_value_field_bits(right, right_bits);
+  return memcmp(left_bits, right_bits, sizeof(left_bits)) == 0;
 }
 
 static size_t small_configuration_index(const uint64_t *words,
@@ -531,8 +560,13 @@ static void test_duplicate_permutation_and_cache_grid(void) {
       memcpy(baseline, result.value, sizeof(baseline));
       have_baseline = 1;
     } else {
-      CHECK(memcmp(baseline, result.value, sizeof(baseline)) == 0,
-            "cache capacity changed mathematical scaled values");
+      int order;
+      for (order = 0; order <= 3; ++order) {
+        CHECK(scaled_values_bitwise_equal(&baseline[order],
+                                          &result.value[order]),
+              "cache capacity changed scaled-value fields at order %d",
+              order);
+      }
     }
     CHECK(actual_cache_bytes <= capacities[capacity_index] &&
               (set_bytes == 0 || actual_cache_bytes % set_bytes == 0),
@@ -888,20 +922,16 @@ static void test_rank_invariance(void) {
   CHECK(memcmp(minimum, maximum, sizeof(minimum)) == 0,
         "plan/ROW/cache/callback trace differs by MPI rank");
   for (order = 0; order <= 3; ++order) {
-    unsigned char local[sizeof(MVMCScaledComplex)];
-    unsigned char gathered_min[sizeof(MVMCScaledComplex)];
-    unsigned char gathered_max[sizeof(MVMCScaledComplex)];
-    size_t byte;
-    memcpy(local, &result.value[order], sizeof(local));
-    MPI_Allreduce(local, gathered_min, (int)sizeof(local), MPI_UNSIGNED_CHAR,
-                  MPI_MIN, MPI_COMM_WORLD);
-    MPI_Allreduce(local, gathered_max, (int)sizeof(local), MPI_UNSIGNED_CHAR,
-                  MPI_MAX, MPI_COMM_WORLD);
-    for (byte = 0; byte < sizeof(local); ++byte) {
-      CHECK(gathered_min[byte] == gathered_max[byte],
-            "scaled value differs by rank at order %d byte %zu", order,
-            byte);
-    }
+    uint64_t local[8];
+    uint64_t gathered_min[8];
+    uint64_t gathered_max[8];
+    scaled_value_field_bits(&result.value[order], local);
+    MPI_Allreduce(local, gathered_min, 8, MPI_UINT64_T, MPI_MIN,
+                  MPI_COMM_WORLD);
+    MPI_Allreduce(local, gathered_max, 8, MPI_UINT64_T, MPI_MAX,
+                  MPI_COMM_WORLD);
+    CHECK(memcmp(gathered_min, gathered_max, sizeof(gathered_min)) == 0,
+          "scaled-value fields differ by rank at order %d", order);
   }
 #endif
 }

--- a/test/bounded_krylov_engine_unit.c
+++ b/test/bounded_krylov_engine_unit.c
@@ -1,0 +1,948 @@
+#include "bounded_krylov_engine.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failures = 0;
+static int world_rank = 0;
+static int world_size = 1;
+
+#define CHECK(condition, ...)                                                   \
+  do {                                                                          \
+    if (!(condition)) {                                                         \
+      fprintf(stderr, "BoundedKrylovEngine_Unit FAIL rank %d: ",              \
+              world_rank);                                                      \
+      fprintf(stderr, __VA_ARGS__);                                             \
+      fprintf(stderr, " (line %d)\n", __LINE__);                              \
+      ++failures;                                                               \
+    }                                                                           \
+  } while (0)
+
+typedef struct {
+  double complex values[64];
+  uint64_t calls;
+  uint64_t trace_hash;
+  MVMCKrylovStatus forced_status;
+  int return_nonfinite;
+} TableAmplitude;
+
+static uint64_t hash_u64_value(uint64_t hash, uint64_t value) {
+  int byte;
+  for (byte = 0; byte < 8; ++byte) {
+    hash ^= value & UINT64_C(0xff);
+    hash *= UINT64_C(1099511628211);
+    value >>= 8;
+  }
+  return hash;
+}
+
+static size_t small_configuration_index(const uint64_t *words,
+                                        size_t word_count) {
+  return word_count == 1 ? (size_t)(words[0] & UINT64_C(63)) : 63;
+}
+
+static MVMCKrylovStatus scaled_table_callback(
+    const uint64_t *words, size_t word_count, void *context,
+    MVMCKrylovScaledAmplitudeResult *result) {
+  TableAmplitude *table = (TableAmplitude *)context;
+  const size_t index = small_configuration_index(words, word_count);
+  ++table->calls;
+  table->trace_hash = hash_u64_value(table->trace_hash, (uint64_t)index);
+  if (table->forced_status != MVMC_KRYLOV_STATUS_OK) {
+    return table->forced_status;
+  }
+  memset(result, 0, sizeof(*result));
+  if (table->return_nonfinite) {
+    memset(&result->value, 0, sizeof(result->value));
+    result->value.state = MVMC_SCALED_COMPLEX_NONFINITE;
+    return MVMC_KRYLOV_STATUS_OK;
+  }
+  if (creal(table->values[index]) == 0.0 &&
+      cimag(table->values[index]) == 0.0) {
+    if (mvmc_scaled_complex_make_exact_zero(&result->value) !=
+        MVMC_PFAFFIAN_STATUS_OK) {
+      return MVMC_KRYLOV_STATUS_INTERNAL_INVARIANT_FAILURE;
+    }
+    result->exact_zero_component_count = 1;
+  } else {
+    if (mvmc_scaled_complex_from_raw_testing(table->values[index],
+                                              &result->value) !=
+        MVMC_PFAFFIAN_STATUS_OK) {
+      return MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+    }
+    result->well_pivoted_component_count = 1;
+  }
+  result->local_factorization_count = 1;
+  result->global_factorization_count = 1;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovStatus raw_table_callback(
+    const uint64_t *words, size_t word_count, void *context,
+    MVMCKrylovAmplitudeResult *result) {
+  TableAmplitude *table = (TableAmplitude *)context;
+  const size_t index = small_configuration_index(words, word_count);
+  ++table->calls;
+  memset(result, 0, sizeof(*result));
+  if (table->forced_status != MVMC_KRYLOV_STATUS_OK) {
+    return table->forced_status;
+  }
+  result->value = table->return_nonfinite ? NAN + 0.0 * I
+                                           : table->values[index];
+  result->total_zero = creal(result->value) == 0.0 &&
+                       cimag(result->value) == 0.0;
+  result->regular_component_count = result->total_zero ? 0 : 1;
+  result->local_factorization_count = 1;
+  result->global_factorization_count = 1;
+  return MVMC_KRYLOV_STATUS_OK;
+}
+
+static MVMCKrylovFockModel electronic_model(
+    size_t site_count, size_t up_count, size_t down_count,
+    const MVMCKrylovHamiltonianTerm *terms, size_t term_count,
+    const MVMCKrylovFermionOperator *operators, size_t operator_count) {
+  MVMCKrylovFockModel model;
+  memset(&model, 0, sizeof(model));
+  model.site_count = site_count;
+  model.up_electron_count = up_count;
+  model.down_electron_count = down_count;
+  model.hermitian = 1;
+  model.terms = terms;
+  model.term_count = term_count;
+  model.operators = operators;
+  model.operator_count = operator_count;
+  return model;
+}
+
+static MVMCKrylovBoundedLimits bounded_limits(int order,
+                                               size_t cache_bytes) {
+  MVMCKrylovBoundedLimits limits;
+  limits.amplitude_policy_hash = UINT64_C(0x504f4c4943590001);
+  limits.cache_bytes = cache_bytes;
+  limits.max_row_transitions = 4096;
+  limits.max_workspace_bytes = (size_t)512 * 1024 * 1024;
+  limits.max_node_expansions = UINT64_C(1000000);
+  limits.max_terminal_amplitude_calls = UINT64_C(1000000);
+  limits.max_total_row_transitions = UINT64_C(10000000);
+  limits.max_order = order;
+  return limits;
+}
+
+static MVMCKrylovLimits reference_limits(int order) {
+  MVMCKrylovLimits limits;
+  limits.max_states = 4096;
+  limits.max_transitions = 65536;
+  limits.max_amplitude_evaluations = 4096;
+  limits.max_bytes = (size_t)64 * 1024 * 1024;
+  limits.max_order = order;
+  return limits;
+}
+
+static MVMCKrylovStatus evaluate_bounded(
+    const MVMCKrylovFockModel *model, const uint64_t *root,
+    size_t word_count, const MVMCKrylovBoundedLimits *limits,
+    TableAmplitude *amplitude, MVMCKrylovBoundedResult *result,
+    uint64_t *plan_hash, size_t *workspace_bytes, size_t *cache_set_bytes,
+    size_t *cache_allocated_bytes) {
+  MVMCKrylovBoundedPlan *plan = NULL;
+  MVMCKrylovBoundedWorkspace *workspace = NULL;
+  MVMCKrylovStatus status =
+      mvmc_bounded_krylov_plan_create(model, limits, &plan);
+  if (status != MVMC_KRYLOV_STATUS_OK) return status;
+  if (plan_hash != NULL) *plan_hash = mvmc_bounded_krylov_plan_hash(plan);
+  if (cache_set_bytes != NULL) {
+    *cache_set_bytes = mvmc_bounded_krylov_cache_set_bytes(plan);
+  }
+  status = mvmc_bounded_krylov_workspace_create(plan, &workspace);
+  if (status == MVMC_KRYLOV_STATUS_OK) {
+    if (workspace_bytes != NULL) {
+      *workspace_bytes = mvmc_bounded_krylov_workspace_bytes(workspace);
+    }
+    status = mvmc_bounded_krylov_evaluate(
+        workspace, root, word_count, scaled_table_callback, amplitude, result);
+    if (cache_allocated_bytes != NULL) {
+      *cache_allocated_bytes = result->statistics.cache_allocated_bytes;
+    }
+  }
+  mvmc_bounded_krylov_workspace_destroy(workspace);
+  mvmc_bounded_krylov_plan_destroy(plan);
+  return status;
+}
+
+static MVMCKrylovStatus evaluate_reference(
+    const MVMCKrylovFockModel *model, const uint64_t *root,
+    size_t word_count, int order, TableAmplitude *amplitude,
+    MVMCKrylovResult *result) {
+  MVMCKrylovStatus status;
+  const MVMCKrylovLimits limits = reference_limits(order);
+  MVMCKrylovWorkspace *workspace =
+      mvmc_krylov_workspace_create(model->site_count, &limits, &status);
+  if (workspace == NULL) return status;
+  status = mvmc_krylov_evaluate(workspace, model, root, word_count,
+                                raw_table_callback, amplitude, result);
+  mvmc_krylov_workspace_destroy(workspace);
+  return status;
+}
+
+static int scaled_to_raw(const MVMCScaledComplex *value,
+                         double complex *raw) {
+  if (value->state == MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+    *raw = 0.0;
+    return 1;
+  }
+  return mvmc_scaled_complex_export_common_scale(value, 0.0, raw) ==
+         MVMC_SCALED_EXPORT_OK;
+}
+
+static int close_complex(double complex actual, double complex expected,
+                         double tolerance) {
+  return cabs(actual - expected) <= tolerance * (1.0 + cabs(expected));
+}
+
+static int finite_nonnegative_timings(
+    const MVMCKrylovBoundedStatistics *statistics) {
+  int depth;
+  const double values[] = {
+      statistics->reset_seconds,
+      statistics->total_seconds,
+      statistics->evaluation_wall_seconds,
+      statistics->amplitude_wall_seconds,
+      statistics->connectivity_wall_seconds,
+      statistics->cache_wall_seconds,
+  };
+  size_t index;
+  for (index = 0; index < sizeof(values) / sizeof(values[0]); ++index) {
+    if (!isfinite(values[index]) || values[index] < 0.0) return 0;
+  }
+  for (depth = 0; depth <= MVMC_KRYLOV_MAX_ORDER; ++depth) {
+    if (!isfinite(statistics->depth_wall_seconds[depth]) ||
+        statistics->depth_wall_seconds[depth] < 0.0) return 0;
+  }
+  return statistics->total_seconds + 1.0e-12 >=
+         statistics->reset_seconds;
+}
+
+static void check_atomic_failure(const MVMCKrylovBoundedResult *result,
+                                 MVMCKrylovStatus status,
+                                 const char *label) {
+  int order;
+  CHECK(!result->valid && result->status == status,
+        "%s did not return invalid status %d", label, (int)status);
+  CHECK(result->evaluated_order == -1 &&
+            result->statistics.completed_order == -1,
+        "%s exposed a completed partial order", label);
+  for (order = 0; order <= MVMC_KRYLOV_MAX_ORDER; ++order) {
+    CHECK(result->value[order].state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+          "%s exposed partial value[%d]", label, order);
+  }
+}
+
+static void test_dense_ed_and_p3(void) {
+  const double complex a = 0.7 + 0.2 * I;
+  const double complex b = -0.3 + 0.4 * I;
+  const double diagonal[3] = {0.25, -0.5, 0.75};
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 2},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+      {MVMC_KRYLOV_FERMION_CREATE, 2},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {diagonal[0], 0, 2, 0, 0}, {diagonal[1], 2, 2, 0, 1},
+      {diagonal[2], 4, 2, 0, 2}, {a, 6, 2, 1, 0},
+      {conj(a), 8, 2, 1, 1},     {b, 10, 2, 1, 2},
+      {conj(b), 12, 2, 1, 3},
+  };
+  const MVMCKrylovFockModel model = electronic_model(
+      3, 1, 0, terms, sizeof(terms) / sizeof(terms[0]), operators,
+      sizeof(operators) / sizeof(operators[0]));
+  const double complex matrix[3][3] = {
+      {diagonal[0], a, 0.0},
+      {conj(a), diagonal[1], b},
+      {0.0, conj(b), diagonal[2]},
+  };
+  double complex expected[4][3];
+  TableAmplitude fixture;
+  int order;
+  int row;
+  memset(&fixture, 0, sizeof(fixture));
+  fixture.trace_hash = UINT64_C(1469598103934665603);
+  expected[0][0] = 0.2 - 0.1 * I;
+  expected[0][1] = -0.3 + 0.8 * I;
+  expected[0][2] = 0.6 + 0.4 * I;
+  fixture.values[1] = expected[0][0];
+  fixture.values[2] = expected[0][1];
+  fixture.values[4] = expected[0][2];
+  for (order = 1; order <= 3; ++order) {
+    for (row = 0; row < 3; ++row) {
+      int column;
+      expected[order][row] = 0.0;
+      for (column = 0; column < 3; ++column) {
+        expected[order][row] +=
+            matrix[row][column] * expected[order - 1][column];
+      }
+    }
+  }
+  for (row = 0; row < 3; ++row) {
+    const uint64_t root = UINT64_C(1) << row;
+    const MVMCKrylovBoundedLimits limits =
+        bounded_limits(3, (size_t)1024 * 1024);
+    MVMCKrylovBoundedResult bounded;
+    MVMCKrylovResult reference;
+    TableAmplitude bounded_amplitude = fixture;
+    TableAmplitude reference_amplitude = fixture;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &bounded_amplitude,
+                           &bounded, NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_OK &&
+              bounded.valid,
+          "dense ED bounded root %d failed", row);
+    CHECK(evaluate_reference(&model, &root, 1, 3, &reference_amplitude,
+                             &reference) == MVMC_KRYLOV_STATUS_OK &&
+              reference.valid,
+          "dense ED P3 root %d failed", row);
+    for (order = 0; order <= 3; ++order) {
+      double complex actual = NAN + I * NAN;
+      CHECK(scaled_to_raw(&bounded.value[order], &actual),
+            "dense root %d order %d did not export", row, order);
+      CHECK(close_complex(actual, expected[order][row], 3.0e-13),
+            "dense ED mismatch root=%d order=%d", row, order);
+      CHECK(close_complex(actual, reference.value[order], 3.0e-13),
+            "P3 A/B mismatch root=%d order=%d", row, order);
+    }
+    CHECK(bounded.statistics.engine_heap_allocations == 0,
+          "evaluate hot path reported a heap allocation");
+    CHECK(bounded.statistics.plan_bytes >= bounded.statistics.model_bytes &&
+              bounded.statistics.workspace_bytes >=
+                  bounded.statistics.frame_bytes +
+                      bounded.statistics.scratch_bytes,
+          "byte breakdown is inconsistent");
+    CHECK(finite_nonnegative_timings(&bounded.statistics),
+          "bounded timing fields are not finite/nonnegative");
+  }
+}
+
+static void test_zero_bridge_and_repeated_reset(void) {
+  const double complex hopping = 1.0 + 2.0 * I;
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {hopping, 0, 2, 1, 0}, {conj(hopping), 2, 2, 1, 1}};
+  const MVMCKrylovFockModel model =
+      electronic_model(2, 1, 0, terms, 2, operators, 4);
+  MVMCKrylovBoundedLimits limits = bounded_limits(3, 4096);
+  MVMCKrylovBoundedPlan *plan = NULL;
+  MVMCKrylovBoundedWorkspace *workspace = NULL;
+  MVMCKrylovBoundedResult first;
+  MVMCKrylovBoundedResult second;
+  TableAmplitude amplitude;
+  const uint64_t root = UINT64_C(1);
+  double complex raw;
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.trace_hash = UINT64_C(1469598103934665603);
+  amplitude.values[2] = 3.0 - I;
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            mvmc_bounded_krylov_workspace_create(plan, &workspace) ==
+                MVMC_KRYLOV_STATUS_OK,
+        "zero-bridge workspace creation failed");
+  if (workspace == NULL) {
+    mvmc_bounded_krylov_plan_destroy(plan);
+    return;
+  }
+  CHECK(mvmc_bounded_krylov_evaluate(workspace, &root, 1,
+                                      scaled_table_callback, &amplitude,
+                                      &first) == MVMC_KRYLOV_STATUS_OK,
+        "zero-bridge evaluation failed");
+  CHECK(first.value[0].state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "zero bridge v0 was not exact zero");
+  CHECK(scaled_to_raw(&first.value[1], &raw) &&
+            close_complex(raw, hopping * amplitude.values[2], 1.0e-14),
+        "zero bridge was truncated at depth 1");
+  CHECK(first.value[2].state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "zero bridge v2 was not exact zero");
+  CHECK(scaled_to_raw(&first.value[3], &raw) &&
+            close_complex(raw,
+                          hopping * amplitude.values[2] *
+                              creal(hopping * conj(hopping)),
+                          2.0e-13),
+        "zero bridge depth-3 value mismatch");
+  amplitude.values[2] = -0.75 + 0.25 * I;
+  amplitude.calls = 0;
+  amplitude.trace_hash = UINT64_C(1469598103934665603);
+  CHECK(mvmc_bounded_krylov_evaluate(workspace, &root, 1,
+                                      scaled_table_callback, &amplitude,
+                                      &second) == MVMC_KRYLOV_STATUS_OK,
+        "repeated evaluation failed");
+  CHECK(scaled_to_raw(&second.value[1], &raw) &&
+            close_complex(raw, hopping * amplitude.values[2], 1.0e-14),
+        "logical reset reused a stale root cache");
+  mvmc_bounded_krylov_workspace_destroy(workspace);
+  mvmc_bounded_krylov_plan_destroy(plan);
+}
+
+static void test_scaled_multipath_cancellation(void) {
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+      {MVMC_KRYLOV_FERMION_CREATE, 2},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1},
+      {1.0, 4, 2, 1, 2}, {1.0, 6, 2, 1, 3},
+  };
+  const MVMCKrylovFockModel model =
+      electronic_model(3, 1, 0, terms, 4, operators, 8);
+  const MVMCKrylovBoundedLimits limits = bounded_limits(1, 0);
+  const uint64_t root = UINT64_C(2);
+  TableAmplitude amplitude;
+  MVMCKrylovBoundedResult result;
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.values[1] = 1.0;
+  amplitude.values[4] = -1.0;
+  CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                         NULL, NULL, NULL, NULL) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "scaled multipath cancellation evaluation failed");
+  CHECK(result.value[1].state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+            result.statistics.computed_numeric_zero_values > 0,
+        "finite multipath cancellation was not diagnosed as NUMERIC_ZERO");
+}
+
+static void test_duplicate_permutation_and_cache_grid(void) {
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  MVMCKrylovHamiltonianTerm terms_a[] = {
+      {1.0e16, 0, 2, 1, 10}, {1.0, 0, 2, 1, 12},
+      {-1.0e16, 0, 2, 1, 11}, {1.0e16, 2, 2, 1, 10},
+      {1.0, 2, 2, 1, 12}, {-1.0e16, 2, 2, 1, 11},
+  };
+  const MVMCKrylovHamiltonianTerm terms_b[] = {
+      {-1.0e16, 2, 2, 1, 11}, {1.0, 0, 2, 1, 12},
+      {1.0e16, 2, 2, 1, 10},  {-1.0e16, 0, 2, 1, 11},
+      {1.0, 2, 2, 1, 12},     {1.0e16, 0, 2, 1, 10},
+  };
+  MVMCKrylovFockModel model_a =
+      electronic_model(2, 1, 0, terms_a, 6, operators, 4);
+  const MVMCKrylovFockModel model_b =
+      electronic_model(2, 1, 0, terms_b, 6, operators, 4);
+  const uint64_t root = UINT64_C(1);
+  TableAmplitude fixture;
+  MVMCKrylovBoundedLimits hash_limits = bounded_limits(3, 0);
+  MVMCKrylovBoundedPlan *plan_a = NULL;
+  MVMCKrylovBoundedPlan *plan_b = NULL;
+  MVMCKrylovBoundedWorkspace *workspace = NULL;
+  MVMCKrylovBoundedResult deep_copy_result;
+  uint64_t canonical_hash = 0;
+  size_t set_bytes = 0;
+  size_t capacity_index;
+  size_t capacities[4];
+  MVMCScaledComplex baseline[MVMC_KRYLOV_MAX_ORDER + 1];
+  int have_baseline = 0;
+  memset(&fixture, 0, sizeof(fixture));
+  fixture.trace_hash = UINT64_C(1469598103934665603);
+  fixture.values[1] = 3.0;
+  fixture.values[2] = -2.0;
+  CHECK(((1.0 + 1.0e16) + -1.0e16) == 0.0,
+        "dynamic-range fixture no longer defeats naive summation");
+  CHECK(mvmc_bounded_krylov_plan_create(&model_a, &hash_limits, &plan_a) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            mvmc_bounded_krylov_plan_create(&model_b, &hash_limits, &plan_b) ==
+                MVMC_KRYLOV_STATUS_OK,
+        "permutation plans failed");
+  if (plan_a != NULL && plan_b != NULL) {
+    canonical_hash = mvmc_bounded_krylov_plan_hash(plan_a);
+    CHECK(canonical_hash == mvmc_bounded_krylov_plan_hash(plan_b),
+          "term permutation changed canonical plan hash");
+    set_bytes = mvmc_bounded_krylov_cache_set_bytes(plan_a);
+  }
+  CHECK(set_bytes > 0, "cache set byte formula is zero");
+  CHECK(mvmc_bounded_krylov_workspace_create(plan_a, &workspace) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "deep-copy workspace creation failed");
+  terms_a[0].coefficient = 17.0;
+  model_a.hermitian = 0;
+  if (workspace != NULL) {
+    TableAmplitude amplitude = fixture;
+    CHECK(mvmc_bounded_krylov_evaluate(workspace, &root, 1,
+                                        scaled_table_callback, &amplitude,
+                                        &deep_copy_result) ==
+              MVMC_KRYLOV_STATUS_OK,
+          "immutable plan did not survive source mutation");
+    {
+      double complex raw;
+      CHECK(scaled_to_raw(&deep_copy_result.value[1], &raw) &&
+                close_complex(raw, -2.0, 1.0e-14),
+            "Neumaier duplicate residual was lost");
+    }
+  }
+  mvmc_bounded_krylov_workspace_destroy(workspace);
+  mvmc_bounded_krylov_plan_destroy(plan_b);
+  mvmc_bounded_krylov_plan_destroy(plan_a);
+
+  terms_a[0].coefficient = 1.0e16;
+  model_a.hermitian = 1;
+  capacities[0] = 0;
+  capacities[1] = set_bytes + set_bytes / 2;
+  capacities[2] = (size_t)64 * 1024 * 1024;
+  capacities[3] = (size_t)256 * 1024 * 1024;
+  for (capacity_index = 0;
+       capacity_index < (world_size == 1 ? 4U : 2U); ++capacity_index) {
+    MVMCKrylovBoundedLimits limits =
+        bounded_limits(3, capacities[capacity_index]);
+    MVMCKrylovBoundedResult result;
+    TableAmplitude amplitude = fixture;
+    size_t actual_cache_bytes = 0;
+    CHECK(evaluate_bounded(&model_a, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, &actual_cache_bytes) ==
+              MVMC_KRYLOV_STATUS_OK,
+          "cache grid capacity %zu failed", capacities[capacity_index]);
+    if (!have_baseline) {
+      memcpy(baseline, result.value, sizeof(baseline));
+      have_baseline = 1;
+    } else {
+      CHECK(memcmp(baseline, result.value, sizeof(baseline)) == 0,
+            "cache capacity changed mathematical scaled values");
+    }
+    CHECK(actual_cache_bytes <= capacities[capacity_index] &&
+              (set_bytes == 0 || actual_cache_bytes % set_bytes == 0),
+          "cache request was not truncated to complete sets");
+    if (capacity_index == 0) {
+      CHECK(actual_cache_bytes == 0 && result.statistics.cache_insertions == 0 &&
+                result.statistics.cache_hits[0] == 0,
+            "zero-capacity cache was not disabled");
+    }
+    if (capacity_index == 1) {
+      CHECK(actual_cache_bytes == set_bytes &&
+                result.statistics.cache_evictions > 0,
+            "one-set collision/eviction fixture did not evict");
+    }
+  }
+  {
+    MVMCKrylovBoundedLimits changed = hash_limits;
+    MVMCKrylovBoundedPlan *changed_plan = NULL;
+    changed.amplitude_policy_hash ^= UINT64_C(1);
+    CHECK(mvmc_bounded_krylov_plan_create(&model_a, &changed,
+                                           &changed_plan) ==
+              MVMC_KRYLOV_STATUS_OK &&
+              mvmc_bounded_krylov_plan_hash(changed_plan) != canonical_hash,
+          "amplitude-policy change did not change plan hash");
+    mvmc_bounded_krylov_plan_destroy(changed_plan);
+  }
+}
+
+static void test_fermion_sign_pure_spin_and_multiword(void) {
+  {
+    const MVMCKrylovFermionOperator operators[] = {
+        {MVMC_KRYLOV_FERMION_CREATE, 0},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+        {MVMC_KRYLOV_FERMION_CREATE, 1},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+    };
+    const MVMCKrylovHamiltonianTerm terms[] = {
+        {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+    const MVMCKrylovFockModel model =
+        electronic_model(2, 1, 0, terms, 2, operators, 4);
+    const MVMCKrylovBoundedLimits limits = bounded_limits(1, 0);
+    const uint64_t root = UINT64_C(1);
+    TableAmplitude amplitude;
+    MVMCKrylovBoundedResult result;
+    double complex raw;
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[2] = -2.0;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_OK &&
+              scaled_to_raw(&result.value[1], &raw) &&
+              close_complex(raw, -2.0, 1.0e-14),
+          "electronic fermion sign/orientation mismatch");
+  }
+  {
+    const MVMCKrylovFermionOperator operators[] = {
+        {MVMC_KRYLOV_FERMION_CREATE, 0},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+        {MVMC_KRYLOV_FERMION_CREATE, 3},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+        {MVMC_KRYLOV_FERMION_CREATE, 1},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+        {MVMC_KRYLOV_FERMION_CREATE, 2},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 3},
+        {MVMC_KRYLOV_FERMION_CREATE, 1},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+        {MVMC_KRYLOV_FERMION_CREATE, 2},
+        {MVMC_KRYLOV_FERMION_ANNIHILATE, 2},
+    };
+    const MVMCKrylovHamiltonianTerm terms[] = {
+        {0.75, 0, 4, 2, 0}, {0.75, 4, 4, 2, 1},
+        {-0.25, 8, 4, 3, 0}};
+    MVMCKrylovFockModel model =
+        electronic_model(2, 1, 1, terms, 3, operators, 12);
+    const MVMCKrylovBoundedLimits limits = bounded_limits(1, 0);
+    const uint64_t root = UINT64_C(6);
+    TableAmplitude amplitude;
+    MVMCKrylovBoundedResult result;
+    double complex raw;
+    model.pure_spin = 1;
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[6] = 2.0;
+    amplitude.values[9] = 2.0;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_OK &&
+              scaled_to_raw(&result.value[1], &raw) &&
+              close_complex(raw, 1.0, 1.0e-14),
+          "pure-spin Exchange/XXZ sign or diagonal mismatch");
+  }
+  {
+    const MVMCKrylovFockModel model =
+        electronic_model(33, 1, 1, NULL, 0, NULL, 0);
+    const MVMCKrylovBoundedLimits limits = bounded_limits(0, 0);
+    uint64_t root[2] = {UINT64_C(1), UINT64_C(2)};
+    TableAmplitude amplitude;
+    MVMCKrylovBoundedResult result;
+    memset(&amplitude, 0, sizeof(amplitude));
+    amplitude.values[63] = 1.0;
+    CHECK(evaluate_bounded(&model, root, 2, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_OK,
+          "valid multiword configuration failed");
+    root[1] |= UINT64_C(4);
+    CHECK(evaluate_bounded(&model, root, 2, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_INVALID_ARGUMENT,
+          "multiword padding bit was accepted");
+  }
+}
+
+static void test_limits_wrap_and_atomic_failures(void) {
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {1.0, 0, 2, 1, 0}, {1.0, 2, 2, 1, 1}};
+  const MVMCKrylovFockModel model =
+      electronic_model(2, 1, 0, terms, 2, operators, 4);
+  const uint64_t root = UINT64_C(1);
+  TableAmplitude fixture;
+  MVMCKrylovBoundedPlan *plan = NULL;
+  MVMCKrylovBoundedWorkspace *workspace = NULL;
+  MVMCKrylovBoundedResult result;
+  MVMCKrylovBoundedLimits limits;
+  size_t set_bytes;
+  memset(&fixture, 0, sizeof(fixture));
+  fixture.values[1] = 1.0;
+  fixture.values[2] = 2.0;
+
+  limits = bounded_limits(-1, 0);
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            plan == NULL,
+        "negative max order was accepted");
+  limits = bounded_limits(MVMC_KRYLOV_MAX_ORDER + 1, 0);
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            plan == NULL,
+        "max order above the supported domain was accepted");
+  limits = bounded_limits(1, 0);
+  limits.max_node_expansions = 0;
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            plan == NULL,
+        "zero node limit was accepted");
+  {
+    MVMCKrylovFockModel invalid_model = model;
+    invalid_model.hermitian = 0;
+    limits = bounded_limits(1, 0);
+    CHECK(mvmc_bounded_krylov_plan_create(&invalid_model, &limits, &plan) ==
+              MVMC_KRYLOV_STATUS_NON_HERMITIAN_MODEL &&
+              plan == NULL,
+          "non-Hermitian model was accepted");
+  }
+  {
+    MVMCKrylovHamiltonianTerm invalid_terms[2];
+    MVMCKrylovFockModel invalid_model = model;
+    memcpy(invalid_terms, terms, sizeof(invalid_terms));
+    invalid_terms[0].coefficient = NAN + 0.0 * I;
+    invalid_model.terms = invalid_terms;
+    limits = bounded_limits(1, 0);
+    CHECK(mvmc_bounded_krylov_plan_create(&invalid_model, &limits, &plan) ==
+              MVMC_KRYLOV_STATUS_NONFINITE &&
+              plan == NULL,
+          "nonfinite model coefficient was accepted");
+  }
+  {
+    MVMCKrylovFermionOperator invalid_operators[4];
+    MVMCKrylovFockModel invalid_model = model;
+    memcpy(invalid_operators, operators, sizeof(invalid_operators));
+    invalid_operators[0].orbital = 4;
+    invalid_model.operators = invalid_operators;
+    limits = bounded_limits(1, 0);
+    CHECK(mvmc_bounded_krylov_plan_create(&invalid_model, &limits, &plan) ==
+              MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+              plan == NULL,
+          "out-of-range model orbital was accepted");
+  }
+
+  limits = bounded_limits(2, 0);
+  limits.max_row_transitions = 1;
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_RESOURCE_LIMIT &&
+            plan == NULL,
+        "insufficient max-row limit was accepted");
+
+  limits = bounded_limits(2, 0);
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "limit fixture plan creation failed");
+  if (plan == NULL) return;
+  set_bytes = mvmc_bounded_krylov_cache_set_bytes(plan);
+  mvmc_bounded_krylov_plan_destroy(plan);
+  plan = NULL;
+
+  limits = bounded_limits(3, SIZE_MAX);
+  limits.max_workspace_bytes = SIZE_MAX;
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            mvmc_bounded_krylov_workspace_create(plan, &workspace) ==
+                MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            workspace == NULL,
+        "overflowing cache capacity was accepted");
+  mvmc_bounded_krylov_plan_destroy(plan);
+  plan = NULL;
+
+  limits = bounded_limits(2, 0);
+  limits.max_workspace_bytes = 1;
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            mvmc_bounded_krylov_workspace_create(plan, &workspace) ==
+                MVMC_KRYLOV_STATUS_RESOURCE_LIMIT &&
+            workspace == NULL,
+        "workspace byte limit did not fire");
+  mvmc_bounded_krylov_plan_destroy(plan);
+  plan = NULL;
+
+  limits = bounded_limits(2, 0);
+  limits.max_node_expansions = 1;
+  {
+    TableAmplitude amplitude = fixture;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+          "node expansion limit did not fire");
+    check_atomic_failure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                         "node limit");
+  }
+
+  limits = bounded_limits(1, 0);
+  limits.max_terminal_amplitude_calls = 1;
+  {
+    TableAmplitude amplitude = fixture;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+          "terminal call limit did not fire");
+    check_atomic_failure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                         "terminal limit");
+  }
+
+  limits = bounded_limits(2, 0);
+  limits.max_total_row_transitions = 1;
+  {
+    TableAmplitude amplitude = fixture;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+          "total row-transition limit did not fire");
+    check_atomic_failure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                         "row-transition limit");
+  }
+
+  limits = bounded_limits(0, 0);
+  {
+    TableAmplitude amplitude = fixture;
+    amplitude.forced_status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE,
+          "callback failure was not propagated");
+    check_atomic_failure(&result, MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE,
+                         "callback failure");
+  }
+  {
+    TableAmplitude amplitude = fixture;
+    amplitude.return_nonfinite = 1;
+    CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                           NULL, NULL, NULL, NULL) ==
+              MVMC_KRYLOV_STATUS_NONFINITE,
+          "nonfinite callback value was accepted");
+    check_atomic_failure(&result, MVMC_KRYLOV_STATUS_NONFINITE,
+                         "nonfinite callback");
+  }
+
+  limits = bounded_limits(0, set_bytes);
+  CHECK(mvmc_bounded_krylov_plan_create(&model, &limits, &plan) ==
+            MVMC_KRYLOV_STATUS_OK &&
+            mvmc_bounded_krylov_workspace_create(plan, &workspace) ==
+                MVMC_KRYLOV_STATUS_OK,
+        "cache wrap fixture creation failed");
+  if (workspace != NULL) {
+    TableAmplitude amplitude = fixture;
+    CHECK(mvmc_bounded_krylov_testing_force_cache_counters(
+              workspace, UINT64_MAX, 0) == MVMC_KRYLOV_STATUS_OK &&
+              mvmc_bounded_krylov_evaluate(
+                  workspace, &root, 1, scaled_table_callback, &amplitude,
+                  &result) == MVMC_KRYLOV_STATUS_OK &&
+              result.statistics.cache_epoch_full_clears == 1,
+          "epoch wrap did not perform a full logical clear");
+    amplitude = fixture;
+    CHECK(mvmc_bounded_krylov_testing_force_cache_counters(
+              workspace, 7, UINT64_MAX) == MVMC_KRYLOV_STATUS_OK &&
+              mvmc_bounded_krylov_evaluate(
+                  workspace, &root, 1, scaled_table_callback, &amplitude,
+                  &result) == MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+          "access-counter overflow did not fail loud");
+    check_atomic_failure(&result, MVMC_KRYLOV_STATUS_RESOURCE_LIMIT,
+                         "cache access overflow");
+  }
+  mvmc_bounded_krylov_workspace_destroy(workspace);
+  mvmc_bounded_krylov_plan_destroy(plan);
+}
+
+static void test_rank_invariance(void) {
+#ifdef _mpi_use
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {0.5 + 0.25 * I, 0, 2, 1, 0},
+      {0.5 - 0.25 * I, 2, 2, 1, 1},
+  };
+  const MVMCKrylovFockModel model =
+      electronic_model(2, 1, 0, terms, 2, operators, 4);
+  const MVMCKrylovBoundedLimits limits = bounded_limits(3, 4096);
+  const uint64_t root = UINT64_C(1);
+  TableAmplitude amplitude;
+  MVMCKrylovBoundedResult result;
+  uint64_t plan_hash = 0;
+  uint64_t fields[11];
+  uint64_t minimum[11];
+  uint64_t maximum[11];
+  int order;
+  memset(&amplitude, 0, sizeof(amplitude));
+  amplitude.trace_hash = UINT64_C(1469598103934665603);
+  amplitude.values[1] = 0.25 + 0.5 * I;
+  amplitude.values[2] = -0.75 + 0.125 * I;
+  CHECK(evaluate_bounded(&model, &root, 1, &limits, &amplitude, &result,
+                         &plan_hash, NULL, NULL, NULL) ==
+            MVMC_KRYLOV_STATUS_OK,
+        "rank-invariance evaluation failed");
+  fields[0] = plan_hash;
+  fields[1] = result.statistics.trace_hash;
+  fields[2] = amplitude.trace_hash;
+  fields[3] = amplitude.calls;
+  fields[4] = result.statistics.node_expansions;
+  fields[5] = result.statistics.raw_row_transitions;
+  fields[6] = result.statistics.cache_insertions;
+  fields[7] = result.statistics.cache_evictions;
+  fields[8] = result.statistics.row_transition_peak;
+  fields[9] = result.statistics.terminal_amplitude_calls;
+  fields[10] = (uint64_t)(unsigned int)result.status;
+  MPI_Allreduce(fields, minimum, 11, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(fields, maximum, 11, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+  CHECK(memcmp(minimum, maximum, sizeof(minimum)) == 0,
+        "plan/ROW/cache/callback trace differs by MPI rank");
+  for (order = 0; order <= 3; ++order) {
+    unsigned char local[sizeof(MVMCScaledComplex)];
+    unsigned char gathered_min[sizeof(MVMCScaledComplex)];
+    unsigned char gathered_max[sizeof(MVMCScaledComplex)];
+    size_t byte;
+    memcpy(local, &result.value[order], sizeof(local));
+    MPI_Allreduce(local, gathered_min, (int)sizeof(local), MPI_UNSIGNED_CHAR,
+                  MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(local, gathered_max, (int)sizeof(local), MPI_UNSIGNED_CHAR,
+                  MPI_MAX, MPI_COMM_WORLD);
+    for (byte = 0; byte < sizeof(local); ++byte) {
+      CHECK(gathered_min[byte] == gathered_max[byte],
+            "scaled value differs by rank at order %d byte %zu", order,
+            byte);
+    }
+  }
+#endif
+}
+
+int main(int argc, char **argv) {
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  test_dense_ed_and_p3();
+  test_zero_bridge_and_repeated_reset();
+  test_scaled_multipath_cancellation();
+  test_duplicate_permutation_and_cache_grid();
+  test_fermion_sign_pure_spin_and_multiword();
+  test_limits_wrap_and_atomic_failures();
+  test_rank_invariance();
+
+#ifdef _mpi_use
+  {
+    int global_failures = 0;
+    MPI_Allreduce(&failures, &global_failures, 1, MPI_INT, MPI_SUM,
+                  MPI_COMM_WORLD);
+    failures = global_failures;
+  }
+#endif
+  if (failures != 0) {
+    if (world_rank == 0) {
+      fprintf(stderr, "BoundedKrylovEngine_Unit: %d failure(s)\n", failures);
+    }
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+  if (world_rank == 0) puts("BoundedKrylovEngine_Unit: PASS");
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return 0;
+}

--- a/test/bounded_krylov_integration_unit.c
+++ b/test/bounded_krylov_integration_unit.c
@@ -1,0 +1,324 @@
+#include "bounded_krylov_collective.h"
+
+#include <complex.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failures = 0;
+static int world_rank = 0;
+static int world_size = 1;
+
+#define CHECK(condition, ...)                                                   \
+  do {                                                                          \
+    if (!(condition)) {                                                         \
+      fprintf(stderr, "BoundedKrylovIntegration_Unit FAIL rank %d: ",         \
+              world_rank);                                                      \
+      fprintf(stderr, __VA_ARGS__);                                             \
+      fprintf(stderr, " (line %d)\n", __LINE__);                              \
+      ++failures;                                                               \
+    }                                                                           \
+  } while (0)
+
+typedef struct {
+  MVMCKrylovBoundedCollectiveWorkspace *collective;
+  double complex weights[4];
+  int qp_start;
+  int qp_end;
+  int failure_rank;
+  uint64_t calls;
+} CollectiveAmplitudeContext;
+
+static MVMCAbsolutePfaffianScaledValueResult component_value(
+    double complex raw) {
+  MVMCAbsolutePfaffianScaledValueResult component;
+  memset(&component, 0, sizeof(component));
+  component.matrix_scale = 1.0;
+  component.scaled_min_pivot = 0.5;
+  if (creal(raw) == 0.0 && cimag(raw) == 0.0) {
+    component.factor_state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+    component.factor_info = 1;
+    (void)mvmc_scaled_complex_make_exact_zero(&component.value);
+  } else {
+    component.factor_state = MVMC_PFAFFIAN_VALUE_WELL_PIVOTED;
+    (void)mvmc_scaled_complex_from_raw_testing(raw, &component.value);
+  }
+  return component;
+}
+
+static double complex terminal_component(int qp, size_t configuration) {
+  static const double complex configuration_one[4] = {
+      1.0 + 0.5 * I, 2.0 - I, 0.0, -0.25 + 0.75 * I};
+  static const double complex configuration_two[4] = {
+      -0.5 + 0.25 * I, 0.0, 3.0 + I, 0.75 - 0.5 * I};
+  return configuration == 1 ? configuration_one[qp]
+                            : configuration_two[qp];
+}
+
+static MVMCKrylovStatus collective_amplitude_callback(
+    const uint64_t *words, size_t word_count, void *context,
+    MVMCKrylovScaledAmplitudeResult *result) {
+  CollectiveAmplitudeContext *callback =
+      (CollectiveAmplitudeContext *)context;
+  MVMCAbsolutePfaffianScaledValueResult local[4];
+  MVMCKrylovBoundedCollectiveResult collective_result;
+  MVMCKrylovStatus local_status = MVMC_KRYLOV_STATUS_OK;
+  const size_t configuration =
+      word_count == 1 ? (size_t)(words[0] & UINT64_C(63)) : 63;
+  int qp;
+  ++callback->calls;
+  for (qp = callback->qp_start; qp < callback->qp_end; ++qp) {
+    local[qp - callback->qp_start] =
+        component_value(terminal_component(qp, configuration));
+  }
+  if (world_rank == callback->failure_rank && callback->calls == 1) {
+    local_status = MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE;
+  }
+  return mvmc_bounded_krylov_collective_gather_projected_amplitude(
+      callback->collective, local_status, local,
+      (size_t)(callback->qp_end - callback->qp_start), callback->weights,
+      4, callback->qp_start, callback->qp_end, result,
+      &collective_result);
+}
+
+static MVMCKrylovFockModel hopping_model(
+    const MVMCKrylovHamiltonianTerm *terms,
+    const MVMCKrylovFermionOperator *operators) {
+  MVMCKrylovFockModel model;
+  memset(&model, 0, sizeof(model));
+  model.site_count = 2;
+  model.up_electron_count = 1;
+  model.hermitian = 1;
+  model.terms = terms;
+  model.term_count = 2;
+  model.operators = operators;
+  model.operator_count = 4;
+  return model;
+}
+
+static MVMCKrylovBoundedLimits bounded_limits(void) {
+  MVMCKrylovBoundedLimits limits;
+  limits.amplitude_policy_hash = UINT64_C(0x5150312d34504f4c);
+  limits.cache_bytes = 4096;
+  limits.max_row_transitions = 8;
+  limits.max_workspace_bytes = (size_t)1024 * 1024;
+  limits.max_node_expansions = 1000;
+  limits.max_terminal_amplitude_calls = 1000;
+  limits.max_total_row_transitions = 10000;
+  limits.max_order = 3;
+  return limits;
+}
+
+static int scaled_to_raw(const MVMCScaledComplex *value,
+                         double complex *raw) {
+  if (value->state == MVMC_SCALED_COMPLEX_EXACT_ZERO) {
+    *raw = 0.0;
+    return 1;
+  }
+  return mvmc_scaled_complex_export_common_scale(value, 0.0, raw) ==
+         MVMC_SCALED_EXPORT_OK;
+}
+
+static int close_complex(double complex actual, double complex expected,
+                         double tolerance) {
+  return cabs(actual - expected) <= tolerance * (1.0 + cabs(expected));
+}
+
+static double complex projected_terminal(
+    const CollectiveAmplitudeContext *context, size_t configuration) {
+  MVMCAbsolutePfaffianScaledValueResult components[4];
+  MVMCProjectedScaledAmplitudeResult projected;
+  double complex raw = NAN + I * NAN;
+  int qp;
+  for (qp = 0; qp < 4; ++qp) {
+    components[qp] = component_value(terminal_component(qp, configuration));
+  }
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, context->weights, 4, &projected) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            scaled_to_raw(&projected.total, &raw),
+        "integration projection oracle failed");
+  return raw;
+}
+
+static void check_rank_invariance(const MVMCKrylovBoundedResult *result,
+                                  uint64_t calls, uint64_t plan_hash) {
+#ifdef _mpi_use
+  uint64_t local[7];
+  uint64_t minimum[7];
+  uint64_t maximum[7];
+  int order;
+  local[0] = plan_hash;
+  local[1] = calls;
+  local[2] = result->statistics.trace_hash;
+  local[3] = result->statistics.node_expansions;
+  local[4] = result->statistics.raw_row_transitions;
+  local[5] = result->statistics.terminal_amplitude_calls;
+  local[6] = (uint64_t)(unsigned int)result->status;
+  MPI_Allreduce(local, minimum, 7, MPI_UINT64_T, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(local, maximum, 7, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+  CHECK(memcmp(minimum, maximum, sizeof(minimum)) == 0,
+        "integrated plan/ROW/callback trace differs by rank");
+  for (order = 0; order <= 3; ++order) {
+    double fields[6] = {
+        creal(result->value[order].phase),
+        cimag(result->value[order].phase),
+        result->value[order].log_abs,
+        result->value[order].log_abs_error_bound,
+        result->value[order].max_input_log_abs,
+        result->value[order].cancellation_ratio,
+    };
+    double field_min[6];
+    double field_max[6];
+    int state = (int)result->value[order].state;
+    int state_min;
+    int state_max;
+    MPI_Allreduce(fields, field_min, 6, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(fields, field_max, 6, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(&state, &state_min, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(&state, &state_max, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    CHECK(memcmp(field_min, field_max, sizeof(field_min)) == 0 &&
+              state_min == state_max,
+          "integrated scaled value differs by rank at order %d", order);
+  }
+#else
+  (void)result;
+  (void)calls;
+  (void)plan_hash;
+#endif
+}
+
+static void run_integration(
+    MVMCKrylovBoundedCollectiveWorkspace *collective) {
+  const double complex hopping = 1.25 + 0.5 * I;
+  const MVMCKrylovFermionOperator operators[] = {
+      {MVMC_KRYLOV_FERMION_CREATE, 0},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 1},
+      {MVMC_KRYLOV_FERMION_CREATE, 1},
+      {MVMC_KRYLOV_FERMION_ANNIHILATE, 0},
+  };
+  const MVMCKrylovHamiltonianTerm terms[] = {
+      {hopping, 0, 2, 1, 0}, {conj(hopping), 2, 2, 1, 1}};
+  const MVMCKrylovFockModel model = hopping_model(terms, operators);
+  const MVMCKrylovBoundedLimits limits = bounded_limits();
+  MVMCKrylovBoundedPlan *plan = NULL;
+  MVMCKrylovBoundedWorkspace *workspace = NULL;
+  MVMCKrylovBoundedCollectiveResult preflight;
+  MVMCKrylovBoundedResult result;
+  CollectiveAmplitudeContext context;
+  MVMCKrylovStatus local_status;
+  MVMCKrylovStatus status;
+  const uint64_t root = UINT64_C(1);
+  uint64_t plan_hash = 0;
+  double complex terminal_one;
+  double complex terminal_two;
+  double complex expected[4];
+  int order;
+  memset(&context, 0, sizeof(context));
+  context.collective = collective;
+  context.weights[0] = 1.0;
+  context.weights[1] = -0.5 + 0.25 * I;
+  context.weights[2] = 2.0;
+  context.weights[3] = -I;
+  context.qp_start = 4 * world_rank / world_size;
+  context.qp_end = 4 * (world_rank + 1) / world_size;
+  context.failure_rank = -1;
+
+  local_status =
+      mvmc_bounded_krylov_plan_create(&model, &limits, &plan);
+  if (local_status == MVMC_KRYLOV_STATUS_OK) {
+    plan_hash = mvmc_bounded_krylov_plan_hash(plan);
+    local_status = mvmc_bounded_krylov_workspace_create(plan, &workspace);
+  }
+  status = mvmc_bounded_krylov_collective_synchronize(
+      collective, local_status, plan_hash, workspace != NULL, &preflight);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && preflight.valid,
+        "integrated plan/allocation preflight failed");
+  if (status != MVMC_KRYLOV_STATUS_OK || workspace == NULL) {
+    mvmc_bounded_krylov_workspace_destroy(workspace);
+    mvmc_bounded_krylov_plan_destroy(plan);
+    return;
+  }
+  status = mvmc_bounded_krylov_evaluate(
+      workspace, &root, 1, collective_amplitude_callback, &context, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && result.valid &&
+            result.statistics.engine_heap_allocations == 0,
+        "integrated allocation-free bounded evaluation failed");
+  terminal_one = projected_terminal(&context, 1);
+  terminal_two = projected_terminal(&context, 2);
+  expected[0] = terminal_one;
+  expected[1] = hopping * terminal_two;
+  expected[2] = hopping * conj(hopping) * terminal_one;
+  expected[3] = hopping * conj(hopping) * hopping * terminal_two;
+  for (order = 0; order <= 3; ++order) {
+    double complex raw = NAN + I * NAN;
+    CHECK(scaled_to_raw(&result.value[order], &raw) &&
+              close_complex(raw, expected[order], 5.0e-13),
+          "integrated QP=4 result mismatch at order %d", order);
+  }
+  check_rank_invariance(&result, context.calls, plan_hash);
+
+  context.calls = 0;
+  context.failure_rank = world_size - 1;
+  status = mvmc_bounded_krylov_evaluate(
+      workspace, &root, 1, collective_amplitude_callback, &context, &result);
+  CHECK(status == MVMC_KRYLOV_STATUS_AMPLITUDE_FAILURE && !result.valid &&
+            result.evaluated_order == -1,
+        "one-rank integrated callback failure did not fail atomically");
+  check_rank_invariance(&result, context.calls, plan_hash);
+  mvmc_bounded_krylov_workspace_destroy(workspace);
+  mvmc_bounded_krylov_plan_destroy(plan);
+}
+
+int main(int argc, char **argv) {
+  MVMCKrylovBoundedCollectiveWorkspace *collective = NULL;
+  MVMCKrylovStatus status;
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
+  status = mvmc_bounded_krylov_collective_workspace_create(
+      MPI_COMM_WORLD, 4, 4, &collective);
+#else
+  (void)argc;
+  (void)argv;
+  status = mvmc_bounded_krylov_collective_workspace_create(0, 4, 4,
+                                                            &collective);
+#endif
+  CHECK(status == MVMC_KRYLOV_STATUS_OK && collective != NULL,
+        "integration collective workspace creation failed");
+  if (collective != NULL) run_integration(collective);
+  mvmc_bounded_krylov_collective_workspace_destroy(collective);
+#ifdef _mpi_use
+  {
+    int global_failures = 0;
+    MPI_Allreduce(&failures, &global_failures, 1, MPI_INT, MPI_SUM,
+                  MPI_COMM_WORLD);
+    failures = global_failures;
+  }
+#endif
+  if (failures != 0) {
+    if (world_rank == 0) {
+      fprintf(stderr, "BoundedKrylovIntegration_Unit: %d failure(s)\n",
+              failures);
+    }
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return EXIT_FAILURE;
+  }
+  if (world_rank == 0) {
+    printf("BoundedKrylovIntegration_Unit: PASS (%d rank%s)\n", world_size,
+           world_size == 1 ? "" : "s");
+  }
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return EXIT_SUCCESS;
+}

--- a/test/classic_krylov_amplitude_unit.c
+++ b/test/classic_krylov_amplitude_unit.c
@@ -264,6 +264,12 @@ static void test_complex_amplitude(int qp_total, int use_gutzwiller,
   CHECK(mvmc_classic_krylov_complex_amplitude_workspace_bytes(workspace) >
             sizeof(*pfaffians),
         "complex amplitude workspace reports preallocated bytes");
+  if (qp_total == 4 && use_gutzwiller) {
+    memset(slater, 0x5a, sizeof(slater));
+    for (qp = 0; qp < qp_total; ++qp) weights[qp] = 99.0 + 17.0 * I;
+    parameter = 99.0 + 13.0 * I;
+    gutz_indices[0] = gutz_indices[1] = 1;
+  }
   CHECK(mvmc_classic_krylov_complex_amplitude(
             &configuration, 1, workspace, &result) ==
             MVMC_KRYLOV_STATUS_OK,
@@ -307,6 +313,12 @@ static void test_all_zero_and_configuration_guards(void) {
             MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
             result.value == 0.0,
         "wrong particle sector is rejected atomically");
+  configuration = UINT64_C(21);
+  CHECK(mvmc_classic_krylov_real_amplitude(
+            &configuration, 1, workspace, &result) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT &&
+            result.value == 0.0,
+        "nonzero configuration padding bit is rejected atomically");
   if (size > 1) {
     configuration = rank == size - 1 ? UINT64_C(6) : UINT64_C(5);
     CHECK(mvmc_classic_krylov_real_amplitude(
@@ -334,6 +346,15 @@ static void test_projection_allowlist(void) {
   int rank, size;
 
   rank_and_size(&rank, &size);
+  layout = base_layout(1, rank, size);
+  enable_gutzwiller(&layout, gutz_indices, parameter);
+  parameter[0] = -0.43 + I;
+  CHECK(mvmc_classic_krylov_real_amplitude_workspace_create(
+            &layout, slater, weights, &workspace) ==
+            MVMC_KRYLOV_STATUS_INVALID_ARGUMENT && workspace == NULL,
+        "real adapter rejects a finite imaginary projection parameter");
+  parameter[0] = -0.43;
+
   layout = base_layout(1, rank, size);
   layout.nproj = 1;
   layout.njastrow_idx = 1;

--- a/test/scaled_pfaffian_unit.c
+++ b/test/scaled_pfaffian_unit.c
@@ -1,0 +1,532 @@
+#include "absolute_pfaffian.h"
+
+#include <float.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _mpi_use
+#include <mpi.h>
+#endif
+
+static int failures = 0;
+
+#define CHECK(condition, message)                                             \
+  do {                                                                        \
+    if (!(condition)) {                                                       \
+      fprintf(stderr, "ScaledPfaffian_Unit FAIL: %s\n", (message));         \
+      ++failures;                                                             \
+    }                                                                         \
+  } while (0)
+
+static int close_double(double actual, double expected, double tolerance) {
+  return fabs(actual - expected) <=
+         tolerance * fmax(1.0, fabs(expected));
+}
+
+static int close_complex(double complex actual, double complex expected,
+                         double tolerance) {
+  return cabs(actual - expected) <=
+         tolerance * fmax(1.0, cabs(expected));
+}
+
+static void set_real_pair(double *matrix, int n, int left, int right,
+                          double value) {
+  matrix[left + (size_t)right * (size_t)n] = value;
+  matrix[right + (size_t)left * (size_t)n] = -value;
+}
+
+static void set_complex_pair(double complex *matrix, int n, int left,
+                             int right, double complex value) {
+  matrix[left + (size_t)right * (size_t)n] = value;
+  matrix[right + (size_t)left * (size_t)n] = -value;
+}
+
+static double complex dense_pfaffian_recursive(
+    const double complex *matrix, int n) {
+  double complex total = 0.0;
+  int partner;
+  if (n == 0) return 1.0;
+  for (partner = 1; partner < n; ++partner) {
+    double complex minor[36] = {0.0};
+    int source_column, source_row, target_column = 0;
+    for (source_column = 1; source_column < n; ++source_column) {
+      int target_row = 0;
+      if (source_column == partner) continue;
+      for (source_row = 1; source_row < n; ++source_row) {
+        if (source_row == partner) continue;
+        minor[target_row + (size_t)target_column * (size_t)(n - 2)] =
+            matrix[source_row + (size_t)source_column * (size_t)n];
+        ++target_row;
+      }
+      ++target_column;
+    }
+    total += (partner % 2 == 1 ? 1.0 : -1.0) *
+             matrix[(size_t)partner * (size_t)n] *
+             dense_pfaffian_recursive(minor, n - 2);
+  }
+  return total;
+}
+
+static MVMCScaledComplex finite_value(double complex phase, double log_abs) {
+  MVMCScaledComplex value;
+  memset(&value, 0, sizeof(value));
+  CHECK(mvmc_scaled_complex_make_finite(phase, log_abs, -INFINITY, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "finite scaled fixture construction");
+  return value;
+}
+
+static MVMCAbsolutePfaffianScaledValueResult scaled_component(
+    MVMCPfaffianValueState factor_state, MVMCScaledComplex value) {
+  MVMCAbsolutePfaffianScaledValueResult result;
+  memset(&result, 0, sizeof(result));
+  result.factor_state = factor_state;
+  result.value = value;
+  return result;
+}
+
+static void test_scaled_pure_math(void) {
+  MVMCScaledComplex values[6];
+  MVMCScaledComplex product;
+  MVMCScaledComplex sum;
+  MVMCScaledComplex sentinel;
+  double complex exported = 123.0 + 7.0 * I;
+
+  CHECK(mvmc_scaled_complex_make_finite(2.0, 1000.0, -INFINITY,
+                                        &values[0]) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            values[0].state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            close_complex(values[0].phase, 1.0, 1.0e-15) &&
+            values[0].log_abs == 1000.0,
+        "finite constructor normalizes phase and preserves log magnitude");
+  CHECK(mvmc_scaled_complex_export_common_scale(&values[0], 1000.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_OK &&
+            close_complex(exported, 1.0, 1.0e-15),
+        "common-scale export avoids overflow");
+  CHECK(mvmc_scaled_complex_export_common_scale(&values[0], 0.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_OVERFLOW,
+        "overflow export is classified separately");
+
+  values[1] = finite_value(-I, -1000.0);
+  CHECK(mvmc_scaled_complex_export_common_scale(&values[1], 0.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_UNDERFLOW &&
+            exported == 0.0,
+        "underflow export is not exact zero");
+  CHECK(mvmc_scaled_complex_multiply(&values[0], &values[1], &product) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            product.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            close_double(product.log_abs, 0.0, 1.0e-15) &&
+            close_complex(product.phase, -I, 1.0e-15) &&
+            isfinite(product.log_abs_error_bound),
+        "scaled multiplication handles exponent span 2000");
+
+  CHECK(mvmc_scaled_complex_from_raw_testing(0.0, &values[2]) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            values[2].state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+            isfinite(values[2].log_abs_error_bound),
+        "raw zero imports as numeric zero");
+  CHECK(mvmc_scaled_complex_from_raw_testing(NAN + I, &values[3]) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            values[3].state == MVMC_SCALED_COMPLEX_NONFINITE,
+        "raw NaN imports as nonfinite");
+  CHECK(mvmc_scaled_complex_from_raw_testing(
+            DBL_MAX + I * DBL_MAX, &values[3]) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            values[3].state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            values[3].log_abs > log(DBL_MAX) &&
+            close_complex(values[3].phase, (1.0 + I) / sqrt(2.0),
+                          1.0e-15),
+        "finite complex raw input survives cabs-range overflow");
+  CHECK(mvmc_scaled_complex_make_exact_zero(&values[4]) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            values[4].state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "structural exact zero constructor");
+  CHECK(mvmc_scaled_complex_multiply(&values[4], &values[0], &product) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            product.state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "exact zero product remains exact");
+
+  CHECK(mvmc_scaled_complex_make_numeric_zero(
+            -20.0, 0.0, -INFINITY, 0.0, &values[2]) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "numeric zero fixture construction");
+  values[3] = finite_value(1.0, 3.0);
+  values[3].log_abs_error_bound = -30.0;
+  CHECK(mvmc_scaled_complex_multiply(&values[2], &values[3], &product) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            product.state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+            product.log_abs_error_bound >= -17.0,
+        "numeric-zero product propagates both operand error bounds");
+  CHECK(mvmc_scaled_complex_sum_ordered(values + 2, 1, &sum) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            sum.state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+            sum.log_abs_error_bound == -20.0,
+        "all-numeric-zero sum retains its error bound");
+
+  values[0] = finite_value(1.0, 1000.0);
+  values[1] = finite_value(-1.0, 1000.0);
+  CHECK(mvmc_scaled_complex_sum_ordered(values, 2, &sum) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            sum.state == MVMC_SCALED_COMPLEX_NUMERIC_ZERO &&
+            sum.max_input_log_abs == 1000.0 &&
+            sum.cancellation_ratio == 0.0 &&
+            isfinite(sum.log_abs_error_bound),
+        "finite cancellation is numeric rather than exact zero");
+  values[0] = finite_value(1.0, 1000.0);
+  values[1] = finite_value(I, -1000.0);
+  CHECK(mvmc_scaled_complex_sum_ordered(values, 2, &sum) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            sum.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            close_double(sum.log_abs, 1000.0, 1.0e-15),
+        "ordered sum retains dominant exponent without overflow");
+  CHECK(mvmc_scaled_complex_sum_ordered(values + 4, 1, &sum) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            sum.state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "all structural-zero sum remains exact");
+
+  memset(&sentinel, 0x5a, sizeof(sentinel));
+  values[5] = sentinel;
+  CHECK(mvmc_scaled_complex_make_finite(1.0, INFINITY, -INFINITY,
+                                        &sentinel) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            memcmp(&sentinel, &values[5], sizeof(sentinel)) == 0,
+        "invalid pure operation preserves caller result");
+  values[5] = finite_value(1.0, 0.0);
+  values[5].phase = 2.0;
+  memset(&sentinel, 0x5a, sizeof(sentinel));
+  values[4] = sentinel;
+  CHECK(mvmc_scaled_complex_multiply(&values[5], &values[0], &sentinel) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            memcmp(&sentinel, &values[4], sizeof(sentinel)) == 0,
+        "non-unit input phase is rejected transactionally");
+}
+
+static void test_real_scaled_pfaffian(void) {
+  double matrix[16] = {0.0};
+  MVMCAbsolutePfaffianScaledValueResult result;
+  MVMCAbsolutePfaffianScaledValueResult sentinel;
+  MVMCAbsolutePfaffianValueResult raw_result;
+  double small = exp(-500.0);
+  double large = exp(500.0);
+  double complex exported = 0.0;
+
+  set_real_pair(matrix, 4, 0, 1, 2.0);
+  set_real_pair(matrix, 4, 2, 3, -3.0);
+  CHECK(mvmc_absolute_pfaffian_real_scaled_value(matrix, 4, 4, 0.0,
+                                                 &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_absolute_pfaffian_real_value(matrix, 4, 4, 0.0,
+                                              &raw_result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_scaled_complex_export_common_scale(&result.value, 0.0,
+                                                     &exported) ==
+            MVMC_SCALED_EXPORT_OK &&
+            close_complex(exported, raw_result.pfaffian, 1.0e-14),
+        "representable real scaled Pfaffian matches P1 value-only API");
+
+  memset(matrix, 0, sizeof(matrix));
+  set_real_pair(matrix, 4, 0, 1, small);
+  set_real_pair(matrix, 4, 2, 3, small);
+  CHECK(mvmc_absolute_pfaffian_real_scaled_value(matrix, 4, 4, 0.0,
+                                                 &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            result.factor_state == MVMC_PFAFFIAN_VALUE_WELL_PIVOTED &&
+            result.value.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            close_double(result.value.log_abs, -1000.0, 1.0e-13) &&
+            close_complex(result.value.phase, 1.0, 1.0e-14),
+        "real Pfaffian underflow-scale product remains finite in log form");
+  CHECK(mvmc_scaled_complex_export_common_scale(&result.value, 0.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_UNDERFLOW,
+        "real underflow-scale raw export is classified");
+
+  memset(matrix, 0, sizeof(matrix));
+  set_real_pair(matrix, 4, 0, 1, large);
+  set_real_pair(matrix, 4, 2, 3, -large);
+  CHECK(mvmc_absolute_pfaffian_real_scaled_value(matrix, 4, 4, 0.0,
+                                                 &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            result.value.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            close_double(result.value.log_abs, 1000.0, 1.0e-13) &&
+            close_complex(result.value.phase, -1.0, 1.0e-14),
+        "real Pfaffian overflow-scale product remains finite in log form");
+  CHECK(mvmc_scaled_complex_export_common_scale(&result.value, 1000.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_OK &&
+            close_complex(exported, -1.0, 1.0e-13),
+        "overflow-scale Pfaffian exports at a common scale");
+
+  memset(matrix, 0, sizeof(matrix));
+  set_real_pair(matrix, 4, 0, 1, 1.0);
+  set_real_pair(matrix, 4, 2, 3, 1.0e-20);
+  CHECK(mvmc_absolute_pfaffian_real_scaled_value(matrix, 4, 4, 0.0,
+                                                 &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            result.factor_state == MVMC_PFAFFIAN_VALUE_NEAR_PIVOT &&
+            result.value.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO,
+        "near-singular real Pfaffian retains a finite scaled value");
+  memset(matrix, 0, sizeof(matrix));
+  set_real_pair(matrix, 4, 0, 1, 1.0);
+  CHECK(mvmc_absolute_pfaffian_real_scaled_value(matrix, 4, 4, 0.0,
+                                                 &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            result.factor_state == MVMC_PFAFFIAN_VALUE_SINGULAR &&
+            result.value.state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "factorization-proven singular Pfaffian is exact zero");
+
+  memset(&sentinel, 0x37, sizeof(sentinel));
+  result = sentinel;
+  CHECK(mvmc_absolute_pfaffian_real_scaled_value(NULL, 4, 4, 0.0,
+                                                 &result) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            memcmp(&result, &sentinel, sizeof(result)) == 0,
+        "invalid scaled Pfaffian call preserves old state");
+}
+
+static void test_complex_dense_oracle(void) {
+  const int n = 6;
+  double complex matrix[36] = {0.0};
+  double complex expected;
+  double expected_abs;
+  MVMCAbsolutePfaffianScaledValueResult result;
+  MVMCAbsolutePfaffianValueResult raw_result;
+  double complex exported = 0.0;
+  int left, right;
+
+  for (right = 1; right < n; ++right) {
+    for (left = 0; left < right; ++left) {
+      double real_part = (double)(2 * left - right + 1) / 7.0;
+      double imag_part = (double)(left + 3 * right + 1) / 19.0;
+      set_complex_pair(matrix, n, left, right,
+                       real_part + I * imag_part);
+    }
+  }
+  expected = dense_pfaffian_recursive(matrix, n);
+  expected_abs = cabs(expected);
+  CHECK(expected_abs > 0.0 && isfinite(expected_abs),
+        "independent dense oracle is finite");
+  CHECK(mvmc_absolute_pfaffian_complex_scaled_value(matrix, n, n, 0.0,
+                                                    &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            result.value.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            close_double(result.value.log_abs, log(expected_abs), 2.0e-13) &&
+            close_complex(result.value.phase, expected / expected_abs,
+                          2.0e-13),
+        "complex scaled Pfaffian matches independent dense oracle");
+  CHECK(mvmc_absolute_pfaffian_complex_value(matrix, n, n, 0.0,
+                                             &raw_result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            mvmc_scaled_complex_export_common_scale(&result.value, 0.0,
+                                                     &exported) ==
+            MVMC_SCALED_EXPORT_OK &&
+            close_complex(exported, raw_result.pfaffian, 2.0e-13),
+        "representable complex scaled Pfaffian matches P1 value-only API");
+
+  matrix[0] = INFINITY;
+  CHECK(mvmc_absolute_pfaffian_complex_scaled_value(matrix, n, n, 0.0,
+                                                    &result) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            result.factor_state == MVMC_PFAFFIAN_VALUE_NONFINITE &&
+            result.value.state == MVMC_SCALED_COMPLEX_NONFINITE,
+        "complex nonfinite matrix is classified fail-loud");
+}
+
+static void test_scaled_projection(void) {
+  MVMCAbsolutePfaffianScaledValueResult components[4];
+  MVMCProjectedScaledAmplitudeResult aggregate;
+  MVMCProjectedScaledAmplitudeResult empty;
+  MVMCProjectedScaledAmplitudeResult sentinel;
+  MVMCScaledComplex value;
+  double complex weights[4] = {1.0, 2.0, -I, 0.5 + 0.25 * I};
+  double complex exported = 0.0;
+  const double complex expected = 4.625 + 1.5 * I;
+
+  CHECK(mvmc_scaled_complex_from_raw_testing(-2.5 + 0.75 * I, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "NQP=1 component construction");
+  components[0] =
+      scaled_component(MVMC_PFAFFIAN_VALUE_WELL_PIVOTED, value);
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, 1, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            aggregate.valid && aggregate.well_pivoted_count == 1 &&
+            aggregate.total.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO,
+        "NQP=1 scaled projection remains finite");
+  CHECK(mvmc_scaled_complex_export_common_scale(&aggregate.total, 0.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_OK &&
+            close_complex(exported, -2.5 + 0.75 * I, 2.0e-13),
+        "NQP=1 scaled projection matches direct oracle");
+
+  components[0] = scaled_component(MVMC_PFAFFIAN_VALUE_WELL_PIVOTED,
+                                   finite_value(1.0, 0.0));
+  weights[0] = DBL_MAX + I * DBL_MAX;
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, 1, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_OK && aggregate.valid &&
+            aggregate.total.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO &&
+            aggregate.total.log_abs > log(DBL_MAX) &&
+            close_complex(aggregate.total.phase,
+                          (1.0 + I) / sqrt(2.0), 2.0e-13),
+        "finite complex weight survives raw-magnitude overflow");
+  weights[0] = 1.0;
+
+  CHECK(mvmc_scaled_complex_from_raw_testing(2.0, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "projection regular component construction");
+  components[0] =
+      scaled_component(MVMC_PFAFFIAN_VALUE_WELL_PIVOTED, value);
+  CHECK(mvmc_scaled_complex_make_exact_zero(&value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "projection singular component construction");
+  components[1] = scaled_component(MVMC_PFAFFIAN_VALUE_SINGULAR, value);
+  CHECK(mvmc_scaled_complex_from_raw_testing(-1.0 + I, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "projection near component construction");
+  components[2] = scaled_component(MVMC_PFAFFIAN_VALUE_NEAR_PIVOT, value);
+  CHECK(mvmc_scaled_complex_from_raw_testing(3.0 - 0.5 * I, &value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "projection final component construction");
+  components[3] =
+      scaled_component(MVMC_PFAFFIAN_VALUE_WELL_PIVOTED, value);
+
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, 4, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            aggregate.valid && aggregate.well_pivoted_count == 2 &&
+            aggregate.near_pivot_count == 1 &&
+            aggregate.exact_zero_count == 1 &&
+            aggregate.numeric_zero_count == 0 &&
+            aggregate.total.state == MVMC_SCALED_COMPLEX_FINITE_NONZERO,
+        "global-QP scaled projection preserves classifications");
+  CHECK(mvmc_scaled_complex_export_common_scale(&aggregate.total, 0.0,
+                                                 &exported) ==
+            MVMC_SCALED_EXPORT_OK &&
+            close_complex(exported, expected, 2.0e-13),
+        "global-QP scaled projection matches direct oracle");
+  CHECK(close_double(aggregate.log_sum_abs,
+                     log(2.0 + sqrt(2.0) + cabs(1.625 + 0.5 * I)),
+                     2.0e-13),
+        "projection log absolute sum matches oracle");
+
+  CHECK(mvmc_projected_scaled_amplitude_value_slice(
+            NULL, 0, weights, 4, 2, 2, &empty) ==
+            MVMC_PFAFFIAN_STATUS_OK &&
+            empty.valid &&
+            empty.total.state == MVMC_SCALED_COMPLEX_EXACT_ZERO,
+        "empty local QP slice is a valid exact-zero partial sum");
+
+  memset(&sentinel, 0x2c, sizeof(sentinel));
+  aggregate = sentinel;
+  components[1].factor_state = MVMC_PFAFFIAN_VALUE_SINGULAR;
+  components[1].value = finite_value(1.0, 0.0);
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, 4, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            memcmp(&aggregate, &sentinel, sizeof(aggregate)) == 0,
+        "invalid projected component preserves old result");
+  components[1] = scaled_component(MVMC_PFAFFIAN_VALUE_WELL_PIVOTED,
+                                   value);
+  CHECK(mvmc_scaled_complex_make_exact_zero(&components[1].value) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "inconsistent projected component fixture construction");
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, 4, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT,
+        "well-pivoted component cannot carry exact-zero Pfaffian state");
+  aggregate = sentinel;
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, SIZE_MAX / sizeof(MVMCScaledComplex) + 1,
+            &aggregate) == MVMC_PFAFFIAN_STATUS_INVALID_ARGUMENT &&
+            memcmp(&aggregate, &sentinel, sizeof(aggregate)) == 0,
+        "projected component allocation extent overflow is atomic");
+}
+
+static void test_rank_invariance(void) {
+#ifdef _mpi_use
+  int rank = 0;
+  int size = 1;
+  int qp_start;
+  int qp_end;
+  MVMCAbsolutePfaffianScaledValueResult components[4];
+  MVMCProjectedScaledAmplitudeResult aggregate;
+  MVMCProjectedScaledAmplitudeResult partial;
+  MVMCScaledComplex value;
+  double complex weights[4] = {1.0, -I, 0.5, 2.0 + I};
+  double fields[4];
+  double minimum[4];
+  double maximum[4];
+  int state;
+  int minimum_state;
+  int maximum_state;
+  int index;
+
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  for (index = 0; index < 4; ++index) {
+    CHECK(mvmc_scaled_complex_make_finite(
+              index % 2 == 0 ? 1.0 : I, (double)(index - 2) * 400.0,
+              -INFINITY, &value) == MVMC_PFAFFIAN_STATUS_OK,
+          "rank scaled component construction");
+    components[index] = scaled_component(
+        index == 3 ? MVMC_PFAFFIAN_VALUE_NEAR_PIVOT
+                   : MVMC_PFAFFIAN_VALUE_WELL_PIVOTED,
+        value);
+  }
+  CHECK(mvmc_projected_scaled_amplitude_values(
+            components, weights, 4, &aggregate) ==
+            MVMC_PFAFFIAN_STATUS_OK,
+        "rank-invariant full scaled projection");
+  fields[0] = aggregate.total.log_abs;
+  fields[1] = creal(aggregate.total.phase);
+  fields[2] = cimag(aggregate.total.phase);
+  fields[3] = aggregate.total.log_abs_error_bound;
+  state = (int)aggregate.total.state;
+  MPI_Allreduce(fields, minimum, 4, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(fields, maximum, 4, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+  MPI_Allreduce(&state, &minimum_state, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+  MPI_Allreduce(&state, &maximum_state, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  CHECK(memcmp(minimum, maximum, sizeof(minimum)) == 0 &&
+            minimum_state == maximum_state,
+        "phase/log/status are bitwise invariant at MPI rank 2/4");
+
+  qp_start = 4 * rank / size;
+  qp_end = 4 * (rank + 1) / size;
+  CHECK(mvmc_projected_scaled_amplitude_value_slice(
+            components + qp_start, (size_t)(qp_end - qp_start), weights, 4,
+            qp_start, qp_end, &partial) == MVMC_PFAFFIAN_STATUS_OK &&
+            partial.valid,
+        "rank-local scaled QP slice including empty ownership is valid");
+#endif
+}
+
+int main(int argc, char **argv) {
+#ifdef _mpi_use
+  MPI_Init(&argc, &argv);
+#else
+  (void)argc;
+  (void)argv;
+#endif
+  test_scaled_pure_math();
+  test_real_scaled_pfaffian();
+  test_complex_dense_oracle();
+  test_scaled_projection();
+  test_rank_invariance();
+
+  if (failures != 0) {
+    fprintf(stderr, "ScaledPfaffian_Unit: %d failure(s)\n", failures);
+#ifdef _mpi_use
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+  puts("ScaledPfaffian_Unit: PASS");
+#ifdef _mpi_use
+  MPI_Finalize();
+#endif
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add a scaled complex/Pfaffian value core that keeps exact zero, numeric zero,
  and non-finite outcomes distinct without raw-product underflow or overflow
- add a row-local depth-first Krylov evaluator with a fixed-byte deterministic
  cache, bounded workspaces, hard resource limits, and transactional results
- add MPI collective helpers for plan/status synchronization, global-QP value
  assembly, and deterministic rank-ordered scaled accumulation
- add dense-ED and existing-reference A/B tests, cache/resource tests, MPI rank
  variants, malicious-input coverage, and Testing-disabled isolation checks

## Motivation

The existing absolute Krylov reference intentionally stores the complete visited
state and transition graph for correctness auditing. Its memory use therefore
scales with the explored sector and is not a viable evaluation engine for the
larger power-Lanczos feasibility measurements.

This change introduces the bounded correctness kernel needed for that next
measurement phase. It does not enable a production sampling path or change the
power-Lanczos default behavior.

## Design

- Scaled values use phase plus logarithmic magnitude and carry an error bound.
  Factorization-proven singular values remain distinguishable from numerical
  cancellation and non-finite failures.
- An immutable canonical plan is separated from a mutable, single-allocation
  workspace. Evaluation performs no engine-owned heap allocation.
- Each recursion depth reuses one row frame. Duplicate transitions are merged
  in canonical order with compensated summation before scaled recursion.
- The cache is a deterministic four-way set-associative cache. Requested byte
  capacities are truncated to complete sets, and only completed values enter
  the cache.
- Node, terminal-callback, and row-transition limits fail loudly without
  exposing partial Krylov vectors.
- MPI helpers preserve global QP and rank order, support empty local slices,
  and propagate plan, allocation, callback, and numeric failures collectively.

## Scope

All new engine and scaled-value entry points are compiled only with
`MVMC_ENABLE_POWER_LANCZOS_BOUNDED_ENGINE` under the existing `Testing` gate.
Testing-disabled builds contain none of the new source files, symbols, strings,
or compile definitions. Production routing, RNG state, and defaults are
unchanged.

The bounded resource and exact-IID feasibility decision is a later measurement
slice and is intentionally not claimed by this pull request.

## Validation

- macOS Apple Clang full CTest: 461/461 passed
- macOS and Debian 12/GCC 12 focused Release tests, including serial and MPI
  rank 2/rank 4 variants: 9/9 passed
- Linux ASan/UBSan focused tests: 9/9 passed
- Linux non-MPI LeakSanitizer ownership tests: 3/3 passed
- independent fresh macOS Release build and focused tests: 9/9 passed
- independent direct serial binaries and MPI rank 2 integration binary passed
- independent macOS ASan/UBSan tests: 3/3 passed
- Testing-disabled build and symbol/source/definition isolation checks passed
- warning-clean builds use `-Wall -Wextra -Wpedantic -Werror`
